### PR TITLE
[DOCS] member_stores 테이블 DDL 추가 (#36)

### DIFF
--- a/docs/schema/ddl.sql
+++ b/docs/schema/ddl.sql
@@ -84,6 +84,14 @@ CREATE TABLE `order_items` (
     `created_at` datetime NOT NULL
 );
 
+CREATE TABLE `member_stores` (
+    `id`           bigint   NOT NULL,
+    `user_id`      bigint   NOT NULL,
+    `store_id`     bigint   NOT NULL,
+    `is_preferred` boolean  NOT NULL,
+    `created_at`   datetime NOT NULL
+);
+
 CREATE TABLE `payments` (
     `id`               bigint       NOT NULL,
     `order_id`         bigint       NOT NULL,
@@ -109,6 +117,7 @@ ALTER TABLE `user_social`  ADD CONSTRAINT `PK_USER_SOCIAL`  PRIMARY KEY (`id`);
 ALTER TABLE `products`     ADD CONSTRAINT `PK_PRODUCTS`     PRIMARY KEY (`id`);
 ALTER TABLE `orders`       ADD CONSTRAINT `PK_ORDERS`       PRIMARY KEY (`id`);
 ALTER TABLE `order_items`  ADD CONSTRAINT `PK_ORDER_ITEMS`  PRIMARY KEY (`id`);
+ALTER TABLE `member_stores` ADD CONSTRAINT `PK_MEMBER_STORES` PRIMARY KEY (`id`);
 ALTER TABLE `payments`     ADD CONSTRAINT `PK_PAYMENTS`     PRIMARY KEY (`id`);
 
 -- -------------------------------------------------------------
@@ -117,6 +126,14 @@ ALTER TABLE `payments`     ADD CONSTRAINT `PK_PAYMENTS`     PRIMARY KEY (`id`);
 
 ALTER TABLE `store_admins`
     ADD CONSTRAINT `FK_STORE_ADMINS_STORE_ID`
+    FOREIGN KEY (`store_id`) REFERENCES `stores` (`id`);
+
+ALTER TABLE `member_stores`
+    ADD CONSTRAINT `FK_MEMBER_STORES_USER_ID`
+    FOREIGN KEY (`user_id`) REFERENCES `users` (`id`);
+
+ALTER TABLE `member_stores`
+    ADD CONSTRAINT `FK_MEMBER_STORES_STORE_ID`
     FOREIGN KEY (`store_id`) REFERENCES `stores` (`id`);
 
 ALTER TABLE `user_social`
@@ -156,6 +173,11 @@ ALTER TABLE `user_social`
     ADD CONSTRAINT `UQ_USER_SOCIAL_USER_PROVIDER`
     UNIQUE (`user_id`, `provider`);
 
+-- 동일 회원의 중복 매장 등록 방지
+ALTER TABLE `member_stores`
+    ADD CONSTRAINT `UQ_MEMBER_STORES_USER_STORE`
+    UNIQUE (`user_id`, `store_id`);
+
 -- 결제 멱등키 / PG사 결제번호 / 서버 주문번호 중복 방지
 ALTER TABLE `payments` ADD CONSTRAINT `UQ_PAYMENTS_IDEMPOTENCY_KEY` UNIQUE (`idempotency_key`);
 ALTER TABLE `payments` ADD CONSTRAINT `UQ_PAYMENTS_IMP_UID`         UNIQUE (`imp_uid`);
@@ -166,6 +188,8 @@ ALTER TABLE `payments` ADD CONSTRAINT `UQ_PAYMENTS_MERCHANT_UID`    UNIQUE (`mer
 -- -------------------------------------------------------------
 
 CREATE INDEX `IDX_STORE_ADMINS_STORE_ID`   ON `store_admins` (`store_id`);
+CREATE INDEX `IDX_MEMBER_STORES_USER_ID`   ON `member_stores` (`user_id`);
+CREATE INDEX `IDX_MEMBER_STORES_STORE_ID`  ON `member_stores` (`store_id`);
 CREATE INDEX `IDX_USER_SOCIAL_USER_ID`     ON `user_social`  (`user_id`);
 CREATE INDEX `IDX_PRODUCTS_STORE_ID`       ON `products`     (`store_id`);
 CREATE INDEX `IDX_ORDERS_USER_ID`          ON `orders`       (`user_id`);

--- a/docs/schema/table-definitions.md
+++ b/docs/schema/table-definitions.md
@@ -6,6 +6,7 @@
 
 - [stores](#stores)
 - [store_admins](#store_admins)
+- [member_stores](#member_stores)
 - [users](#users)
 - [user_social](#user_social)
 - [products](#products)
@@ -66,6 +67,36 @@
 
 | 컬럼 | 참조 테이블 | 참조 컬럼 |
 |------|-------------|-----------|
+| store_id | stores | id |
+
+---
+
+## member_stores
+
+회원-매장 다대다 연결 테이블. 회원이 이용 중인 매장 목록을 관리.
+
+| 컬럼 | 타입 | NULL | 기본값 | 설명 |
+|------|------|------|--------|------|
+| id | bigint | NO | — | PK |
+| user_id | bigint | NO | — | FK → users.id |
+| store_id | bigint | NO | — | FK → stores.id |
+| is_preferred | boolean | NO | — | 단골 매장 여부 |
+| created_at | datetime | NO | — | 등록일시 |
+
+**인덱스**
+
+| 이름 | 대상 컬럼 | 종류 | 비고 |
+|------|-----------|------|------|
+| PK_MEMBER_STORES | id | PRIMARY | |
+| UQ_MEMBER_STORES_USER_STORE | (user_id, store_id) | UNIQUE | 동일 매장 중복 등록 방지 |
+| IDX_MEMBER_STORES_USER_ID | user_id | INDEX (FK) | |
+| IDX_MEMBER_STORES_STORE_ID | store_id | INDEX (FK) | |
+
+**FK**
+
+| 컬럼 | 참조 테이블 | 참조 컬럼 |
+|------|-------------|-----------|
+| user_id | users | id |
 | store_id | stores | id |
 
 ---
@@ -296,3 +327,4 @@ CANCELLED  CANCELLED
 | 날짜 | 내용 |
 |------|------|
 | 2026-04-19 | 최초 작성 |
+| 2026-04-25 | member_stores 테이블 추가 (#36) |


### PR DESCRIPTION
## Issue ID
close #36

## 작업 내용
- `docs/schema/ddl.sql`에 `member_stores` 테이블 정의 추가
  - 컬럼: `id`, `user_id`, `store_id`, `is_preferred`, `created_at`
  - FK: `user_id → users.id`, `store_id → stores.id`
  - UQ: `(user_id, store_id)` — 동일 매장 중복 등록 방지
  - INDEX: `IDX_MEMBER_STORES_USER_ID`, `IDX_MEMBER_STORES_STORE_ID`

## 참고사항
- 이슈 #39(MemberStore 엔티티)의 선행 조건