### PR TITLE
[TEST] 컨트롤러 테스트에 @PreAuthorize 권한 검증 추가 (#51)

### DIFF
--- a/src/main/java/com/gongu/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gongu/server/global/exception/GlobalExceptionHandler.java
@@ -86,6 +86,22 @@ public class GlobalExceptionHandler {
                 .body(ErrorResponse.of(errorCode, fieldErrors));
     }
 
+    @ExceptionHandler(org.springframework.security.core.AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthenticationException(org.springframework.security.core.AuthenticationException e) {
+        ErrorCode errorCode = CommonErrorCode.UNAUTHORIZED;
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+
+    @ExceptionHandler(org.springframework.security.access.AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDeniedException(org.springframework.security.access.AccessDeniedException e) {
+        ErrorCode errorCode = CommonErrorCode.FORBIDDEN;
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         log.error("Unhandled exception occurred", e);

--- a/src/main/java/com/gongu/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gongu/server/global/exception/GlobalExceptionHandler.java
@@ -24,6 +24,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(InfraException.class)
     public ResponseEntity<ErrorResponse> handleInfraException(InfraException e) {
+        log.error("External system failure: {}", e.getMessage(), e);
         return handleGonguException(e);
     }
 

--- a/src/test/java/com/gongu/server/domain/store/controller/StoreAdminControllerTest.java
+++ b/src/test/java/com/gongu/server/domain/store/controller/StoreAdminControllerTest.java
@@ -124,7 +124,7 @@ class StoreAdminControllerTest {
     }
 
     @Test
-    @DisplayName("GET /admin/members STORE_ADMIN_NOT_FOUND_404")
+    @DisplayName("GET /admin/members 존재하지 않는 매장 관리자 → 404")
     void getMembers_STORE_ADMIN_NOT_FOUND_404() throws Exception {
         // given
         Long storeAdminId = 999L;

--- a/src/test/java/com/gongu/server/domain/store/controller/StoreAdminControllerTest.java
+++ b/src/test/java/com/gongu/server/domain/store/controller/StoreAdminControllerTest.java
@@ -72,6 +72,21 @@ class StoreAdminControllerTest {
         };
     }
 
+    private RequestPostProcessor asMember(Long memberId) {
+        return (MockHttpServletRequest request) -> {
+            UserPrincipal principal = new UserPrincipal(memberId, Role.MEMBER);
+            UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                    principal,
+                    null,
+                    List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+            );
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(auth);
+            SecurityContextHolder.setContext(context);
+            return request;
+        };
+    }
+
     @Test
     @DisplayName("GET /admin/members 정상_200")
     void getMembers_정상_200() throws Exception {
@@ -144,5 +159,13 @@ class StoreAdminControllerTest {
     void getMembers_인증없음_401() throws Exception {
         mockMvc.perform(get("/admin/members"))
                 .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("GET /admin/members ROLE_STORE_ADMIN 없는 요청 → 403")
+    void getMembers_권한없음_403() throws Exception {
+        mockMvc.perform(get("/admin/members")
+                        .with(asMember(1L)))
+                .andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/com/gongu/server/domain/store/controller/StoreAdminControllerTest.java
+++ b/src/test/java/com/gongu/server/domain/store/controller/StoreAdminControllerTest.java
@@ -12,11 +12,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -38,6 +40,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(StoreAdminController.class)
 @AutoConfigureMockMvc(addFilters = false)
 class StoreAdminControllerTest {
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class SecurityConfig {}
+
 
     @Autowired
     private MockMvc mockMvc;
@@ -130,5 +137,12 @@ class StoreAdminControllerTest {
                         .with(asStoreAdmin(storeAdminId)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("STORE_003"));
+    }
+
+    @Test
+    @DisplayName("GET /admin/members 인증 없는 요청 → 401")
+    void getMembers_인증없음_401() throws Exception {
+        mockMvc.perform(get("/admin/members"))
+                .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/com/gongu/server/domain/user/controller/MemberControllerTest.java
+++ b/src/test/java/com/gongu/server/domain/user/controller/MemberControllerTest.java
@@ -77,6 +77,21 @@ class MemberControllerTest {
         };
     }
 
+    private RequestPostProcessor asStoreAdmin(Long storeAdminId) {
+        return (MockHttpServletRequest request) -> {
+            UserPrincipal principal = new UserPrincipal(storeAdminId, Role.STORE_ADMIN);
+            UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                    principal,
+                    null,
+                    List.of(new SimpleGrantedAuthority("ROLE_STORE_ADMIN"))
+            );
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(auth);
+            SecurityContextHolder.setContext(context);
+            return request;
+        };
+    }
+
     @Test
     @DisplayName("POST /members/me/stores 정상 요청 → 201 + storeId, storeName, isPreferred")
     void registerMemberStore_정상_201() throws Exception {
@@ -141,5 +156,17 @@ class MemberControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("POST /members/me/stores ROLE_MEMBER 없는 요청 → 403")
+    void registerMemberStore_권한없음_403() throws Exception {
+        String requestBody = "{\"storeId\": 1, \"isPreferred\": false}";
+
+        mockMvc.perform(post("/members/me/stores")
+                        .with(asStoreAdmin(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/com/gongu/server/domain/user/controller/MemberControllerTest.java
+++ b/src/test/java/com/gongu/server/domain/user/controller/MemberControllerTest.java
@@ -14,9 +14,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -36,6 +38,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(MemberController.class)
 @AutoConfigureMockMvc(addFilters = false)
 class MemberControllerTest {
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class SecurityConfig {}
+
 
     @Autowired
     private MockMvc mockMvc;
@@ -123,5 +130,16 @@ class MemberControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /members/me/stores 인증 없는 요청 → 401")
+    void registerMemberStore_인증없음_401() throws Exception {
+        String requestBody = "{\"storeId\": 1, \"isPreferred\": false}";
+
+        mockMvc.perform(post("/members/me/stores")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isUnauthorized());
     }
 }


### PR DESCRIPTION
## Issue
close #51

## 작업 내용

### GlobalExceptionHandler 예외 핸들러 추가
- `AuthenticationException` → 401 (인증 정보 없음, e.g. `AuthenticationCredentialsNotFoundException`)
- `AccessDeniedException` → 403 (인증됐으나 권한 부족)

### 컨트롤러 테스트 개선
- `@TestConfiguration @EnableMethodSecurity` 정적 내부 클래스로 메서드 시큐리티 활성화
  - `@Import` 방식은 `@WebMvcTest` 슬라이스에서 AOP 프록시 등록 순서 문제가 있어 정적 내부 클래스 방식 채택
- `MemberControllerTest`: 인증 없는 요청 → 401 테스트 추가
- `StoreAdminControllerTest`: 인증 없는 요청 → 401 테스트 추가
- 미사용 `MethodSecurityTestConfig.java` 삭제

## 참고
- Spring Security: 인증 정보 없음 → `AuthenticationCredentialsNotFoundException` (401), 권한 부족 → `AccessDeniedException` (403)
- `addFilters = false`는 Servlet Filter만 비활성화하므로 AOP 기반 메서드 시큐리티와 공존 가능