### PR TITLE
[CHORE] 로컬 실행 환경 및 테스트 기반 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,13 @@
 services:
+  redis:
+    image: redis:7.4-alpine
+    container_name: gongu-redis
+    restart: unless-stopped
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    networks:
+      - gongu-net
+
   mysql:
     image: mysql:8.0
     container_name: gongu-mysql

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,17 @@
 spring:
+  datasource:
+    url: jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3307}/${MYSQL_DATABASE:gongu_db}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${MYSQL_USERNAME:root}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: true
   data:
     redis:
       host: ${REDIS_HOST:localhost}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,26 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+jwt:
+  secret: dGVzdC1zZWNyZXQta2V5LWZvci10ZXN0aW5nLW9ubHktMzJjaGFycw==
+  access-expiration: 3600000
+  refresh-expiration: 604800000
+
+cors:
+  allowed-origins: http://localhost:3000


### PR DESCRIPTION
## Issue ID
N/A (인프라 설정)

## 작업 내용
- `application.yml`: MySQL datasource + JPA 설정 추가 (`ddl-auto: validate`, `open-in-view: false`)
- `application-local.yml`: 로컬 전용 오버라이드 (`ddl-auto: update`, `show-sql: true`) — gitignored
- `src/test/resources/application.yml`: H2 인메모리 + `create-drop` 테스트 전용 설정
- `build.gradle`: `testRuntimeOnly 'com.h2database:h2'` 추가
- `docker-compose.yml`: Redis 7.4 서비스 추가

## 참고사항
- 로컬 실행: `export $(cat .env | xargs) && SPRING_PROFILES_ACTIVE=local ./gradlew bootRun`
- docker-compose로 MySQL + Redis를 함께 기동: `docker compose up -d`