### PR TITLE
[FEAT] Product 엔티티 및 ProductRepository 구현 (#58)

### DIFF
--- a/src/main/java/com/gongu/server/domain/product/domain/Product.java
+++ b/src/main/java/com/gongu/server/domain/product/domain/Product.java
@@ -64,9 +64,18 @@ public class Product extends BaseEntity {
     @Version
     private Long version;
 
-    public static Product of(Store store, String name, String description, Long price,
-                             int totalStock, ProductStatus status,
-                             LocalDateTime startAt, LocalDateTime endAt) {
+    public static Product create(Store store, String name, String description, Long price,
+                                int totalStock, ProductStatus status,
+                                LocalDateTime startAt, LocalDateTime endAt) {
+        if (price <= 0) {
+            throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_DATA);
+        }
+        if (totalStock <= 0) {
+            throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_DATA);
+        }
+        if (startAt.isAfter(endAt)) {
+            throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_DATA);
+        }
         Product product = new Product();
         product.store = store;
         product.name = name;

--- a/src/main/java/com/gongu/server/domain/product/domain/Product.java
+++ b/src/main/java/com/gongu/server/domain/product/domain/Product.java
@@ -1,0 +1,89 @@
+package com.gongu.server.domain.product.domain;
+
+import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.global.common.BaseEntity;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.ProductErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "products")
+public class Product extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private Long price;
+
+    @Column(name = "total_stock", nullable = false)
+    private int totalStock;
+
+    @Column(name = "remaining_stock", nullable = false)
+    private int remainingStock;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ProductStatus status;
+
+    @Column(name = "start_at", nullable = false)
+    private LocalDateTime startAt;
+
+    @Column(name = "end_at", nullable = false)
+    private LocalDateTime endAt;
+
+    @Version
+    private Long version;
+
+    public static Product of(Store store, String name, String description, Long price,
+                             int totalStock, ProductStatus status,
+                             LocalDateTime startAt, LocalDateTime endAt) {
+        Product product = new Product();
+        product.store = store;
+        product.name = name;
+        product.description = description;
+        product.price = price;
+        product.totalStock = totalStock;
+        product.remainingStock = totalStock;
+        product.status = status;
+        product.startAt = startAt;
+        product.endAt = endAt;
+        return product;
+    }
+
+    public void decreaseStock(int quantity) {
+        if (this.remainingStock < quantity) {
+            throw new BusinessException(ProductErrorCode.INSUFFICIENT_STOCK);
+        }
+        this.remainingStock -= quantity;
+    }
+}

--- a/src/main/java/com/gongu/server/domain/product/domain/ProductStatus.java
+++ b/src/main/java/com/gongu/server/domain/product/domain/ProductStatus.java
@@ -1,0 +1,8 @@
+package com.gongu.server.domain.product.domain;
+
+public enum ProductStatus {
+
+    ON_SALE,
+    ENDED,
+    CANCELLED
+}

--- a/src/main/java/com/gongu/server/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/gongu/server/domain/product/repository/ProductRepository.java
@@ -1,0 +1,18 @@
+package com.gongu.server.domain.product.repository;
+
+import com.gongu.server.domain.product.domain.Product;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    // ADR-005: 비관적 락으로 상품 조회
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Product p WHERE p.id = :id")
+    Optional<Product> findByIdWithLock(@Param("id") Long id);
+}

--- a/src/main/java/com/gongu/server/global/exception/errorcode/ProductErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/ProductErrorCode.java
@@ -8,7 +8,8 @@ public enum ProductErrorCode implements ErrorCode {
 
     PRODUCT_NOT_FOUND("PRODUCT_001", "존재하지 않는 상품입니다", 404),
     INSUFFICIENT_STOCK("PRODUCT_002", "재고가 부족합니다", 409),
-    INVALID_PRODUCT_STATUS("PRODUCT_003", "판매 중이지 않은 상품입니다", 400);
+    INVALID_PRODUCT_STATUS("PRODUCT_003", "판매 중이지 않은 상품입니다", 400),
+    INVALID_PRODUCT_DATA("PRODUCT_004", "유효하지 않은 상품 데이터입니다", 400);
 
     private final String code;
     private final String message;


### PR DESCRIPTION
## Issue ID
close #58

## 작업 내용
- `ProductStatus` enum 구현 (`ON_SALE` / `ENDED` / `CANCELLED`)
- `Product` 엔티티 구현
  - `docs/schema/ddl.sql` 기준 컬럼 전체 매핑
  - `BaseEntity` 상속 (DDL에 `deleted_at` 없음)
  - `@Version` — ADR-005 보조 안전망
  - `Product.of(...)` 정적 팩토리 메서드 (ADR-002)
  - `decreaseStock(int quantity)` 도메인 메서드 — 재고 부족 시 `INSUFFICIENT_STOCK` 예외
- `ProductRepository` 구현
  - `findByIdWithLock` — `@Lock(PESSIMISTIC_WRITE)` + JPQL (ADR-005)

## 참고사항
- ADR-002: Rich Domain Model — setter 없음, 도메인 메서드로 상태 변경
- ADR-005: 비관적 락(`SELECT FOR UPDATE`) 채택 — `findByIdWithLock`으로 구현