### PR TITLE
[FEAT] Store 엔티티·리포지토리 구현 및 StoreAdmin @ManyToOne 리팩터링 (#37)

### DIFF
--- a/src/main/java/com/gongu/server/domain/store/entity/Store.java
+++ b/src/main/java/com/gongu/server/domain/store/entity/Store.java
@@ -1,0 +1,61 @@
+package com.gongu.server.domain.store.entity;
+
+import com.gongu.server.global.common.SoftDeleteEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "stores")
+public class Store extends SoftDeleteEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String address;
+
+    @Column(nullable = false, length = 20)
+    private String phone;
+
+    @Column(nullable = false)
+    private boolean isActive;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Store(String name, String address, String phone, boolean isActive) {
+        this.name = name;
+        this.address = address;
+        this.phone = phone;
+        this.isActive = isActive;
+    }
+
+    public static Store create(String name, String address, String phone) {
+        return Store.builder()
+                .name(name)
+                .address(address)
+                .phone(phone)
+                .isActive(true)
+                .build();
+    }
+
+    public void deactivate() {
+        if (isDeleted()) {
+            return;
+        }
+        this.isActive = false;
+        softDelete();
+    }
+}

--- a/src/main/java/com/gongu/server/domain/store/entity/StoreAdmin.java
+++ b/src/main/java/com/gongu/server/domain/store/entity/StoreAdmin.java
@@ -3,9 +3,12 @@ package com.gongu.server.domain.store.entity;
 import com.gongu.server.global.common.SoftDeleteEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,8 +23,9 @@ public class StoreAdmin extends SoftDeleteEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "store_id", nullable = false)
-    private Long storeId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
 
     @Column(nullable = false, unique = true)
     private String email;
@@ -35,9 +39,9 @@ public class StoreAdmin extends SoftDeleteEntity {
     @Column(nullable = false)
     private boolean isActive;
 
-    public static StoreAdmin of(Long storeId, String email, String encodedPassword, String name) {
+    public static StoreAdmin of(Store store, String email, String encodedPassword, String name) {
         StoreAdmin storeAdmin = new StoreAdmin();
-        storeAdmin.storeId = storeId;
+        storeAdmin.store = store;
         storeAdmin.email = email;
         storeAdmin.password = encodedPassword;
         storeAdmin.name = name;

--- a/src/main/java/com/gongu/server/domain/store/entity/StoreAdmin.java
+++ b/src/main/java/com/gongu/server/domain/store/entity/StoreAdmin.java
@@ -23,7 +23,7 @@ public class StoreAdmin extends SoftDeleteEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
 

--- a/src/main/java/com/gongu/server/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/gongu/server/domain/store/repository/StoreRepository.java
@@ -1,0 +1,15 @@
+package com.gongu.server.domain.store.repository;
+
+import com.gongu.server.domain.store.entity.Store;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+
+    Optional<Store> findByIdAndDeletedAtIsNull(Long id);
+
+    Page<Store> findAllByIsActiveTrueAndDeletedAtIsNull(Pageable pageable);
+}


### PR DESCRIPTION
## Issue ID
close #37

## 작업 내용
- `domain/store/entity/Store.java` 신규 생성
  - `stores` 테이블 DDL 기준 필드 구성
  - `SoftDeleteEntity` 상속
  - 정적 팩토리 메서드 `Store.create(name, address, phone)`
  - `deactivate()` 도메인 메서드
- `domain/store/repository/StoreRepository.java` 신규 생성
  - `findByIdAndDeletedAtIsNull`, `findAllByIsActiveTrueAndDeletedAtIsNull` 제공
- `domain/store/entity/StoreAdmin.java` 수정
  - `Long storeId` → `@ManyToOne(LAZY) Store store`
  - `of()` 시그니처 변경: `Long storeId` → `Store store`

## 참고사항
- `./gradlew compileJava` 통과 확인