### PR TITLE
[REFACTOR] UserPrincipal.memberId → id 필드명 변경 (#53)

### DIFF
--- a/src/main/java/com/gongu/server/domain/store/controller/StoreAdminController.java
+++ b/src/main/java/com/gongu/server/domain/store/controller/StoreAdminController.java
@@ -29,7 +29,7 @@ public class StoreAdminController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @RequestParam(required = false) String name,
             @PageableDefault(size = 20) Pageable pageable) {
-        Page<AdminMemberResponse> result = storeAdminService.getMembers(userPrincipal.memberId(), name, pageable);
+        Page<AdminMemberResponse> result = storeAdminService.getMembers(userPrincipal.id(), name, pageable);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/gongu/server/domain/user/controller/MemberController.java
+++ b/src/main/java/com/gongu/server/domain/user/controller/MemberController.java
@@ -28,7 +28,7 @@ public class MemberController {
     public ResponseEntity<ApiResponse<RegisterMemberStoreResponse>> registerMemberStore(
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody @Valid RegisterMemberStoreRequest request) {
-        RegisterMemberStoreResponse response = storeService.registerMemberStore(principal.memberId(), request);
+        RegisterMemberStoreResponse response = storeService.registerMemberStore(principal.id(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/gongu/server/global/security/UserPrincipal.java
+++ b/src/main/java/com/gongu/server/global/security/UserPrincipal.java
@@ -4,5 +4,5 @@ package com.gongu.server.global.security;
  * Authentication의 principal로 사용되는 단순 DTO.
  * Spring Security UserDetails를 구현하지 않는다.
  */
-public record UserPrincipal(Long memberId, Role role) {
+public record UserPrincipal(Long id, Role role) {
 }


### PR DESCRIPTION
## Issue
close #53

## 작업 내용
`UserPrincipal.memberId` 필드명이 Member 전용처럼 보이지만 실제로는 StoreAdmin ID도 담는 범용 인증 주체 ID 필드. `id`로 변경하여 혼란 해소.

## 변경 파일
- `UserPrincipal.java`: `memberId` → `id`
- `MemberController.java`: `principal.memberId()` → `principal.id()`
- `StoreAdminController.java`: `userPrincipal.memberId()` → `userPrincipal.id()`

## 참고
- `JwtAuthenticationFilter`, `JwtProvider`, `AuthService`는 위치 기반 생성자 또는 다른 record(`RefreshTokenClaims`)를 사용하므로 변경 불필요