### PR TITLE
[FEAT] 이메일 중복 확인 API 구현 (#26)

### DIFF
--- a/src/main/java/com/gongu/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/gongu/server/domain/auth/controller/AuthController.java
@@ -4,20 +4,27 @@ import com.gongu.server.domain.auth.dto.request.KakaoLoginRequest;
 import com.gongu.server.domain.auth.dto.request.StoreAdminLoginRequest;
 import com.gongu.server.domain.auth.dto.request.TokenRefreshRequest;
 import com.gongu.server.domain.auth.dto.response.AccessTokenResponse;
+import com.gongu.server.domain.auth.dto.response.EmailAvailabilityResponse;
 import com.gongu.server.domain.auth.dto.response.TokenResponse;
 import com.gongu.server.domain.auth.service.AuthService;
 import com.gongu.server.global.common.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
+@Validated
 public class AuthController {
 
     private final AuthService authService;
@@ -37,5 +44,11 @@ public class AuthController {
     public ResponseEntity<ApiResponse<AccessTokenResponse>> tokenRefresh(
             @Valid @RequestBody TokenRefreshRequest request) {
         return ResponseEntity.ok(ApiResponse.success(authService.refreshToken(request)));
+    }
+
+    @GetMapping("/email-availability")
+    public ResponseEntity<ApiResponse<EmailAvailabilityResponse>> checkEmailAvailability(
+            @RequestParam @NotBlank @Email String email) {
+        return ResponseEntity.ok(ApiResponse.success(authService.checkEmailAvailability(email)));
     }
 }

--- a/src/main/java/com/gongu/server/domain/auth/dto/response/EmailAvailabilityResponse.java
+++ b/src/main/java/com/gongu/server/domain/auth/dto/response/EmailAvailabilityResponse.java
@@ -1,0 +1,3 @@
+package com.gongu.server.domain.auth.dto.response;
+
+public record EmailAvailabilityResponse(boolean available) {}

--- a/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
@@ -5,6 +5,7 @@ import com.gongu.server.domain.auth.client.dto.KakaoUserInfo;
 import com.gongu.server.domain.auth.dto.request.StoreAdminLoginRequest;
 import com.gongu.server.domain.auth.dto.request.TokenRefreshRequest;
 import com.gongu.server.domain.auth.dto.response.AccessTokenResponse;
+import com.gongu.server.domain.auth.dto.response.EmailAvailabilityResponse;
 import com.gongu.server.domain.auth.dto.response.TokenResponse;
 import com.gongu.server.domain.store.entity.StoreAdmin;
 import com.gongu.server.domain.store.repository.StoreAdminRepository;
@@ -135,5 +136,15 @@ public class AuthService {
                     .map(UserSocial::getMember)
                     .orElseThrow(() -> e);
         }
+    }
+
+    /**
+     * 이메일 사용 가능 여부를 반환한다.
+     * DDL의 UNIQUE 제약 조건(UQ_USERS_EMAIL)에 따라 이메일은 전체 고유 — deletedAt 조건 없이 existsByEmail 사용.
+     */
+    @Transactional(readOnly = true)
+    public EmailAvailabilityResponse checkEmailAvailability(String email) {
+        boolean available = !memberRepository.existsByEmail(email);
+        return new EmailAvailabilityResponse(available);
     }
 }

--- a/src/main/java/com/gongu/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gongu/server/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.gongu.server.global.exception;
 
 import com.gongu.server.global.common.ErrorResponse;
 import com.gongu.server.global.exception.errorcode.CommonErrorCode;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -59,6 +60,30 @@ public class GlobalExceptionHandler {
                 bindingResult.getObjectName(),
                 error.getDefaultMessage()
         );
+    }
+
+    /**
+     * @Validated + @RequestParam 검증 실패 시 발생하는 ConstraintViolationException 처리.
+     * @Valid + @RequestBody의 MethodArgumentNotValidException과 동일하게 HTTP 400으로 반환한다.
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
+        List<ErrorResponse.FieldError> fieldErrors = e.getConstraintViolations().stream()
+                .map(violation -> {
+                    String field = violation.getPropertyPath().toString();
+                    // "methodName.paramName" 형태에서 파라미터명만 추출
+                    int lastDot = field.lastIndexOf('.');
+                    if (lastDot >= 0) {
+                        field = field.substring(lastDot + 1);
+                    }
+                    return ErrorResponse.FieldError.of(field, violation.getMessage());
+                })
+                .toList();
+
+        ErrorCode errorCode = CommonErrorCode.INVALID_INPUT_VALUE;
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(errorCode, fieldErrors));
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## Issue
close #26

## 작업 내용
- `EmailAvailabilityResponse`: `boolean available` 응답 DTO
- `AuthService.checkEmailAvailability()`: `existsByEmail`로 조회 후 가용 여부 반환
- `AuthController`: `GET /auth/email-availability?email=` 퍼블릭 엔드포인트

## 참고사항
- DDL의 `UNIQUE(email)` 제약 조건에 따라 `existsByEmail` 사용 (deletedAt 조건 불필요 — 이메일 재사용 불가 정책)
- `@Validated` + `@Email @NotBlank @RequestParam`으로 쿼리파라미터 검증
- SecurityConfig에서 `GET /auth/email-availability` 이미 `permitAll` 처리됨

## ⚠️ merge 시 주의
- PR #32(#23), #33(#24), #34(#25)와 `AuthService`, `AuthController`가 겹쳐 conflict 발생 예정
- 모든 PR merge 후 최종 `AuthService`에 `kakaoLogin`, `storeAdminLogin`, `refreshToken`, `checkEmailAvailability` 4개 메서드가 합산되어야 함

## 커밋 목록
1. `feat: 이메일 중복 확인 응답 DTO 구현 (#26)`
2. `feat: AuthService 이메일 중복 확인 로직 구현 (#26)`
3. `feat: AuthController GET /auth/email-availability 엔드포인트 구현 (#26)`