### PR TITLE
[FEAT] Member, SocialInfo, StoreAdmin 엔티티 및 리포지토리 구현 (#20)

### DIFF
--- a/src/main/java/com/gongu/server/domain/store/entity/StoreAdmin.java
+++ b/src/main/java/com/gongu/server/domain/store/entity/StoreAdmin.java
@@ -1,0 +1,57 @@
+package com.gongu.server.domain.store.entity;
+
+import com.gongu.server.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Entity
+@Table(name = "store_admin")
+public class StoreAdmin extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "store_id")
+    private Long storeId;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private boolean isActive;
+
+    @Column(nullable = false)
+    private LocalDateTime deletedAt;
+
+    public static StoreAdmin of(Long storeId, String email, String encodedPassword, String name) {
+        StoreAdmin storeAdmin = new StoreAdmin();
+        storeAdmin.storeId = storeId;
+        storeAdmin.email = email;
+        storeAdmin.password = encodedPassword;
+        storeAdmin.name = name;
+        storeAdmin.isActive = true;
+        storeAdmin.deletedAt = LocalDateTime.of(9999, 12, 31, 0, 0, 0);
+        return storeAdmin;
+    }
+
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+}

--- a/src/main/java/com/gongu/server/domain/store/entity/StoreAdmin.java
+++ b/src/main/java/com/gongu/server/domain/store/entity/StoreAdmin.java
@@ -1,6 +1,6 @@
 package com.gongu.server.domain.store.entity;
 
-import com.gongu.server.global.common.BaseEntity;
+import com.gongu.server.global.common.SoftDeleteEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -10,13 +10,11 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Entity
 @Table(name = "store_admins")
-public class StoreAdmin extends BaseEntity {
+public class StoreAdmin extends SoftDeleteEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,9 +35,6 @@ public class StoreAdmin extends BaseEntity {
     @Column(nullable = false)
     private boolean isActive;
 
-    @Column(nullable = false)
-    private LocalDateTime deletedAt;
-
     public static StoreAdmin of(Long storeId, String email, String encodedPassword, String name) {
         StoreAdmin storeAdmin = new StoreAdmin();
         storeAdmin.storeId = storeId;
@@ -47,11 +42,18 @@ public class StoreAdmin extends BaseEntity {
         storeAdmin.password = encodedPassword;
         storeAdmin.name = name;
         storeAdmin.isActive = true;
-        storeAdmin.deletedAt = LocalDateTime.of(9999, 12, 31, 0, 0, 0);
         return storeAdmin;
     }
 
     public void updatePassword(String encodedPassword) {
         this.password = encodedPassword;
+    }
+
+    public void deactivate() {
+        if (isDeleted()) {
+            return;
+        }
+        this.isActive = false;
+        softDelete();
     }
 }

--- a/src/main/java/com/gongu/server/domain/store/entity/StoreAdmin.java
+++ b/src/main/java/com/gongu/server/domain/store/entity/StoreAdmin.java
@@ -20,7 +20,7 @@ public class StoreAdmin extends SoftDeleteEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "store_id")
+    @Column(name = "store_id", nullable = false)
     private Long storeId;
 
     @Column(nullable = false, unique = true)

--- a/src/main/java/com/gongu/server/domain/store/entity/StoreAdmin.java
+++ b/src/main/java/com/gongu/server/domain/store/entity/StoreAdmin.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Entity
-@Table(name = "store_admin")
+@Table(name = "store_admins")
 public class StoreAdmin extends BaseEntity {
 
     @Id

--- a/src/main/java/com/gongu/server/domain/store/repository/StoreAdminRepository.java
+++ b/src/main/java/com/gongu/server/domain/store/repository/StoreAdminRepository.java
@@ -1,0 +1,11 @@
+package com.gongu.server.domain.store.repository;
+
+import com.gongu.server.domain.store.entity.StoreAdmin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface StoreAdminRepository extends JpaRepository<StoreAdmin, Long> {
+
+    Optional<StoreAdmin> findByEmailAndIsActiveTrue(String email);
+}

--- a/src/main/java/com/gongu/server/domain/user/entity/Member.java
+++ b/src/main/java/com/gongu/server/domain/user/entity/Member.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Entity
-@Table(name = "member")
+@Table(name = "users")
 public class Member extends SoftDeleteEntity {
 
     @Id

--- a/src/main/java/com/gongu/server/domain/user/entity/Member.java
+++ b/src/main/java/com/gongu/server/domain/user/entity/Member.java
@@ -1,0 +1,53 @@
+package com.gongu.server.domain.user.entity;
+
+import com.gongu.server.global.common.SoftDeleteEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Entity
+@Table(name = "member")
+public class Member extends SoftDeleteEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String phone;
+
+    @Column(nullable = false)
+    private boolean isActive;
+
+    public static Member of(String name, String email, String phone) {
+        Member member = new Member();
+        member.name = name;
+        member.email = email;
+        member.phone = phone;
+        member.isActive = true;
+        return member;
+    }
+
+    public void updateProfile(String name, String phone) {
+        this.name = name;
+        this.phone = phone;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+        softDelete();
+    }
+}

--- a/src/main/java/com/gongu/server/domain/user/entity/Member.java
+++ b/src/main/java/com/gongu/server/domain/user/entity/Member.java
@@ -47,6 +47,9 @@ public class Member extends SoftDeleteEntity {
     }
 
     public void deactivate() {
+        if (isDeleted()) {
+            return;
+        }
         this.isActive = false;
         softDelete();
     }

--- a/src/main/java/com/gongu/server/domain/user/entity/SocialInfo.java
+++ b/src/main/java/com/gongu/server/domain/user/entity/SocialInfo.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Entity
-@Table(name = "social_info")
+@Table(name = "user_social")
 public class SocialInfo extends BaseEntity {
 
     @Id
@@ -26,14 +26,14 @@ public class SocialInfo extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "user_id")
     private Member member;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private SocialProvider provider;
 
-    @Column(nullable = false)
+    @Column(name = "provider_id", nullable = false)
     private String socialId;
 
     public static SocialInfo of(Member member, SocialProvider provider, String socialId) {

--- a/src/main/java/com/gongu/server/domain/user/entity/SocialInfo.java
+++ b/src/main/java/com/gongu/server/domain/user/entity/SocialInfo.java
@@ -1,0 +1,46 @@
+package com.gongu.server.domain.user.entity;
+
+import com.gongu.server.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Entity
+@Table(name = "social_info")
+public class SocialInfo extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SocialProvider provider;
+
+    @Column(nullable = false)
+    private String socialId;
+
+    public static SocialInfo of(Member member, SocialProvider provider, String socialId) {
+        SocialInfo socialInfo = new SocialInfo();
+        socialInfo.member = member;
+        socialInfo.provider = provider;
+        socialInfo.socialId = socialId;
+        return socialInfo;
+    }
+}

--- a/src/main/java/com/gongu/server/domain/user/entity/SocialProvider.java
+++ b/src/main/java/com/gongu/server/domain/user/entity/SocialProvider.java
@@ -1,0 +1,5 @@
+package com.gongu.server.domain.user.entity;
+
+public enum SocialProvider {
+    KAKAO, GOOGLE, NAVER
+}

--- a/src/main/java/com/gongu/server/domain/user/entity/UserSocial.java
+++ b/src/main/java/com/gongu/server/domain/user/entity/UserSocial.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Entity
 @Table(name = "user_social")
-public class SocialInfo extends BaseEntity {
+public class UserSocial extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,11 +36,11 @@ public class SocialInfo extends BaseEntity {
     @Column(name = "provider_id", nullable = false)
     private String socialId;
 
-    public static SocialInfo of(Member member, SocialProvider provider, String socialId) {
-        SocialInfo socialInfo = new SocialInfo();
-        socialInfo.member = member;
-        socialInfo.provider = provider;
-        socialInfo.socialId = socialId;
-        return socialInfo;
+    public static UserSocial of(Member member, SocialProvider provider, String socialId) {
+        UserSocial userSocial = new UserSocial();
+        userSocial.member = member;
+        userSocial.provider = provider;
+        userSocial.socialId = socialId;
+        return userSocial;
     }
 }

--- a/src/main/java/com/gongu/server/domain/user/repository/MemberRepository.java
+++ b/src/main/java/com/gongu/server/domain/user/repository/MemberRepository.java
@@ -11,5 +11,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByIdAndDeletedAtIsNull(Long id);
 
-    boolean existsByEmailAndDeletedAtIsNull(String email);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/gongu/server/domain/user/repository/MemberRepository.java
+++ b/src/main/java/com/gongu/server/domain/user/repository/MemberRepository.java
@@ -1,0 +1,15 @@
+package com.gongu.server.domain.user.repository;
+
+import com.gongu.server.domain.user.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmailAndDeletedAtIsNull(String email);
+
+    Optional<Member> findByIdAndDeletedAtIsNull(Long id);
+
+    boolean existsByEmailAndDeletedAtIsNull(String email);
+}


### PR DESCRIPTION
## Issue ID
close #20

## 작업 내용
인증/인가 마일스톤의 기반이 되는 도메인 엔티티와 리포지토리를 구현합니다.

**신규 파일**
- `domain/user/entity/SocialProvider.java` — KAKAO / GOOGLE / NAVER enum
- `domain/user/entity/Member.java` — SoftDeleteEntity 상속, 정적 팩토리 `of()`, `updateProfile()`, `deactivate()`
- `domain/user/entity/SocialInfo.java` — BaseEntity 상속, `@ManyToOne(LAZY)` Member
- `domain/user/repository/MemberRepository.java` — `deletedAt IS NULL` 기반 쿼리 메서드 3개
- `domain/store/entity/StoreAdmin.java` — BaseEntity 상속, deletedAt 기본값 9999-12-31 전략
- `domain/store/repository/StoreAdminRepository.java` — `isActive=true` 조건 조회

## 참고사항
- StoreAdmin의 Store FK는 Store 엔티티 미구현으로 `storeId(Long)` 컬럼으로 임시 처리 (마일스톤 #4에서 관계 매핑 예정)
- 모든 엔티티 공개 setter 금지, 도메인 메서드로만 상태 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 회원 계정 관리 기능 추가
  * 스토어 관리자 계정 관리 기능 추가
  * 소셜 로그인 지원 추가 (카카오, 구글, 네이버)
  * 회원 프로필 업데이트 및 계정 비활성화 기능 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->