### PR TITLE
[FEAT] 예외 계층 구조 및 GlobalExceptionHandler 구현 (#12)

### DIFF
--- a/src/main/java/com/gongu/server/global/exception/BusinessException.java
+++ b/src/main/java/com/gongu/server/global/exception/BusinessException.java
@@ -1,0 +1,8 @@
+package com.gongu.server.global.exception;
+
+public class BusinessException extends GonguException {
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/gongu/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gongu/server/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,58 @@
+package com.gongu.server.global.exception;
+
+import com.gongu.server.global.common.ErrorResponse;
+import com.gongu.server.global.exception.errorcode.CommonErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+
+    @ExceptionHandler(InfraException.class)
+    public ResponseEntity<ErrorResponse> handleInfraException(InfraException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        BindingResult bindingResult = e.getBindingResult();
+        List<ErrorResponse.FieldError> fieldErrors = bindingResult.getFieldErrors().stream()
+                .map(fieldError -> ErrorResponse.FieldError.of(
+                        fieldError.getField(),
+                        fieldError.getDefaultMessage()
+                ))
+                .toList();
+
+        ErrorCode errorCode = CommonErrorCode.INVALID_INPUT_VALUE;
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(errorCode, fieldErrors));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unhandled exception occurred", e);
+        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+}

--- a/src/main/java/com/gongu/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gongu/server/global/exception/GlobalExceptionHandler.java
@@ -18,14 +18,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
-        ErrorCode errorCode = e.getErrorCode();
-        return ResponseEntity
-                .status(errorCode.getHttpStatus())
-                .body(ErrorResponse.of(errorCode));
+        return handleGonguException(e);
     }
 
     @ExceptionHandler(InfraException.class)
     public ResponseEntity<ErrorResponse> handleInfraException(InfraException e) {
+        return handleGonguException(e);
+    }
+
+    @ExceptionHandler(GonguException.class)
+    public ResponseEntity<ErrorResponse> handleGonguException(GonguException e) {
         ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getHttpStatus())

--- a/src/main/java/com/gongu/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gongu/server/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.gongu.server.global.exception.errorcode.CommonErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -34,17 +35,28 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         BindingResult bindingResult = e.getBindingResult();
-        List<ErrorResponse.FieldError> fieldErrors = bindingResult.getFieldErrors().stream()
-                .map(fieldError -> ErrorResponse.FieldError.of(
-                        fieldError.getField(),
-                        fieldError.getDefaultMessage()
-                ))
+        List<ErrorResponse.FieldError> fieldErrors = bindingResult.getAllErrors().stream()
+                .map(error -> toFieldError(bindingResult, error))
                 .toList();
 
         ErrorCode errorCode = CommonErrorCode.INVALID_INPUT_VALUE;
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(ErrorResponse.of(errorCode, fieldErrors));
+    }
+
+    private ErrorResponse.FieldError toFieldError(BindingResult bindingResult, ObjectError error) {
+        if (error instanceof org.springframework.validation.FieldError fieldError) {
+            return ErrorResponse.FieldError.of(
+                    fieldError.getField(),
+                    fieldError.getDefaultMessage()
+            );
+        }
+
+        return ErrorResponse.FieldError.of(
+                bindingResult.getObjectName(),
+                error.getDefaultMessage()
+        );
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/gongu/server/global/exception/GonguException.java
+++ b/src/main/java/com/gongu/server/global/exception/GonguException.java
@@ -1,0 +1,14 @@
+package com.gongu.server.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class GonguException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public GonguException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/gongu/server/global/exception/GonguException.java
+++ b/src/main/java/com/gongu/server/global/exception/GonguException.java
@@ -3,7 +3,7 @@ package com.gongu.server.global.exception;
 import lombok.Getter;
 
 @Getter
-public class GonguException extends RuntimeException {
+public abstract class GonguException extends RuntimeException {
 
     private final ErrorCode errorCode;
 

--- a/src/main/java/com/gongu/server/global/exception/InfraException.java
+++ b/src/main/java/com/gongu/server/global/exception/InfraException.java
@@ -1,0 +1,8 @@
+package com.gongu.server.global.exception;
+
+public class InfraException extends GonguException {
+
+    public InfraException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/gongu/server/global/exception/errorcode/AuthErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/AuthErrorCode.java
@@ -1,0 +1,31 @@
+package com.gongu.server.global.exception.errorcode;
+
+import com.gongu.server.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    INVALID_TOKEN("AUTH_001", "유효하지 않은 토큰입니다", 401),
+    EXPIRED_TOKEN("AUTH_002", "만료된 토큰입니다", 401),
+    KAKAO_API_ERROR("AUTH_003", "카카오 API 호출에 실패했습니다", 502);
+
+    private final String code;
+    private final String message;
+    private final int httpStatus;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/gongu/server/global/exception/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/CommonErrorCode.java
@@ -1,0 +1,32 @@
+package com.gongu.server.global.exception.errorcode;
+
+import com.gongu.server.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+    INVALID_INPUT_VALUE("COMMON_001", "입력값이 올바르지 않습니다", 400),
+    INTERNAL_SERVER_ERROR("COMMON_002", "서버 내부 오류가 발생했습니다", 500),
+    UNAUTHORIZED("COMMON_003", "인증이 필요합니다", 401),
+    FORBIDDEN("COMMON_004", "접근 권한이 없습니다", 403);
+
+    private final String code;
+    private final String message;
+    private final int httpStatus;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/gongu/server/global/exception/errorcode/OrderErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/OrderErrorCode.java
@@ -1,0 +1,31 @@
+package com.gongu.server.global.exception.errorcode;
+
+import com.gongu.server.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum OrderErrorCode implements ErrorCode {
+
+    ORDER_NOT_FOUND("ORDER_001", "존재하지 않는 주문입니다", 404),
+    CANCEL_NOT_ALLOWED("ORDER_002", "취소할 수 없는 상태의 주문입니다", 409),
+    RECEIVE_NOT_ALLOWED("ORDER_003", "수령할 수 없는 상태의 주문입니다", 409);
+
+    private final String code;
+    private final String message;
+    private final int httpStatus;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java
@@ -1,0 +1,32 @@
+package com.gongu.server.global.exception.errorcode;
+
+import com.gongu.server.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum PaymentErrorCode implements ErrorCode {
+
+    PAYMENT_NOT_FOUND("PAYMENT_001", "존재하지 않는 결제입니다", 404),
+    PAYMENT_AMOUNT_MISMATCH("PAYMENT_002", "결제 금액이 일치하지 않습니다", 400),
+    PAYMENT_ALREADY_PROCESSED("PAYMENT_003", "이미 처리된 결제입니다", 409),
+    PG_API_ERROR("PAYMENT_004", "결제 API 호출에 실패했습니다", 502);
+
+    private final String code;
+    private final String message;
+    private final int httpStatus;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/gongu/server/global/exception/errorcode/ProductErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/ProductErrorCode.java
@@ -1,0 +1,31 @@
+package com.gongu.server.global.exception.errorcode;
+
+import com.gongu.server.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ProductErrorCode implements ErrorCode {
+
+    PRODUCT_NOT_FOUND("PRODUCT_001", "존재하지 않는 상품입니다", 404),
+    INSUFFICIENT_STOCK("PRODUCT_002", "재고가 부족합니다", 409),
+    INVALID_PRODUCT_STATUS("PRODUCT_003", "판매 중이지 않은 상품입니다", 400);
+
+    private final String code;
+    private final String message;
+    private final int httpStatus;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/gongu/server/global/exception/errorcode/UserErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/UserErrorCode.java
@@ -1,0 +1,30 @@
+package com.gongu.server.global.exception.errorcode;
+
+import com.gongu.server.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+    USER_NOT_FOUND("USER_001", "존재하지 않는 회원입니다", 404),
+    DUPLICATE_EMAIL("USER_002", "이미 사용 중인 이메일입니다", 409);
+
+    private final String code;
+    private final String message;
+    private final int httpStatus;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+}


### PR DESCRIPTION
## 🔷 Github Issue ID
close #12

## 📌 작업 내용 및 특이사항
- `GonguException` / `BusinessException` / `InfraException` 예외 계층 구성
- 도메인별 `ErrorCode` enum 6종: Common / Auth / User / Product / Order / Payment
- `GlobalExceptionHandler` (`@RestControllerAdvice`)
  - `BusinessException` → `errorCode.getHttpStatus()` 상태코드
  - `InfraException` → `errorCode.getHttpStatus()` 상태코드
  - `MethodArgumentNotValidException` → 400 + `errors` 배열
  - `Exception` (catch-all) → 500, 상세 메시지 미노출, `log.error()`로 서버 로그에만 기록

## 📚 참고사항
- ADR-004 (예외 처리 전략) 기준

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * API 오류 응답이 중앙에서 일관된 형식으로 처리됩니다.
  * 인증, 주문, 결제, 상품, 회원 관련 상세 오류 코드와 적절한 HTTP 상태가 반환됩니다.
  * 검증 실패 시 필드별 상세 오류 정보가 구조화된 형식으로 제공됩니다.
  * 예상치 못한 서버 오류에 대해 표준화된 에러 응답이 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->