### PR TITLE
[FEAT] 공통 응답 구조 구현 (#11)

### DIFF
--- a/src/main/java/com/gongu/server/global/common/ApiResponse.java
+++ b/src/main/java/com/gongu/server/global/common/ApiResponse.java
@@ -1,0 +1,25 @@
+package com.gongu.server.global.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+    private final String code;
+    private final T data;
+
+    private ApiResponse(String code, T data) {
+        this.code = code;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>("SUCCESS", data);
+    }
+
+    public static ApiResponse<Void> success() {
+        return new ApiResponse<>("SUCCESS", null);
+    }
+}

--- a/src/main/java/com/gongu/server/global/common/ErrorResponse.java
+++ b/src/main/java/com/gongu/server/global/common/ErrorResponse.java
@@ -1,0 +1,46 @@
+package com.gongu.server.global.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.gongu.server.global.exception.ErrorCode;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse {
+
+    private final String code;
+    private final String message;
+    private final List<FieldError> errors;
+
+    private ErrorResponse(String code, String message, List<FieldError> errors) {
+        this.code = code;
+        this.message = message;
+        this.errors = errors;
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), null);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, List<FieldError> errors) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), errors);
+    }
+
+    @Getter
+    public static class FieldError {
+
+        private final String field;
+        private final String reason;
+
+        private FieldError(String field, String reason) {
+            this.field = field;
+            this.reason = reason;
+        }
+
+        public static FieldError of(String field, String reason) {
+            return new FieldError(field, reason);
+        }
+    }
+}

--- a/src/main/java/com/gongu/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/ErrorCode.java
@@ -1,0 +1,10 @@
+package com.gongu.server.global.exception;
+
+public interface ErrorCode {
+
+    String getCode();
+
+    String getMessage();
+
+    int getHttpStatus();
+}


### PR DESCRIPTION
## 🔷 Github Issue ID
close #11

## 📌 작업 내용 및 특이사항
- `ApiResponse<T>`: 성공 응답 래퍼, `success(T data)` / `success()` 정적 팩토리 메서드
- `ErrorResponse`: 실패 응답 DTO, `FieldError` 내부 정적 클래스 포함 (유효성 오류 배열 지원)
- `ErrorCode` 인터페이스: 이후 도메인별 enum이 구현할 계약 (`getCode`, `getMessage`, `getHttpStatus`)
- 모든 클래스 생성자 private, 정적 팩토리 메서드로만 생성 가능
- `@JsonInclude(NON_NULL)` 적용으로 null 필드 응답 미포함

## 📚 참고사항
- ADR-004 (예외 처리 전략) 응답 형식 기준

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * API 응답 및 오류 처리 구조 개선을 위한 기본 인프라 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->