### PR TITLE
[FEAT] 카카오 소셜 로그인 API 구현 (#23)

### DIFF
--- a/src/main/java/com/gongu/server/domain/auth/client/KakaoApiClient.java
+++ b/src/main/java/com/gongu/server/domain/auth/client/KakaoApiClient.java
@@ -1,0 +1,31 @@
+package com.gongu.server.domain.auth.client;
+
+import com.gongu.server.domain.auth.client.dto.KakaoUserInfo;
+import com.gongu.server.global.exception.InfraException;
+import com.gongu.server.global.exception.errorcode.AuthErrorCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class KakaoApiClient {
+
+    private final RestClient restClient;
+
+    public KakaoApiClient() {
+        this.restClient = RestClient.builder()
+                .baseUrl("https://kapi.kakao.com")
+                .build();
+    }
+
+    public KakaoUserInfo getUserInfo(String kakaoAccessToken) {
+        try {
+            return restClient.get()
+                    .uri("/v2/user/me")
+                    .header("Authorization", "Bearer " + kakaoAccessToken)
+                    .retrieve()
+                    .body(KakaoUserInfo.class);
+        } catch (Exception e) {
+            throw new InfraException(AuthErrorCode.KAKAO_API_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/gongu/server/domain/auth/client/KakaoApiClient.java
+++ b/src/main/java/com/gongu/server/domain/auth/client/KakaoApiClient.java
@@ -11,19 +11,32 @@ public class KakaoApiClient {
 
     private final RestClient restClient;
 
-    public KakaoApiClient() {
-        this.restClient = RestClient.builder()
+    /**
+     * Spring Boot가 자동 구성한 RestClient.Builder를 주입받아 사용한다.
+     * application.yml의 spring.http.client.connect-timeout / read-timeout 설정이 적용된다.
+     */
+    public KakaoApiClient(RestClient.Builder restClientBuilder) {
+        this.restClient = restClientBuilder
                 .baseUrl("https://kapi.kakao.com")
                 .build();
     }
 
     public KakaoUserInfo getUserInfo(String kakaoAccessToken) {
         try {
-            return restClient.get()
+            KakaoUserInfo userInfo = restClient.get()
                     .uri("/v2/user/me")
                     .header("Authorization", "Bearer " + kakaoAccessToken)
                     .retrieve()
                     .body(KakaoUserInfo.class);
+
+            // id가 null이면 카카오로부터 유효한 응답이 아님
+            if (userInfo == null || userInfo.id() == null) {
+                throw new InfraException(AuthErrorCode.KAKAO_API_ERROR);
+            }
+
+            return userInfo;
+        } catch (InfraException e) {
+            throw e;
         } catch (Exception e) {
             throw new InfraException(AuthErrorCode.KAKAO_API_ERROR);
         }

--- a/src/main/java/com/gongu/server/domain/auth/client/dto/KakaoUserInfo.java
+++ b/src/main/java/com/gongu/server/domain/auth/client/dto/KakaoUserInfo.java
@@ -1,0 +1,16 @@
+package com.gongu.server.domain.auth.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUserInfo(
+        Long id,
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
+
+    public record KakaoAccount(
+            String email,
+            Profile profile
+    ) {}
+
+    public record Profile(String nickname) {}
+}

--- a/src/main/java/com/gongu/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/gongu/server/domain/auth/controller/AuthController.java
@@ -1,0 +1,26 @@
+package com.gongu.server.domain.auth.controller;
+
+import com.gongu.server.domain.auth.dto.request.KakaoLoginRequest;
+import com.gongu.server.domain.auth.dto.response.TokenResponse;
+import com.gongu.server.domain.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/oauth2/login")
+    public ResponseEntity<TokenResponse> kakaoLogin(@Valid @RequestBody KakaoLoginRequest request) {
+        TokenResponse tokenResponse = authService.kakaoLogin(request.accessToken());
+        return ResponseEntity.ok(tokenResponse);
+    }
+}

--- a/src/main/java/com/gongu/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/gongu/server/domain/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.gongu.server.domain.auth.controller;
 import com.gongu.server.domain.auth.dto.request.KakaoLoginRequest;
 import com.gongu.server.domain.auth.dto.response.TokenResponse;
 import com.gongu.server.domain.auth.service.AuthService;
+import com.gongu.server.global.common.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,8 +20,8 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/oauth2/login")
-    public ResponseEntity<TokenResponse> kakaoLogin(@Valid @RequestBody KakaoLoginRequest request) {
+    public ResponseEntity<ApiResponse<TokenResponse>> kakaoLogin(@Valid @RequestBody KakaoLoginRequest request) {
         TokenResponse tokenResponse = authService.kakaoLogin(request.accessToken());
-        return ResponseEntity.ok(tokenResponse);
+        return ResponseEntity.ok(ApiResponse.success(tokenResponse));
     }
 }

--- a/src/main/java/com/gongu/server/domain/auth/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/gongu/server/domain/auth/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,7 @@
+package com.gongu.server.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record KakaoLoginRequest(
+        @NotBlank String accessToken  // 프론트엔드가 카카오 SDK로 획득한 카카오 액세스 토큰
+) {}

--- a/src/main/java/com/gongu/server/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/gongu/server/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,3 @@
+package com.gongu.server.domain.auth.dto.response;
+
+public record TokenResponse(String accessToken, String refreshToken) {}

--- a/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
@@ -12,6 +12,7 @@ import com.gongu.server.global.security.Role;
 import com.gongu.server.global.security.jwt.JwtProvider;
 import com.gongu.server.global.security.jwt.RefreshTokenStore;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,33 +36,46 @@ public class AuthService {
         // 2. UserSocial 조회
         Member member = userSocialRepository.findByProviderAndSocialId(SocialProvider.KAKAO, socialId)
                 .map(UserSocial::getMember)
-                .orElseGet(() -> {
-                    // 3-A. 신규 회원 가입
-                    String nickname = "";
-                    String email = "";
+                .orElseGet(() -> registerKakaoMember(userInfo, socialId));
 
-                    if (userInfo.kakaoAccount() != null) {
-                        KakaoUserInfo.KakaoAccount account = userInfo.kakaoAccount();
-
-                        if (account.profile() != null && account.profile().nickname() != null) {
-                            nickname = account.profile().nickname();
-                        }
-                        if (account.email() != null) {
-                            email = account.email();
-                        }
-                    }
-
-                    Member newMember = memberRepository.save(Member.of(nickname, email, ""));
-                    userSocialRepository.save(UserSocial.of(newMember, SocialProvider.KAKAO, socialId));
-                    return newMember;
-                });
-
-        // 4-6. 토큰 발급 및 저장
+        // 3. 토큰 발급 및 저장
         String accessToken = jwtProvider.generateAccessToken(member.getId(), Role.MEMBER);
         String refreshToken = jwtProvider.generateRefreshToken(member.getId());
         refreshTokenStore.save(member.getId(), refreshToken);
 
-        // 7. 토큰 반환
+        // 4. 토큰 반환
         return new TokenResponse(accessToken, refreshToken);
+    }
+
+    /**
+     * 신규 카카오 회원 등록.
+     * 동시 요청으로 UNIQUE 제약 충돌 시 DataIntegrityViolationException을 잡아
+     * 이미 등록된 UserSocial을 재조회한다.
+     */
+    private Member registerKakaoMember(KakaoUserInfo userInfo, String socialId) {
+        String nickname = "";
+        // 이메일 미제공 시 socialId 기반 고유 fallback 이메일 사용 (UNIQUE 제약 충족)
+        String email = "kakao-" + socialId + "@noemail.local";
+
+        if (userInfo.kakaoAccount() != null) {
+            KakaoUserInfo.KakaoAccount account = userInfo.kakaoAccount();
+            if (account.profile() != null && account.profile().nickname() != null) {
+                nickname = account.profile().nickname();
+            }
+            if (account.email() != null) {
+                email = account.email();
+            }
+        }
+
+        try {
+            Member newMember = memberRepository.save(Member.of(nickname, email, ""));
+            userSocialRepository.save(UserSocial.of(newMember, SocialProvider.KAKAO, socialId));
+            return newMember;
+        } catch (DataIntegrityViolationException e) {
+            // 동시 요청으로 인한 중복 삽입 — 이미 등록된 소셜 계정 재조회
+            return userSocialRepository.findByProviderAndSocialId(SocialProvider.KAKAO, socialId)
+                    .map(UserSocial::getMember)
+                    .orElseThrow(() -> e);
+        }
     }
 }

--- a/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
@@ -1,0 +1,67 @@
+package com.gongu.server.domain.auth.service;
+
+import com.gongu.server.domain.auth.client.KakaoApiClient;
+import com.gongu.server.domain.auth.client.dto.KakaoUserInfo;
+import com.gongu.server.domain.auth.dto.response.TokenResponse;
+import com.gongu.server.domain.user.entity.Member;
+import com.gongu.server.domain.user.entity.SocialProvider;
+import com.gongu.server.domain.user.entity.UserSocial;
+import com.gongu.server.domain.user.repository.MemberRepository;
+import com.gongu.server.domain.user.repository.UserSocialRepository;
+import com.gongu.server.global.security.Role;
+import com.gongu.server.global.security.jwt.JwtProvider;
+import com.gongu.server.global.security.jwt.RefreshTokenStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthService {
+
+    private final KakaoApiClient kakaoApiClient;
+    private final MemberRepository memberRepository;
+    private final UserSocialRepository userSocialRepository;
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenStore refreshTokenStore;
+
+    public TokenResponse kakaoLogin(String kakaoAccessToken) {
+        // 1. 카카오 사용자 정보 조회
+        KakaoUserInfo userInfo = kakaoApiClient.getUserInfo(kakaoAccessToken);
+
+        String socialId = String.valueOf(userInfo.id());
+
+        // 2. UserSocial 조회
+        Member member = userSocialRepository.findByProviderAndSocialId(SocialProvider.KAKAO, socialId)
+                .map(UserSocial::getMember)
+                .orElseGet(() -> {
+                    // 3-A. 신규 회원 가입
+                    String nickname = "";
+                    String email = "";
+
+                    if (userInfo.kakaoAccount() != null) {
+                        KakaoUserInfo.KakaoAccount account = userInfo.kakaoAccount();
+
+                        if (account.profile() != null && account.profile().nickname() != null) {
+                            nickname = account.profile().nickname();
+                        }
+                        if (account.email() != null) {
+                            email = account.email();
+                        }
+                    }
+
+                    Member newMember = memberRepository.save(Member.of(nickname, email, ""));
+                    userSocialRepository.save(UserSocial.of(newMember, SocialProvider.KAKAO, socialId));
+                    return newMember;
+                });
+
+        // 4-6. 토큰 발급 및 저장
+        String accessToken = jwtProvider.generateAccessToken(member.getId(), Role.MEMBER);
+        String refreshToken = jwtProvider.generateRefreshToken(member.getId());
+        refreshTokenStore.save(member.getId(), refreshToken);
+
+        // 7. 토큰 반환
+        return new TokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/gongu/server/domain/user/repository/UserSocialRepository.java
+++ b/src/main/java/com/gongu/server/domain/user/repository/UserSocialRepository.java
@@ -1,0 +1,12 @@
+package com.gongu.server.domain.user.repository;
+
+import com.gongu.server.domain.user.entity.SocialProvider;
+import com.gongu.server.domain.user.entity.UserSocial;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserSocialRepository extends JpaRepository<UserSocial, Long> {
+
+    Optional<UserSocial> findByProviderAndSocialId(SocialProvider provider, String socialId);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,10 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+  http:
+    client:
+      connect-timeout: 3s
+      read-timeout: 5s
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
## Issue
close #23

## 작업 내용
- `KakaoApiClient`: 카카오 `/v2/user/me` API 호출, 실패 시 `InfraException(KAKAO_API_ERROR)` 발생
- `KakaoUserInfo`: 카카오 응답 record DTO (nullable 필드 처리)
- `KakaoLoginRequest` / `TokenResponse`: 요청·응답 DTO
- `UserSocialRepository`: `findByProviderAndSocialId` 조회 메서드
- `AuthService.kakaoLogin()`: 소셜 계정 조회 → 신규 회원 자동 가입 → JWT 발급 → Redis 저장
- `AuthController`: `POST /auth/oauth2/login` 엔드포인트

## 참고사항
- 카카오 로그인 플로우: 프론트엔드가 Kakao SDK로 액세스 토큰 획득 후 백엔드에 전달 (ADR-003)
- 신규 회원은 `Member.of(nickname, email, "")` 로 자동 생성, phone 은 빈 문자열로 초기화
- `SecurityConfig`에서 `POST /auth/**` 는 permitAll 처리되어 있어 별도 인증 불필요

## 커밋 목록
1. `feat: KakaoApiClient 및 KakaoUserInfo 응답 DTO 구현 (#23)`
2. `feat: 카카오 로그인 요청/응답 DTO 구현 (#23)`
3. `feat: AuthService 카카오 로그인 비즈니스 로직 및 UserSocialRepository 구현 (#23)`
4. `feat: AuthController POST /auth/oauth2/login 엔드포인트 구현 (#23)`