### PR TITLE
[FEAT] StoreErrorCode 구현 (#38)

### DIFF
--- a/src/main/java/com/gongu/server/global/exception/errorcode/StoreErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/StoreErrorCode.java
@@ -1,0 +1,30 @@
+package com.gongu.server.global.exception.errorcode;
+
+import com.gongu.server.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum StoreErrorCode implements ErrorCode {
+
+    STORE_NOT_FOUND("STORE_001", "존재하지 않는 매장입니다", 404),
+    MEMBER_STORE_DUPLICATE("STORE_002", "이미 등록된 매장입니다", 409);
+
+    private final String code;
+    private final String message;
+    private final int httpStatus;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+}


### PR DESCRIPTION
## Issue ID
close #38

## 작업 내용
- `global/exception/errorcode/StoreErrorCode.java` 신규 생성
  - `STORE_001` — `STORE_NOT_FOUND` (404, "존재하지 않는 매장입니다")
  - `STORE_002` — `MEMBER_STORE_DUPLICATE` (409, "이미 등록된 매장입니다")
  - `ErrorCode` 인터페이스 구현, `STORE_{3자리숫자}` 코드 형식 준수

## 참고사항
- `./gradlew compileJava` 통과 확인