### PR TITLE
[CHORE] build.gradle 의존성 추가 (#8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
+local.env

--- a/build.gradle
+++ b/build.gradle
@@ -25,13 +25,32 @@ repositories {
 }
 
 dependencies {
+	// Web / JPA / Validation
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// DB
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 


### PR DESCRIPTION
## 🔷 Github Issue ID
close #8

## 📌 작업 내용 및 특이사항
- Spring Security (`spring-boot-starter-security`) 추가
- JWT `jjwt` 0.12.6 추가 (jjwt-api / jjwt-impl / jjwt-jackson)
- Spring Data Redis (`spring-boot-starter-data-redis`) 추가
- 기존 의존성 그룹별 주석으로 정리
- `local.env` `.gitignore`에 추가 (민감 정보 보호)

## 📚 참고사항
- OAuth2 Client는 ADR-003(인증 방식 선택) 결정에 따라 미추가
- jjwt는 Spring Boot BOM 미포함으로 버전 명시