### PR TITLE
[FEAT] MemberStore 엔티티 및 리포지토리 구현 (#39)

### DIFF
--- a/src/main/java/com/gongu/server/domain/store/entity/MemberStore.java
+++ b/src/main/java/com/gongu/server/domain/store/entity/MemberStore.java
@@ -1,0 +1,72 @@
+package com.gongu.server.domain.store.entity;
+
+import com.gongu.server.domain.user.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "member_stores",
+        uniqueConstraints = @UniqueConstraint(
+                name = "UQ_MEMBER_STORES_USER_STORE",
+                columnNames = {"user_id", "store_id"}
+        )
+)
+public class MemberStore {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @Column(name = "is_preferred", nullable = false)
+    private boolean isPreferred;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    private MemberStore(Member member, Store store, boolean isPreferred) {
+        this.member = member;
+        this.store = store;
+        this.isPreferred = isPreferred;
+    }
+
+    public static MemberStore create(Member member, Store store, boolean isPreferred) {
+        return new MemberStore(member, store, isPreferred);
+    }
+
+    public void markAsPreferred() {
+        this.isPreferred = true;
+    }
+
+    public void unmarkAsPreferred() {
+        this.isPreferred = false;
+    }
+}

--- a/src/main/java/com/gongu/server/domain/store/repository/MemberStoreRepository.java
+++ b/src/main/java/com/gongu/server/domain/store/repository/MemberStoreRepository.java
@@ -1,0 +1,21 @@
+package com.gongu.server.domain.store.repository;
+
+import com.gongu.server.domain.store.entity.MemberStore;
+import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.domain.user.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberStoreRepository extends JpaRepository<MemberStore, Long> {
+
+    boolean existsByMemberAndStore(Member member, Store store);
+
+    Optional<MemberStore> findByMemberAndStore(Member member, Store store);
+
+    Optional<MemberStore> findByMemberAndIsPreferredTrue(Member member);
+
+    Page<MemberStore> findAllByStore(Store store, Pageable pageable);
+}

--- a/src/test/java/com/gongu/server/domain/store/repository/MemberStoreRepositoryTest.java
+++ b/src/test/java/com/gongu/server/domain/store/repository/MemberStoreRepositoryTest.java
@@ -1,0 +1,121 @@
+package com.gongu.server.domain.store.repository;
+
+import com.gongu.server.domain.store.entity.MemberStore;
+import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.domain.user.entity.Member;
+import com.gongu.server.global.config.JpaConfig;
+import jakarta.persistence.PersistenceException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+class MemberStoreRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private MemberStoreRepository memberStoreRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    private Member member;
+    private Store store;
+
+    @BeforeEach
+    void setUp() {
+        member = em.persist(Member.of("테스터", "test@test.com", "010-0000-0000"));
+        store = em.persist(Store.create("테스트매장", "서울시", "02-1234-5678"));
+        em.flush();
+    }
+
+    @Test
+    void existsByMemberAndStore_등록된_경우_true_반환() {
+        // given
+        MemberStore memberStore = MemberStore.create(member, store, false);
+        em.persist(memberStore);
+        em.flush();
+        em.clear();
+
+        Member foundMember = em.find(Member.class, member.getId());
+        Store foundStore = em.find(Store.class, store.getId());
+
+        // when
+        boolean result = memberStoreRepository.existsByMemberAndStore(foundMember, foundStore);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void existsByMemberAndStore_미등록_경우_false_반환() {
+        // when
+        boolean result = memberStoreRepository.existsByMemberAndStore(member, store);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void findByMemberAndIsPreferredTrue_선호_매장_있을_때_반환() {
+        // given
+        MemberStore memberStore = MemberStore.create(member, store, true);
+        em.persist(memberStore);
+        em.flush();
+        em.clear();
+
+        Member foundMember = em.find(Member.class, member.getId());
+
+        // when
+        Optional<MemberStore> result = memberStoreRepository.findByMemberAndIsPreferredTrue(foundMember);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().isPreferred()).isTrue();
+        assertThat(result.get().getStore().getId()).isEqualTo(store.getId());
+    }
+
+    @Test
+    void findByMemberAndIsPreferredTrue_선호_매장_없을_때_empty_반환() {
+        // given
+        MemberStore memberStore = MemberStore.create(member, store, false);
+        em.persist(memberStore);
+        em.flush();
+        em.clear();
+
+        Member foundMember = em.find(Member.class, member.getId());
+
+        // when
+        Optional<MemberStore> result = memberStoreRepository.findByMemberAndIsPreferredTrue(foundMember);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void 동일_회원_동일_매장_중복_저장시_예외_발생() {
+        // given
+        MemberStore first = MemberStore.create(member, store, false);
+        em.persist(first);
+        em.flush();
+
+        MemberStore duplicate = MemberStore.create(member, store, false);
+
+        // when & then
+        assertThatThrownBy(() -> {
+            em.persist(duplicate);
+            em.flush();
+        }).isInstanceOf(PersistenceException.class);
+    }
+}


### PR DESCRIPTION
## Issue ID
close #39

## 작업 내용
- `MemberStore.java` 신규 생성
  - `member_stores` DDL 기준, BaseEntity 미상속 (`updated_at` 없음)
  - `@EntityListeners` + `@CreatedDate` 직접 선언
  - `UQ_MEMBER_STORES_USER_STORE` uniqueConstraint 명시
  - `create()` 팩토리, `markAsPreferred()` / `unmarkAsPreferred()` 도메인 메서드
- `MemberStoreRepository.java` 신규 생성
  - `existsByMemberAndStore`, `findByMemberAndStore`, `findByMemberAndIsPreferredTrue`, `findAllByStore`
- `MemberStoreRepositoryTest.java` — `@DataJpaTest` 테스트 5건 통과