### PR TITLE
[FEAT] 액세스 토큰 재발급 API 구현 (#25)

### DIFF
--- a/src/main/java/com/gongu/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/gongu/server/domain/auth/controller/AuthController.java
@@ -2,6 +2,8 @@ package com.gongu.server.domain.auth.controller;
 
 import com.gongu.server.domain.auth.dto.request.KakaoLoginRequest;
 import com.gongu.server.domain.auth.dto.request.StoreAdminLoginRequest;
+import com.gongu.server.domain.auth.dto.request.TokenRefreshRequest;
+import com.gongu.server.domain.auth.dto.response.AccessTokenResponse;
 import com.gongu.server.domain.auth.dto.response.TokenResponse;
 import com.gongu.server.domain.auth.service.AuthService;
 import com.gongu.server.global.common.ApiResponse;
@@ -22,13 +24,18 @@ public class AuthController {
 
     @PostMapping("/oauth2/login")
     public ResponseEntity<ApiResponse<TokenResponse>> kakaoLogin(@Valid @RequestBody KakaoLoginRequest request) {
-        TokenResponse tokenResponse = authService.kakaoLogin(request.accessToken());
-        return ResponseEntity.ok(ApiResponse.success(tokenResponse));
+        return ResponseEntity.ok(ApiResponse.success(authService.kakaoLogin(request.accessToken())));
     }
 
     @PostMapping("/store-admin/login")
     public ResponseEntity<ApiResponse<TokenResponse>> storeAdminLogin(
             @Valid @RequestBody StoreAdminLoginRequest request) {
         return ResponseEntity.ok(ApiResponse.success(authService.storeAdminLogin(request)));
+    }
+
+    @PostMapping("/token/refresh")
+    public ResponseEntity<ApiResponse<AccessTokenResponse>> tokenRefresh(
+            @Valid @RequestBody TokenRefreshRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(authService.refreshToken(request)));
     }
 }

--- a/src/main/java/com/gongu/server/domain/auth/dto/request/TokenRefreshRequest.java
+++ b/src/main/java/com/gongu/server/domain/auth/dto/request/TokenRefreshRequest.java
@@ -1,0 +1,7 @@
+package com.gongu.server.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenRefreshRequest(
+        @NotBlank String refreshToken
+) {}

--- a/src/main/java/com/gongu/server/domain/auth/dto/response/AccessTokenResponse.java
+++ b/src/main/java/com/gongu/server/domain/auth/dto/response/AccessTokenResponse.java
@@ -1,0 +1,3 @@
+package com.gongu.server.domain.auth.dto.response;
+
+public record AccessTokenResponse(String accessToken) {}

--- a/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
@@ -56,7 +56,7 @@ public class AuthService {
                 .orElseGet(() -> registerKakaoMember(userInfo, socialId));
 
         String accessToken = jwtProvider.generateAccessToken(member.getId(), Role.MEMBER);
-        String refreshToken = jwtProvider.generateRefreshToken(member.getId());
+        String refreshToken = jwtProvider.generateRefreshToken(member.getId(), Role.MEMBER);
         refreshTokenStore.save(member.getId(), Role.MEMBER, refreshToken);
 
         return new TokenResponse(accessToken, refreshToken);
@@ -73,7 +73,7 @@ public class AuthService {
 
         StoreAdmin storeAdmin = adminOpt.get();
         String accessToken = jwtProvider.generateAccessToken(storeAdmin.getId(), Role.STORE_ADMIN);
-        String refreshToken = jwtProvider.generateRefreshToken(storeAdmin.getId());
+        String refreshToken = jwtProvider.generateRefreshToken(storeAdmin.getId(), Role.STORE_ADMIN);
         refreshTokenStore.save(storeAdmin.getId(), Role.STORE_ADMIN, refreshToken);
 
         return new TokenResponse(accessToken, refreshToken);

--- a/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
@@ -20,13 +20,16 @@ import com.gongu.server.global.security.jwt.JwtProvider;
 import com.gongu.server.global.security.jwt.RefreshTokenStore;
 import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -82,8 +85,9 @@ public class AuthService {
     /**
      * Refresh Token을 검증하고 새 Access Token을 발급한다.
      * RTR(Refresh Token Rotation) 미적용 — Refresh Token은 갱신하지 않는다.
+     * DB 접근이 없으므로 트랜잭션을 열지 않는다.
      */
-    @Transactional(readOnly = true)
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public AccessTokenResponse refreshToken(TokenRefreshRequest request) {
         if (!jwtProvider.validateRefreshToken(request.refreshToken())) {
             throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
@@ -102,6 +106,7 @@ public class AuthService {
         String storedToken = refreshTokenStore.get(memberId, role)
                 .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN));
         if (!storedToken.equals(request.refreshToken())) {
+            log.warn("[보안] Refresh Token 불일치 감지 — 재사용 공격 의심. memberId={}, role={}", memberId, role);
             throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 

--- a/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
@@ -3,6 +3,8 @@ package com.gongu.server.domain.auth.service;
 import com.gongu.server.domain.auth.client.KakaoApiClient;
 import com.gongu.server.domain.auth.client.dto.KakaoUserInfo;
 import com.gongu.server.domain.auth.dto.request.StoreAdminLoginRequest;
+import com.gongu.server.domain.auth.dto.request.TokenRefreshRequest;
+import com.gongu.server.domain.auth.dto.response.AccessTokenResponse;
 import com.gongu.server.domain.auth.dto.response.TokenResponse;
 import com.gongu.server.domain.store.entity.StoreAdmin;
 import com.gongu.server.domain.store.repository.StoreAdminRepository;
@@ -16,6 +18,7 @@ import com.gongu.server.global.exception.errorcode.AuthErrorCode;
 import com.gongu.server.global.security.Role;
 import com.gongu.server.global.security.jwt.JwtProvider;
 import com.gongu.server.global.security.jwt.RefreshTokenStore;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -60,7 +63,6 @@ public class AuthService {
     }
 
     public TokenResponse storeAdminLogin(StoreAdminLoginRequest request) {
-        // 타이밍 어택 방지: 이메일 미존재 시에도 더미 해시로 BCrypt를 항상 실행해 응답 시간을 일정하게 유지
         Optional<StoreAdmin> adminOpt = storeAdminRepository.findByEmailAndIsActiveTrue(request.email());
         String hashToCheck = adminOpt.map(StoreAdmin::getPassword).orElse(DUMMY_HASH);
         boolean passwordMatches = passwordEncoder.matches(request.password(), hashToCheck);
@@ -75,6 +77,35 @@ public class AuthService {
         refreshTokenStore.save(storeAdmin.getId(), Role.STORE_ADMIN, refreshToken);
 
         return new TokenResponse(accessToken, refreshToken);
+    }
+
+    /**
+     * Refresh Token을 검증하고 새 Access Token을 발급한다.
+     * RTR(Refresh Token Rotation) 미적용 — Refresh Token은 갱신하지 않는다.
+     */
+    @Transactional(readOnly = true)
+    public AccessTokenResponse refreshToken(TokenRefreshRequest request) {
+        if (!jwtProvider.validateRefreshToken(request.refreshToken())) {
+            throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        Long memberId;
+        Role role;
+        try {
+            memberId = jwtProvider.getMemberIdFromToken(request.refreshToken());
+            role = jwtProvider.getRoleFromToken(request.refreshToken());
+        } catch (JwtException e) {
+            throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // Redis 저장 토큰과 일치 여부 확인 (재사용 공격 방지)
+        String storedToken = refreshTokenStore.get(memberId, role)
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN));
+        if (!storedToken.equals(request.refreshToken())) {
+            throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        return new AccessTokenResponse(jwtProvider.generateAccessToken(memberId, role));
     }
 
     /**

--- a/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
@@ -89,28 +89,22 @@ public class AuthService {
      */
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public AccessTokenResponse refreshToken(TokenRefreshRequest request) {
-        if (!jwtProvider.validateRefreshToken(request.refreshToken())) {
-            throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
-        }
-
-        Long memberId;
-        Role role;
+        JwtProvider.RefreshTokenClaims claims;
         try {
-            memberId = jwtProvider.getMemberIdFromToken(request.refreshToken());
-            role = jwtProvider.getRoleFromToken(request.refreshToken());
+            claims = jwtProvider.parseRefreshToken(request.refreshToken());
         } catch (JwtException e) {
             throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
         // Redis 저장 토큰과 일치 여부 확인 (재사용 공격 방지)
-        String storedToken = refreshTokenStore.get(memberId, role)
+        String storedToken = refreshTokenStore.get(claims.memberId(), claims.role())
                 .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN));
         if (!storedToken.equals(request.refreshToken())) {
-            log.warn("[보안] Refresh Token 불일치 감지 — 재사용 공격 의심. memberId={}, role={}", memberId, role);
+            log.warn("[보안] Refresh Token 불일치 감지 — 재사용 공격 의심. memberId={}, role={}", claims.memberId(), claims.role());
             throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        return new AccessTokenResponse(jwtProvider.generateAccessToken(memberId, role));
+        return new AccessTokenResponse(jwtProvider.generateAccessToken(claims.memberId(), claims.role()));
     }
 
     /**

--- a/src/main/java/com/gongu/server/global/exception/errorcode/AuthErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/AuthErrorCode.java
@@ -11,7 +11,8 @@ public enum AuthErrorCode implements ErrorCode {
     KAKAO_API_ERROR("AUTH_003", "카카오 API 호출에 실패했습니다", 502),
     UNAUTHORIZED("AUTH_004", "인증이 필요합니다", 401),
     FORBIDDEN("AUTH_005", "접근 권한이 없습니다", 403),
-    INVALID_CREDENTIALS("AUTH_006", "이메일 또는 비밀번호가 올바르지 않습니다", 401);
+    INVALID_CREDENTIALS("AUTH_006", "이메일 또는 비밀번호가 올바르지 않습니다", 401),
+    INVALID_REFRESH_TOKEN("AUTH_007", "유효하지 않은 리프레시 토큰입니다", 401);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/gongu/server/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/gongu/server/global/security/jwt/JwtProvider.java
@@ -118,7 +118,7 @@ public class JwtProvider {
     }
 
     /**
-     * Access Token 전용. Refresh Token에는 role 클레임이 없으므로 사용 불가.
+     * 토큰에서 role 클레임을 추출한다.
      */
     public Role getRoleFromToken(String token) {
         String role = Jwts.parser()
@@ -128,7 +128,7 @@ public class JwtProvider {
                 .getPayload()
                 .get("role", String.class);
         if (role == null) {
-            throw new JwtException("role claim is missing — access token only");
+            throw new JwtException("role claim is missing");
         }
         try {
             return Role.valueOf(role);
@@ -136,4 +136,43 @@ public class JwtProvider {
             throw new JwtException("Unknown role claim: " + role, e);
         }
     }
+
+    /**
+     * Refresh Token을 파싱하여 memberId와 role을 한 번에 반환한다.
+     * 내부적으로 서명·만료·type=refresh 검증을 수행하며, JWT를 한 번만 파싱한다.
+     * 검증 실패 또는 클레임 추출 실패 시 JwtException을 던진다.
+     */
+    public RefreshTokenClaims parseRefreshToken(String token) {
+        var claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        if (!"refresh".equals(claims.get("type", String.class))) {
+            throw new JwtException("Not a refresh token");
+        }
+
+        Long memberId;
+        try {
+            memberId = Long.parseLong(claims.getSubject());
+        } catch (NumberFormatException e) {
+            throw new JwtException("Invalid member ID in token subject", e);
+        }
+
+        String roleName = claims.get("role", String.class);
+        if (roleName == null) {
+            throw new JwtException("role claim is missing");
+        }
+        Role role;
+        try {
+            role = Role.valueOf(roleName);
+        } catch (IllegalArgumentException e) {
+            throw new JwtException("Unknown role claim: " + roleName, e);
+        }
+
+        return new RefreshTokenClaims(memberId, role);
+    }
+
+    public record RefreshTokenClaims(Long memberId, Role role) {}
 }

--- a/src/main/java/com/gongu/server/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/gongu/server/global/security/jwt/JwtProvider.java
@@ -45,15 +45,33 @@ public class JwtProvider {
                 .compact();
     }
 
-    public String generateRefreshToken(Long memberId) {
+    public String generateRefreshToken(Long memberId, Role role) {
         long now = System.currentTimeMillis();
         return Jwts.builder()
                 .subject(String.valueOf(memberId))
                 .claim("type", "refresh")
+                .claim("role", role.name())
                 .issuedAt(new Date(now))
                 .expiration(new Date(now + refreshExpiration))
                 .signWith(secretKey)
                 .compact();
+    }
+
+    /**
+     * Refresh Token 전용 검증. 서명·만료 확인 후 type=refresh 클레임을 추가로 검증한다.
+     */
+    public boolean validateRefreshToken(String token) {
+        try {
+            String type = Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .get("type", String.class);
+            return "refresh".equals(type);
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
     }
 
     public boolean validateToken(String token) {


### PR DESCRIPTION
## Issue
close #25

## 작업 내용
- `JwtProvider.generateRefreshToken(Long memberId, Role role)` — role 클레임 추가 (토큰 재발급 시 DB 조회 없이 role 확인)
- `JwtProvider.validateRefreshToken(String token)` — type=refresh 클레임 추가 검증
- `AuthErrorCode.INVALID_REFRESH_TOKEN` 추가
- `TokenRefreshRequest`: `@NotBlank refreshToken` record DTO
- `AccessTokenResponse`: `accessToken`만 포함하는 응답 DTO
- `AuthService.refreshToken()`: 검증 → Redis 비교 → 새 Access Token 발급
- `AuthController`: `POST /auth/token/refresh` 엔드포인트

## 참고사항
- RTR(Refresh Token Rotation) 미적용 — 이슈 명세 준수
- Redis 저장 토큰과 불일치 시 재사용 공격으로 간주 → `INVALID_REFRESH_TOKEN` 반환
- role 클레임을 refresh token에 포함시켜 DB 조회 없이 Access Token 발급 가능

## ⚠️ merge 시 주의
- **PR #32(#23)**: `AuthService.kakaoLogin()`에서 `generateRefreshToken(member.getId())` 호출 → `generateRefreshToken(member.getId(), Role.MEMBER)` 로 수정 필요
- **PR #33(#24)**: `AuthService.storeAdminLogin()`에서 `generateRefreshToken(storeAdmin.getId())` 호출 → `generateRefreshToken(storeAdmin.getId(), Role.STORE_ADMIN)` 로 수정 필요
- 세 PR 모두 `AuthService`, `AuthController`, `TokenResponse`가 겹쳐 conflict 발생 예정 → 먼저 merge된 PR 기준으로 나머지 메서드를 합산

## 커밋 목록
1. `feat: JwtProvider refresh token에 role 클레임 추가 및 INVALID_REFRESH_TOKEN 에러 코드 추가 (#25)`
2. `feat: 토큰 재발급 요청/응답 DTO 구현 (#25)`
3. `feat: AuthService 리프레시 토큰 검증 및 액세스 토큰 재발급 로직 구현 (#25)`
4. `feat: AuthController POST /auth/token/refresh 엔드포인트 구현 (#25)`