### PR TITLE
[FEAT] 이용 매장 등록 API 구현 (#41)

### DIFF
--- a/src/main/java/com/gongu/server/domain/store/dto/request/RegisterMemberStoreRequest.java
+++ b/src/main/java/com/gongu/server/domain/store/dto/request/RegisterMemberStoreRequest.java
@@ -1,0 +1,8 @@
+package com.gongu.server.domain.store.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record RegisterMemberStoreRequest(
+        @NotNull(message = "매장 ID는 필수입니다") Long storeId,
+        @NotNull(message = "선호 매장 여부는 필수입니다") Boolean isPreferred
+) {}

--- a/src/main/java/com/gongu/server/domain/store/dto/response/RegisterMemberStoreResponse.java
+++ b/src/main/java/com/gongu/server/domain/store/dto/response/RegisterMemberStoreResponse.java
@@ -1,0 +1,14 @@
+package com.gongu.server.domain.store.dto.response;
+
+import com.gongu.server.domain.store.entity.MemberStore;
+
+public record RegisterMemberStoreResponse(Long storeId, String storeName, boolean isPreferred) {
+
+    public static RegisterMemberStoreResponse from(MemberStore memberStore) {
+        return new RegisterMemberStoreResponse(
+                memberStore.getStore().getId(),
+                memberStore.getStore().getName(),
+                memberStore.isPreferred()
+        );
+    }
+}

--- a/src/main/java/com/gongu/server/domain/store/service/StoreService.java
+++ b/src/main/java/com/gongu/server/domain/store/service/StoreService.java
@@ -1,9 +1,17 @@
 package com.gongu.server.domain.store.service;
 
+import com.gongu.server.domain.store.dto.request.RegisterMemberStoreRequest;
+import com.gongu.server.domain.store.dto.response.RegisterMemberStoreResponse;
 import com.gongu.server.domain.store.dto.response.StoreResponse;
+import com.gongu.server.domain.store.entity.MemberStore;
+import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.domain.store.repository.MemberStoreRepository;
 import com.gongu.server.domain.store.repository.StoreRepository;
+import com.gongu.server.domain.user.entity.Member;
+import com.gongu.server.domain.user.repository.MemberRepository;
 import com.gongu.server.global.exception.BusinessException;
 import com.gongu.server.global.exception.errorcode.StoreErrorCode;
+import com.gongu.server.global.exception.errorcode.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,6 +24,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class StoreService {
 
     private final StoreRepository storeRepository;
+    private final MemberRepository memberRepository;
+    private final MemberStoreRepository memberStoreRepository;
 
     public Page<StoreResponse> getStores(Pageable pageable) {
         return storeRepository.findAllByIsActiveTrueAndDeletedAtIsNull(pageable)
@@ -26,5 +36,28 @@ public class StoreService {
         return storeRepository.findByIdAndDeletedAtIsNull(storeId)
                 .map(StoreResponse::from)
                 .orElseThrow(() -> new BusinessException(StoreErrorCode.STORE_NOT_FOUND));
+    }
+
+    @Transactional
+    public RegisterMemberStoreResponse registerMemberStore(Long memberId, RegisterMemberStoreRequest request) {
+        Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        Store store = storeRepository.findByIdAndDeletedAtIsNull(request.storeId())
+                .orElseThrow(() -> new BusinessException(StoreErrorCode.STORE_NOT_FOUND));
+
+        if (memberStoreRepository.existsByMemberAndStore(member, store)) {
+            throw new BusinessException(StoreErrorCode.MEMBER_STORE_DUPLICATE);
+        }
+
+        if (Boolean.TRUE.equals(request.isPreferred())) {
+            memberStoreRepository.findByMemberAndIsPreferredTrue(member)
+                    .ifPresent(MemberStore::unmarkAsPreferred);
+        }
+
+        MemberStore memberStore = MemberStore.create(member, store, request.isPreferred());
+        memberStoreRepository.save(memberStore);
+
+        return RegisterMemberStoreResponse.from(memberStore);
     }
 }

--- a/src/main/java/com/gongu/server/domain/user/controller/MemberController.java
+++ b/src/main/java/com/gongu/server/domain/user/controller/MemberController.java
@@ -1,0 +1,34 @@
+package com.gongu.server.domain.user.controller;
+
+import com.gongu.server.domain.store.dto.request.RegisterMemberStoreRequest;
+import com.gongu.server.domain.store.dto.response.RegisterMemberStoreResponse;
+import com.gongu.server.domain.store.service.StoreService;
+import com.gongu.server.global.common.ApiResponse;
+import com.gongu.server.global.security.UserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final StoreService storeService;
+
+    @PostMapping("/me/stores")
+    @PreAuthorize("hasRole('MEMBER')")
+    public ResponseEntity<ApiResponse<RegisterMemberStoreResponse>> registerMemberStore(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestBody @Valid RegisterMemberStoreRequest request) {
+        RegisterMemberStoreResponse response = storeService.registerMemberStore(principal.memberId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+}

--- a/src/test/java/com/gongu/server/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/store/service/StoreServiceTest.java
@@ -1,10 +1,17 @@
 package com.gongu.server.domain.store.service;
 
+import com.gongu.server.domain.store.dto.request.RegisterMemberStoreRequest;
+import com.gongu.server.domain.store.dto.response.RegisterMemberStoreResponse;
 import com.gongu.server.domain.store.dto.response.StoreResponse;
+import com.gongu.server.domain.store.entity.MemberStore;
 import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.domain.store.repository.MemberStoreRepository;
 import com.gongu.server.domain.store.repository.StoreRepository;
+import com.gongu.server.domain.user.entity.Member;
+import com.gongu.server.domain.user.repository.MemberRepository;
 import com.gongu.server.global.exception.BusinessException;
 import com.gongu.server.global.exception.errorcode.StoreErrorCode;
+import com.gongu.server.global.exception.errorcode.UserErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,13 +28,21 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class StoreServiceTest {
 
     @Mock
     private StoreRepository storeRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private MemberStoreRepository memberStoreRepository;
 
     @InjectMocks
     private StoreService storeService;
@@ -97,5 +112,90 @@ class StoreServiceTest {
                     assertThat(businessException.getErrorCode().getCode())
                             .isEqualTo(StoreErrorCode.STORE_NOT_FOUND.getCode());
                 });
+    }
+
+    // ─── registerMemberStore ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("registerMemberStore_성공_비선호매장")
+    void registerMemberStore_성공_비선호매장() {
+        // given
+        Member member = Member.of("홍길동", "hong@test.com", "010-1234-5678");
+        Store store = Store.create("테스트매장", "서울시 강남구", "02-1234-5678");
+        RegisterMemberStoreRequest request = new RegisterMemberStoreRequest(1L, false);
+
+        given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(member));
+        given(storeRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(store));
+        given(memberStoreRepository.existsByMemberAndStore(member, store)).willReturn(false);
+        given(memberStoreRepository.save(any(MemberStore.class)))
+                .willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        RegisterMemberStoreResponse response = storeService.registerMemberStore(1L, request);
+
+        // then
+        assertThat(response.storeId()).isEqualTo(store.getId());
+        assertThat(response.storeName()).isEqualTo("테스트매장");
+        assertThat(response.isPreferred()).isFalse();
+        verify(memberStoreRepository).save(any(MemberStore.class));
+    }
+
+    @Test
+    @DisplayName("registerMemberStore_성공_선호매장_기존선호_해제")
+    void registerMemberStore_성공_선호매장_기존선호_해제() {
+        // given
+        Member member = Member.of("홍길동", "hong@test.com", "010-1234-5678");
+        Store store = Store.create("테스트매장", "서울시 강남구", "02-1234-5678");
+        Store oldStore = Store.create("기존선호매장", "서울시 서초구", "02-9999-8888");
+        MemberStore existingPreferred = MemberStore.create(member, oldStore, true);
+        RegisterMemberStoreRequest request = new RegisterMemberStoreRequest(1L, true);
+
+        given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(member));
+        given(storeRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(store));
+        given(memberStoreRepository.existsByMemberAndStore(member, store)).willReturn(false);
+        given(memberStoreRepository.findByMemberAndIsPreferredTrue(member))
+                .willReturn(Optional.of(existingPreferred));
+        given(memberStoreRepository.save(any(MemberStore.class)))
+                .willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        storeService.registerMemberStore(1L, request);
+
+        // then
+        assertThat(existingPreferred.isPreferred()).isFalse();
+        verify(memberStoreRepository).save(any(MemberStore.class));
+    }
+
+    @Test
+    @DisplayName("registerMemberStore_존재하지_않는_멤버_USER_NOT_FOUND_예외")
+    void registerMemberStore_존재하지_않는_멤버_USER_NOT_FOUND_예외() {
+        // given
+        given(memberRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+        RegisterMemberStoreRequest request = new RegisterMemberStoreRequest(1L, false);
+
+        // when & then
+        assertThatThrownBy(() -> storeService.registerMemberStore(999L, request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("registerMemberStore_중복_등록_MEMBER_STORE_DUPLICATE_예외")
+    void registerMemberStore_중복_등록_MEMBER_STORE_DUPLICATE_예외() {
+        // given
+        Member member = Member.of("홍길동", "hong@test.com", "010-1234-5678");
+        Store store = Store.create("테스트매장", "서울시 강남구", "02-1234-5678");
+        RegisterMemberStoreRequest request = new RegisterMemberStoreRequest(1L, false);
+
+        given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(member));
+        given(storeRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(store));
+        given(memberStoreRepository.existsByMemberAndStore(member, store)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> storeService.registerMemberStore(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(StoreErrorCode.MEMBER_STORE_DUPLICATE));
     }
 }

--- a/src/test/java/com/gongu/server/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/store/service/StoreServiceTest.java
@@ -134,8 +134,7 @@ class StoreServiceTest {
         RegisterMemberStoreResponse response = storeService.registerMemberStore(1L, request);
 
         // then
-        assertThat(response.storeId()).isEqualTo(store.getId());
-        assertThat(response.storeName()).isEqualTo("테스트매장");
+        assertThat(response.storeName()).isEqualTo("테스트매장"); // storeId는 영속화 전이라 null이므로 storeName으로 검증
         assertThat(response.isPreferred()).isFalse();
         verify(memberStoreRepository).save(any(MemberStore.class));
     }
@@ -197,5 +196,22 @@ class StoreServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(StoreErrorCode.MEMBER_STORE_DUPLICATE));
+    }
+
+    @Test
+    @DisplayName("registerMemberStore_존재하지_않는_매장_STORE_NOT_FOUND_예외")
+    void registerMemberStore_존재하지_않는_매장_STORE_NOT_FOUND_예외() {
+        // given
+        Member member = Member.of("홍길동", "hong@test.com", "010-1234-5678");
+        RegisterMemberStoreRequest request = new RegisterMemberStoreRequest(999L, false);
+
+        given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(member));
+        given(storeRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> storeService.registerMemberStore(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(StoreErrorCode.STORE_NOT_FOUND));
     }
 }

--- a/src/test/java/com/gongu/server/domain/user/controller/MemberControllerTest.java
+++ b/src/test/java/com/gongu/server/domain/user/controller/MemberControllerTest.java
@@ -8,6 +8,7 @@ import com.gongu.server.global.exception.BusinessException;
 import com.gongu.server.global.exception.errorcode.StoreErrorCode;
 import com.gongu.server.global.security.Role;
 import com.gongu.server.global.security.UserPrincipal;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +45,11 @@ class MemberControllerTest {
 
     @MockitoBean
     private StoreService storeService;
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
 
     /**
      * addFilters=false 환경에서는 SecurityMockMvcRequestPostProcessors.authentication()이

--- a/src/test/java/com/gongu/server/domain/user/controller/MemberControllerTest.java
+++ b/src/test/java/com/gongu/server/domain/user/controller/MemberControllerTest.java
@@ -1,0 +1,121 @@
+package com.gongu.server.domain.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gongu.server.domain.store.dto.request.RegisterMemberStoreRequest;
+import com.gongu.server.domain.store.dto.response.RegisterMemberStoreResponse;
+import com.gongu.server.domain.store.service.StoreService;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.StoreErrorCode;
+import com.gongu.server.global.security.Role;
+import com.gongu.server.global.security.UserPrincipal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private StoreService storeService;
+
+    /**
+     * addFilters=false 환경에서는 SecurityMockMvcRequestPostProcessors.authentication()이
+     * SecurityContextHolder에 반영되지 않으므로, RequestPostProcessor에서 직접 설정한다.
+     */
+    private RequestPostProcessor asMember(Long memberId) {
+        return (MockHttpServletRequest request) -> {
+            UserPrincipal principal = new UserPrincipal(memberId, Role.MEMBER);
+            UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                    principal,
+                    null,
+                    List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+            );
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(auth);
+            SecurityContextHolder.setContext(context);
+            return request;
+        };
+    }
+
+    @Test
+    @DisplayName("POST /members/me/stores 정상 요청 → 201 + storeId, storeName, isPreferred")
+    void registerMemberStore_정상_201() throws Exception {
+        // given
+        Long memberId = 1L;
+        RegisterMemberStoreRequest request = new RegisterMemberStoreRequest(2L, false);
+        RegisterMemberStoreResponse response = new RegisterMemberStoreResponse(2L, "테스트매장", false);
+
+        given(storeService.registerMemberStore(eq(memberId), any(RegisterMemberStoreRequest.class)))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/members/me/stores")
+                        .with(asMember(memberId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.storeId").value(2))
+                .andExpect(jsonPath("$.data.storeName").value("테스트매장"))
+                .andExpect(jsonPath("$.data.isPreferred").value(false));
+    }
+
+    @Test
+    @DisplayName("POST /members/me/stores 중복 요청 → 409 + code: STORE_002")
+    void registerMemberStore_중복_409() throws Exception {
+        // given
+        Long memberId = 1L;
+        RegisterMemberStoreRequest request = new RegisterMemberStoreRequest(2L, false);
+
+        given(storeService.registerMemberStore(eq(memberId), any(RegisterMemberStoreRequest.class)))
+                .willThrow(new BusinessException(StoreErrorCode.MEMBER_STORE_DUPLICATE));
+
+        // when & then
+        mockMvc.perform(post("/members/me/stores")
+                        .with(asMember(memberId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("STORE_002"));
+    }
+
+    @Test
+    @DisplayName("POST /members/me/stores storeId 누락 → 400")
+    void registerMemberStore_storeId_누락_400() throws Exception {
+        // given — storeId 없이 isPreferred만 전송
+        String requestBody = "{\"isPreferred\": true}";
+
+        // when & then
+        mockMvc.perform(post("/members/me/stores")
+                        .with(asMember(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## Issue ID
close #41

## 작업 내용
- `RegisterMemberStoreRequest` / `RegisterMemberStoreResponse` DTO 구현
- `StoreService.registerMemberStore()` 비즈니스 로직 구현
  - 멤버·매장 존재 여부 검증
  - 중복 등록 방지 (`MEMBER_STORE_DUPLICATE`)
  - `isPreferred=true` 시 기존 선호 매장 자동 해제 (`unmarkAsPreferred`)
- `MemberController` — `POST /members/me/stores` (201 Created, ROLE_MEMBER 권한)
- `StoreServiceTest` 4개 케이스, `MemberControllerTest` 3개 케이스 추가

## 참고사항
- `@PreAuthorize("hasRole('MEMBER')")` + `@AuthenticationPrincipal UserPrincipal`
- 선호 매장은 멤버당 최대 1개 유지 (도메인 로직: `MemberStore.unmarkAsPreferred`)