### PR TITLE
[FEAT] 매장 조회 API 구현 (GET /stores, GET /stores/{store_id}) (#40)

### DIFF
--- a/src/main/java/com/gongu/server/domain/store/controller/StoreController.java
+++ b/src/main/java/com/gongu/server/domain/store/controller/StoreController.java
@@ -1,0 +1,35 @@
+package com.gongu.server.domain.store.controller;
+
+import com.gongu.server.domain.store.dto.response.StoreResponse;
+import com.gongu.server.domain.store.service.StoreService;
+import com.gongu.server.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/stores")
+@RequiredArgsConstructor
+public class StoreController {
+
+    private final StoreService storeService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<StoreResponse>>> getStores(
+            @PageableDefault(size = 20) Pageable pageable) {
+        Page<StoreResponse> stores = storeService.getStores(pageable);
+        return ResponseEntity.ok(ApiResponse.success(stores));
+    }
+
+    @GetMapping("/{storeId}")
+    public ResponseEntity<ApiResponse<StoreResponse>> getStore(@PathVariable Long storeId) {
+        StoreResponse store = storeService.getStore(storeId);
+        return ResponseEntity.ok(ApiResponse.success(store));
+    }
+}

--- a/src/main/java/com/gongu/server/domain/store/dto/response/StoreResponse.java
+++ b/src/main/java/com/gongu/server/domain/store/dto/response/StoreResponse.java
@@ -1,0 +1,15 @@
+package com.gongu.server.domain.store.dto.response;
+
+import com.gongu.server.domain.store.entity.Store;
+
+public record StoreResponse(Long id, String name, String address, String phone) {
+
+    public static StoreResponse from(Store store) {
+        return new StoreResponse(
+                store.getId(),
+                store.getName(),
+                store.getAddress(),
+                store.getPhone()
+        );
+    }
+}

--- a/src/main/java/com/gongu/server/domain/store/service/StoreService.java
+++ b/src/main/java/com/gongu/server/domain/store/service/StoreService.java
@@ -1,0 +1,30 @@
+package com.gongu.server.domain.store.service;
+
+import com.gongu.server.domain.store.dto.response.StoreResponse;
+import com.gongu.server.domain.store.repository.StoreRepository;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.StoreErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoreService {
+
+    private final StoreRepository storeRepository;
+
+    public Page<StoreResponse> getStores(Pageable pageable) {
+        return storeRepository.findAllByIsActiveTrueAndDeletedAtIsNull(pageable)
+                .map(StoreResponse::from);
+    }
+
+    public StoreResponse getStore(Long storeId) {
+        return storeRepository.findByIdAndDeletedAtIsNull(storeId)
+                .map(StoreResponse::from)
+                .orElseThrow(() -> new BusinessException(StoreErrorCode.STORE_NOT_FOUND));
+    }
+}

--- a/src/test/java/com/gongu/server/domain/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/gongu/server/domain/store/controller/StoreControllerTest.java
@@ -1,0 +1,88 @@
+package com.gongu.server.domain.store.controller;
+
+import com.gongu.server.domain.store.dto.response.StoreResponse;
+import com.gongu.server.domain.store.service.StoreService;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.StoreErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(StoreController.class)
+@AutoConfigureMockMvc(addFilters = false)   // Security 필터 제외 — HTTP 로직 단위 테스트
+class StoreControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private StoreService storeService;
+
+    @Test
+    @DisplayName("GET /stores — 200 + Page 구조 확인")
+    void getStores_200_Page구조확인() throws Exception {
+        // given
+        StoreResponse response1 = new StoreResponse(1L, "매장1", "서울시 강남구", "02-1234-5678");
+        StoreResponse response2 = new StoreResponse(2L, "매장2", "서울시 서초구", "02-9876-5432");
+        Page<StoreResponse> page = new PageImpl<>(
+                List.of(response1, response2),
+                PageRequest.of(0, 20),
+                2
+        );
+        given(storeService.getStores(any())).willReturn(page);
+
+        // when & then
+        mockMvc.perform(get("/stores"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.content.length()").value(2))
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andExpect(jsonPath("$.data.content[0].name").value("매장1"))
+                .andExpect(jsonPath("$.data.content[1].name").value("매장2"));
+    }
+
+    @Test
+    @DisplayName("GET /stores/{id} 존재 — 200 + StoreResponse 필드 확인")
+    void getStore_존재_200_필드확인() throws Exception {
+        // given
+        StoreResponse response = new StoreResponse(1L, "테스트매장", "서울시 마포구", "02-1111-2222");
+        given(storeService.getStore(1L)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/stores/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.name").value("테스트매장"))
+                .andExpect(jsonPath("$.data.address").value("서울시 마포구"))
+                .andExpect(jsonPath("$.data.phone").value("02-1111-2222"));
+    }
+
+    @Test
+    @DisplayName("GET /stores/{id} 없음 — 404 + code: STORE_001 확인")
+    void getStore_없음_404_STORE_001() throws Exception {
+        // given
+        given(storeService.getStore(999L)).willThrow(new BusinessException(StoreErrorCode.STORE_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/stores/999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("STORE_001"));
+    }
+}

--- a/src/test/java/com/gongu/server/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/store/service/StoreServiceTest.java
@@ -1,0 +1,101 @@
+package com.gongu.server.domain.store.service;
+
+import com.gongu.server.domain.store.dto.response.StoreResponse;
+import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.domain.store.repository.StoreRepository;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.StoreErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class StoreServiceTest {
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @InjectMocks
+    private StoreService storeService;
+
+    @Test
+    @DisplayName("getStores_활성_매장_목록_반환")
+    void getStores_활성_매장_목록_반환() {
+        // given
+        Store store1 = Store.create("매장1", "서울시 강남구", "02-1234-5678");
+        Store store2 = Store.create("매장2", "서울시 서초구", "02-9876-5432");
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Store> storePage = new PageImpl<>(List.of(store1, store2), pageable, 2);
+
+        given(storeRepository.findAllByIsActiveTrueAndDeletedAtIsNull(pageable)).willReturn(storePage);
+
+        // when
+        Page<StoreResponse> result = storeService.getStores(pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent()).extracting("name")
+                .containsExactly("매장1", "매장2");
+    }
+
+    @Test
+    @DisplayName("getStore_존재하는_매장_반환")
+    void getStore_존재하는_매장_반환() {
+        // given
+        Store store = Store.create("테스트매장", "서울시 마포구", "02-1111-2222");
+        given(storeRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(store));
+
+        // when
+        StoreResponse result = storeService.getStore(1L);
+
+        // then
+        assertThat(result.name()).isEqualTo("테스트매장");
+        assertThat(result.address()).isEqualTo("서울시 마포구");
+        assertThat(result.phone()).isEqualTo("02-1111-2222");
+    }
+
+    @Test
+    @DisplayName("getStore_삭제된_매장_STORE_NOT_FOUND_예외")
+    void getStore_삭제된_매장_STORE_NOT_FOUND_예외() {
+        // given
+        given(storeRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> storeService.getStore(1L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException businessException = (BusinessException) ex;
+                    assertThat(businessException.getErrorCode()).isEqualTo(StoreErrorCode.STORE_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("getStore_존재하지_않는_ID_STORE_NOT_FOUND_예외")
+    void getStore_존재하지_않는_ID_STORE_NOT_FOUND_예외() {
+        // given
+        given(storeRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> storeService.getStore(999L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException businessException = (BusinessException) ex;
+                    assertThat(businessException.getErrorCode().getCode())
+                            .isEqualTo(StoreErrorCode.STORE_NOT_FOUND.getCode());
+                });
+    }
+}


### PR DESCRIPTION
## Issue ID
close #40

## 작업 내용
- `StoreResponse.java` — `record` DTO, `from(Store)` 팩토리
- `StoreService.java` — `getStores(Pageable)`, `getStore(Long)` / 없으면 `STORE_NOT_FOUND`
- `StoreController.java` — `GET /stores` (페이지네이션), `GET /stores/{storeId}`

## 테스트
- `StoreServiceTest` — 4건 (Mockito 단위 테스트)
- `StoreControllerTest` — 3건 (`@WebMvcTest`, `@AutoConfigureMockMvc(addFilters = false)`)