### PR TITLE
[FEAT] 매장 관리자 이메일 로그인 API 구현 (#24)

### DIFF
--- a/src/main/java/com/gongu/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/gongu/server/domain/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.gongu.server.domain.auth.controller;
 
 import com.gongu.server.domain.auth.dto.request.KakaoLoginRequest;
+import com.gongu.server.domain.auth.dto.request.StoreAdminLoginRequest;
 import com.gongu.server.domain.auth.dto.response.TokenResponse;
 import com.gongu.server.domain.auth.service.AuthService;
 import com.gongu.server.global.common.ApiResponse;
@@ -23,5 +24,11 @@ public class AuthController {
     public ResponseEntity<ApiResponse<TokenResponse>> kakaoLogin(@Valid @RequestBody KakaoLoginRequest request) {
         TokenResponse tokenResponse = authService.kakaoLogin(request.accessToken());
         return ResponseEntity.ok(ApiResponse.success(tokenResponse));
+    }
+
+    @PostMapping("/store-admin/login")
+    public ResponseEntity<ApiResponse<TokenResponse>> storeAdminLogin(
+            @Valid @RequestBody StoreAdminLoginRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(authService.storeAdminLogin(request)));
     }
 }

--- a/src/main/java/com/gongu/server/domain/auth/dto/request/StoreAdminLoginRequest.java
+++ b/src/main/java/com/gongu/server/domain/auth/dto/request/StoreAdminLoginRequest.java
@@ -1,0 +1,9 @@
+package com.gongu.server.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record StoreAdminLoginRequest(
+        @NotBlank @Email String email,
+        @NotBlank String password
+) {}

--- a/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
@@ -2,17 +2,23 @@ package com.gongu.server.domain.auth.service;
 
 import com.gongu.server.domain.auth.client.KakaoApiClient;
 import com.gongu.server.domain.auth.client.dto.KakaoUserInfo;
+import com.gongu.server.domain.auth.dto.request.StoreAdminLoginRequest;
 import com.gongu.server.domain.auth.dto.response.TokenResponse;
+import com.gongu.server.domain.store.entity.StoreAdmin;
+import com.gongu.server.domain.store.repository.StoreAdminRepository;
 import com.gongu.server.domain.user.entity.Member;
 import com.gongu.server.domain.user.entity.SocialProvider;
 import com.gongu.server.domain.user.entity.UserSocial;
 import com.gongu.server.domain.user.repository.MemberRepository;
 import com.gongu.server.domain.user.repository.UserSocialRepository;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.AuthErrorCode;
 import com.gongu.server.global.security.Role;
 import com.gongu.server.global.security.jwt.JwtProvider;
 import com.gongu.server.global.security.jwt.RefreshTokenStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,26 +30,38 @@ public class AuthService {
     private final KakaoApiClient kakaoApiClient;
     private final MemberRepository memberRepository;
     private final UserSocialRepository userSocialRepository;
+    private final StoreAdminRepository storeAdminRepository;
+    private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
     private final RefreshTokenStore refreshTokenStore;
 
     public TokenResponse kakaoLogin(String kakaoAccessToken) {
-        // 1. 카카오 사용자 정보 조회
         KakaoUserInfo userInfo = kakaoApiClient.getUserInfo(kakaoAccessToken);
-
         String socialId = String.valueOf(userInfo.id());
 
-        // 2. UserSocial 조회
         Member member = userSocialRepository.findByProviderAndSocialId(SocialProvider.KAKAO, socialId)
                 .map(UserSocial::getMember)
                 .orElseGet(() -> registerKakaoMember(userInfo, socialId));
 
-        // 3. 토큰 발급 및 저장
         String accessToken = jwtProvider.generateAccessToken(member.getId(), Role.MEMBER);
         String refreshToken = jwtProvider.generateRefreshToken(member.getId());
         refreshTokenStore.save(member.getId(), refreshToken);
 
-        // 4. 토큰 반환
+        return new TokenResponse(accessToken, refreshToken);
+    }
+
+    public TokenResponse storeAdminLogin(StoreAdminLoginRequest request) {
+        StoreAdmin storeAdmin = storeAdminRepository.findByEmailAndIsActiveTrue(request.email())
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_CREDENTIALS));
+
+        if (!passwordEncoder.matches(request.password(), storeAdmin.getPassword())) {
+            throw new BusinessException(AuthErrorCode.INVALID_CREDENTIALS);
+        }
+
+        String accessToken = jwtProvider.generateAccessToken(storeAdmin.getId(), Role.STORE_ADMIN);
+        String refreshToken = jwtProvider.generateRefreshToken(storeAdmin.getId());
+        refreshTokenStore.save(storeAdmin.getId(), refreshToken);
+
         return new TokenResponse(accessToken, refreshToken);
     }
 
@@ -54,7 +72,6 @@ public class AuthService {
      */
     private Member registerKakaoMember(KakaoUserInfo userInfo, String socialId) {
         String nickname = "";
-        // 이메일 미제공 시 socialId 기반 고유 fallback 이메일 사용 (UNIQUE 제약 충족)
         String email = "kakao-" + socialId + "@noemail.local";
 
         if (userInfo.kakaoAccount() != null) {
@@ -72,7 +89,6 @@ public class AuthService {
             userSocialRepository.save(UserSocial.of(newMember, SocialProvider.KAKAO, socialId));
             return newMember;
         } catch (DataIntegrityViolationException e) {
-            // 동시 요청으로 인한 중복 삽입 — 이미 등록된 소셜 계정 재조회
             return userSocialRepository.findByProviderAndSocialId(SocialProvider.KAKAO, socialId)
                     .map(UserSocial::getMember)
                     .orElseThrow(() -> e);

--- a/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
@@ -22,10 +22,19 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class AuthService {
+
+    /**
+     * 타이밍 어택 방지용 더미 BCrypt 해시.
+     * 이메일이 존재하지 않을 때도 항상 passwordEncoder.matches()를 실행해
+     * 응답 시간을 일정하게 유지한다.
+     */
+    private static final String DUMMY_HASH = "$2a$10$7EqJtq98hPqEX7fNZaFWoOe1F0FQT9VgQHtP5WrNwrQeX9wQZvJ3K";
 
     private final KakaoApiClient kakaoApiClient;
     private final MemberRepository memberRepository;
@@ -45,22 +54,25 @@ public class AuthService {
 
         String accessToken = jwtProvider.generateAccessToken(member.getId(), Role.MEMBER);
         String refreshToken = jwtProvider.generateRefreshToken(member.getId());
-        refreshTokenStore.save(member.getId(), refreshToken);
+        refreshTokenStore.save(member.getId(), Role.MEMBER, refreshToken);
 
         return new TokenResponse(accessToken, refreshToken);
     }
 
     public TokenResponse storeAdminLogin(StoreAdminLoginRequest request) {
-        StoreAdmin storeAdmin = storeAdminRepository.findByEmailAndIsActiveTrue(request.email())
-                .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_CREDENTIALS));
+        // 타이밍 어택 방지: 이메일 미존재 시에도 더미 해시로 BCrypt를 항상 실행해 응답 시간을 일정하게 유지
+        Optional<StoreAdmin> adminOpt = storeAdminRepository.findByEmailAndIsActiveTrue(request.email());
+        String hashToCheck = adminOpt.map(StoreAdmin::getPassword).orElse(DUMMY_HASH);
+        boolean passwordMatches = passwordEncoder.matches(request.password(), hashToCheck);
 
-        if (!passwordEncoder.matches(request.password(), storeAdmin.getPassword())) {
+        if (adminOpt.isEmpty() || !passwordMatches) {
             throw new BusinessException(AuthErrorCode.INVALID_CREDENTIALS);
         }
 
+        StoreAdmin storeAdmin = adminOpt.get();
         String accessToken = jwtProvider.generateAccessToken(storeAdmin.getId(), Role.STORE_ADMIN);
         String refreshToken = jwtProvider.generateRefreshToken(storeAdmin.getId());
-        refreshTokenStore.save(storeAdmin.getId(), refreshToken);
+        refreshTokenStore.save(storeAdmin.getId(), Role.STORE_ADMIN, refreshToken);
 
         return new TokenResponse(accessToken, refreshToken);
     }

--- a/src/main/java/com/gongu/server/global/exception/errorcode/AuthErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/AuthErrorCode.java
@@ -10,7 +10,8 @@ public enum AuthErrorCode implements ErrorCode {
     EXPIRED_TOKEN("AUTH_002", "만료된 토큰입니다", 401),
     KAKAO_API_ERROR("AUTH_003", "카카오 API 호출에 실패했습니다", 502),
     UNAUTHORIZED("AUTH_004", "인증이 필요합니다", 401),
-    FORBIDDEN("AUTH_005", "접근 권한이 없습니다", 403);
+    FORBIDDEN("AUTH_005", "접근 권한이 없습니다", 403),
+    INVALID_CREDENTIALS("AUTH_006", "이메일 또는 비밀번호가 올바르지 않습니다", 401);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/gongu/server/global/security/jwt/RefreshTokenStore.java
+++ b/src/main/java/com/gongu/server/global/security/jwt/RefreshTokenStore.java
@@ -1,5 +1,6 @@
 package com.gongu.server.global.security.jwt;
 
+import com.gongu.server.global.security.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -17,20 +18,24 @@ public class RefreshTokenStore {
     @Value("${jwt.refresh-expiration}")
     private long refreshExpiration;
 
-    private String key(Long memberId) {
-        return "refresh:" + memberId;
+    /**
+     * Redis 키에 role 접두사를 포함해 Member·StoreAdmin 간 ID 충돌을 방지한다.
+     * 예: "refresh:MEMBER:1", "refresh:STORE_ADMIN:1"
+     */
+    private String key(Long memberId, Role role) {
+        return "refresh:" + role.name() + ":" + memberId;
     }
 
-    public void save(Long memberId, String refreshToken) {
+    public void save(Long memberId, Role role, String refreshToken) {
         stringRedisTemplate.opsForValue()
-                .set(key(memberId), refreshToken, refreshExpiration, TimeUnit.MILLISECONDS);
+                .set(key(memberId, role), refreshToken, refreshExpiration, TimeUnit.MILLISECONDS);
     }
 
-    public Optional<String> get(Long memberId) {
-        return Optional.ofNullable(stringRedisTemplate.opsForValue().get(key(memberId)));
+    public Optional<String> get(Long memberId, Role role) {
+        return Optional.ofNullable(stringRedisTemplate.opsForValue().get(key(memberId, role)));
     }
 
-    public void delete(Long memberId) {
-        stringRedisTemplate.delete(key(memberId));
+    public void delete(Long memberId, Role role) {
+        stringRedisTemplate.delete(key(memberId, role));
     }
 }


### PR DESCRIPTION
## Issue
close #24

## 작업 내용
- `AuthErrorCode.INVALID_CREDENTIALS` 추가 — 계정 열거 방지를 위해 이메일 미존재·비밀번호 불일치를 동일 메시지 처리
- `StoreAdminLoginRequest`: `@Email @NotBlank email`, `@NotBlank password` record DTO
- `TokenResponse`: `accessToken`, `refreshToken` record DTO
- `AuthService.storeAdminLogin()`: 이메일로 활성 관리자 조회 → 비밀번호 검증 → JWT 발급 → Redis 저장
- `AuthController`: `POST /auth/store-admin/login` 엔드포인트

## 참고사항
- `findByEmailAndIsActiveTrue`: soft-delete(deletedAt IS NULL) + 비활성화(isActive=false) 동시 필터링
- role=STORE_ADMIN으로 Access Token 발급
- SecurityConfig에서 `POST /auth/**` permitAll 처리되어 별도 인증 불필요
- **merge 시 주의**: PR #32(#23 카카오 로그인)와 AuthService, AuthController, TokenResponse 파일이 겹침 → 두 PR 중 하나가 먼저 merge된 후 나머지는 conflict 해소 필요

## 커밋 목록
1. `feat: INVALID_CREDENTIALS 에러 코드 추가 및 매장 관리자 로그인 DTO 구현 (#24)`
2. `feat: AuthService 매장 관리자 이메일 로그인 비즈니스 로직 구현 (#24)`
3. `feat: AuthController POST /auth/store-admin/login 엔드포인트 구현 (#24)`