### PR TITLE
[FIX] StoreAdmin 조회 JOIN FETCH 추가 및 미사용 findAllByStore 제거 (#53)

### DIFF
--- a/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
@@ -67,7 +67,7 @@ public class AuthService {
     }
 
     public TokenResponse storeAdminLogin(StoreAdminLoginRequest request) {
-        Optional<StoreAdmin> adminOpt = storeAdminRepository.findByEmailAndIsActiveTrue(request.email());
+        Optional<StoreAdmin> adminOpt = storeAdminRepository.findByEmailAndIsActiveTrueAndDeletedAtIsNull(request.email());
         String hashToCheck = adminOpt.map(StoreAdmin::getPassword).orElse(DUMMY_HASH);
         boolean passwordMatches = passwordEncoder.matches(request.password(), hashToCheck);
 

--- a/src/main/java/com/gongu/server/domain/store/repository/MemberStoreRepository.java
+++ b/src/main/java/com/gongu/server/domain/store/repository/MemberStoreRepository.java
@@ -19,8 +19,6 @@ public interface MemberStoreRepository extends JpaRepository<MemberStore, Long> 
 
     Optional<MemberStore> findByMemberAndIsPreferredTrue(Member member);
 
-    Page<MemberStore> findAllByStore(Store store, Pageable pageable);
-
     @Query(value = """
             SELECT ms FROM MemberStore ms
             JOIN FETCH ms.member m

--- a/src/main/java/com/gongu/server/domain/store/repository/StoreAdminRepository.java
+++ b/src/main/java/com/gongu/server/domain/store/repository/StoreAdminRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface StoreAdminRepository extends JpaRepository<StoreAdmin, Long> {
 
-    Optional<StoreAdmin> findByEmailAndIsActiveTrue(String email);
+    Optional<StoreAdmin> findByEmailAndIsActiveTrueAndDeletedAtIsNull(String email);
 
     @Query("SELECT sa FROM StoreAdmin sa JOIN FETCH sa.store WHERE sa.id = :id AND sa.deletedAt IS NULL")
     Optional<StoreAdmin> findByIdAndDeletedAtIsNull(@Param("id") Long id);

--- a/src/main/java/com/gongu/server/domain/store/repository/StoreAdminRepository.java
+++ b/src/main/java/com/gongu/server/domain/store/repository/StoreAdminRepository.java
@@ -2,6 +2,8 @@ package com.gongu.server.domain.store.repository;
 
 import com.gongu.server.domain.store.entity.StoreAdmin;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -9,5 +11,6 @@ public interface StoreAdminRepository extends JpaRepository<StoreAdmin, Long> {
 
     Optional<StoreAdmin> findByEmailAndIsActiveTrue(String email);
 
-    Optional<StoreAdmin> findByIdAndDeletedAtIsNull(Long id);
+    @Query("SELECT sa FROM StoreAdmin sa JOIN FETCH sa.store WHERE sa.id = :id AND sa.deletedAt IS NULL")
+    Optional<StoreAdmin> findByIdAndDeletedAtIsNull(@Param("id") Long id);
 }


### PR DESCRIPTION
## Issue
ref #53

## 배경
PR #54 머지 이후 Codex 리뷰에서 발견된 이슈를 수정한 커밋이 머지에 포함되지 않아 별도 PR로 분리.

## 작업 내용

### StoreAdminRepository
- `findByIdAndDeletedAtIsNull`에 `JOIN FETCH sa.store` 추가
- `StoreAdminService.getMembers()` 호출 시 3쿼리(StoreAdmin → Store Lazy 로딩 → MemberStore 페이지) → 2쿼리로 감소

### MemberStoreRepository
- `findAllByStore(Store, Pageable)` 제거
- `findAllByStoreWithMember`로 이미 대체됨. 방치 시 N+1 발생 위험

## 참고
PR #54 Codex 리뷰 Minor 지적 수용 건