### PR TITLE
[FEAT] 상품 목록·상세 조회 API 구현 (#59)

### DIFF
--- a/src/main/java/com/gongu/server/domain/product/controller/AdminProductController.java
+++ b/src/main/java/com/gongu/server/domain/product/controller/AdminProductController.java
@@ -1,0 +1,44 @@
+package com.gongu.server.domain.product.controller;
+
+import com.gongu.server.domain.product.dto.ProductDetailResponse;
+import com.gongu.server.domain.product.dto.ProductSummaryResponse;
+import com.gongu.server.domain.product.service.ProductService;
+import com.gongu.server.global.common.ApiResponse;
+import com.gongu.server.global.security.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/products")
+@RequiredArgsConstructor
+public class AdminProductController {
+
+    private final ProductService productService;
+
+    @GetMapping
+    @PreAuthorize("hasRole('STORE_ADMIN')")
+    public ResponseEntity<ApiResponse<Page<ProductSummaryResponse>>> getAdminProducts(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PageableDefault(size = 20) Pageable pageable) {
+        Page<ProductSummaryResponse> result = productService.getAdminProducts(userPrincipal.id(), pageable);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasRole('STORE_ADMIN')")
+    public ResponseEntity<ApiResponse<ProductDetailResponse>> getAdminProduct(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long id) {
+        ProductDetailResponse result = productService.getAdminProduct(userPrincipal.id(), id);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/com/gongu/server/domain/product/controller/MemberProductController.java
+++ b/src/main/java/com/gongu/server/domain/product/controller/MemberProductController.java
@@ -1,0 +1,46 @@
+package com.gongu.server.domain.product.controller;
+
+import com.gongu.server.domain.product.dto.ProductDetailResponse;
+import com.gongu.server.domain.product.dto.ProductSummaryResponse;
+import com.gongu.server.domain.product.service.ProductService;
+import com.gongu.server.global.common.ApiResponse;
+import com.gongu.server.global.security.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/products")
+@RequiredArgsConstructor
+public class MemberProductController {
+
+    private final ProductService productService;
+
+    @GetMapping
+    @PreAuthorize("hasRole('MEMBER')")
+    public ResponseEntity<ApiResponse<Page<ProductSummaryResponse>>> getProducts(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam(required = false) Long storeId,
+            @PageableDefault(size = 20) Pageable pageable) {
+        Page<ProductSummaryResponse> result = productService.getProducts(userPrincipal.id(), storeId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasRole('MEMBER')")
+    public ResponseEntity<ApiResponse<ProductDetailResponse>> getProduct(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long id) {
+        ProductDetailResponse result = productService.getProduct(userPrincipal.id(), id);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/com/gongu/server/domain/product/domain/ProductStatus.java
+++ b/src/main/java/com/gongu/server/domain/product/domain/ProductStatus.java
@@ -2,7 +2,8 @@ package com.gongu.server.domain.product.domain;
 
 public enum ProductStatus {
 
-    ON_SALE,
-    ENDED,
-    CANCELLED
+    UPCOMING,
+    ACTIVE,
+    SOLD_OUT,
+    CLOSED
 }

--- a/src/main/java/com/gongu/server/domain/product/dto/ProductDetailResponse.java
+++ b/src/main/java/com/gongu/server/domain/product/dto/ProductDetailResponse.java
@@ -1,0 +1,32 @@
+package com.gongu.server.domain.product.dto;
+
+import com.gongu.server.domain.product.domain.Product;
+import com.gongu.server.domain.product.domain.ProductStatus;
+
+import java.time.LocalDateTime;
+
+public record ProductDetailResponse(
+        Long id,
+        String name,
+        String description,
+        Long price,
+        int totalStock,
+        int remainingStock,
+        ProductStatus status,
+        LocalDateTime startAt,
+        LocalDateTime endAt
+) {
+    public static ProductDetailResponse from(Product product) {
+        return new ProductDetailResponse(
+                product.getId(),
+                product.getName(),
+                product.getDescription(),
+                product.getPrice(),
+                product.getTotalStock(),
+                product.getRemainingStock(),
+                product.getStatus(),
+                product.getStartAt(),
+                product.getEndAt()
+        );
+    }
+}

--- a/src/main/java/com/gongu/server/domain/product/dto/ProductSummaryResponse.java
+++ b/src/main/java/com/gongu/server/domain/product/dto/ProductSummaryResponse.java
@@ -1,0 +1,28 @@
+package com.gongu.server.domain.product.dto;
+
+import com.gongu.server.domain.product.domain.Product;
+import com.gongu.server.domain.product.domain.ProductStatus;
+
+import java.time.LocalDateTime;
+
+public record ProductSummaryResponse(
+        Long id,
+        String name,
+        Long price,
+        int remainingStock,
+        ProductStatus status,
+        LocalDateTime startAt,
+        LocalDateTime endAt
+) {
+    public static ProductSummaryResponse from(Product product) {
+        return new ProductSummaryResponse(
+                product.getId(),
+                product.getName(),
+                product.getPrice(),
+                product.getRemainingStock(),
+                product.getStatus(),
+                product.getStartAt(),
+                product.getEndAt()
+        );
+    }
+}

--- a/src/main/java/com/gongu/server/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/gongu/server/domain/product/repository/ProductRepository.java
@@ -1,12 +1,17 @@
 package com.gongu.server.domain.product.repository;
 
 import com.gongu.server.domain.product.domain.Product;
+import com.gongu.server.domain.product.domain.ProductStatus;
+import com.gongu.server.domain.store.entity.Store;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
@@ -15,4 +20,23 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM Product p WHERE p.id = :id")
     Optional<Product> findByIdWithLock(@Param("id") Long id);
+
+    // 관리자: 자신의 매장 상품 목록 (페이지네이션)
+    @Query(value = "SELECT p FROM Product p WHERE p.store = :store",
+           countQuery = "SELECT COUNT(p) FROM Product p WHERE p.store = :store")
+    Page<Product> findAllByStore(@Param("store") Store store, Pageable pageable);
+
+    // 회원: 가입한 매장들의 상품 목록 (storeId 필터 있을 때)
+    @Query(value = "SELECT p FROM Product p WHERE p.store = :store AND p.status = :status",
+           countQuery = "SELECT COUNT(p) FROM Product p WHERE p.store = :store AND p.status = :status")
+    Page<Product> findAllByStoreAndStatus(@Param("store") Store store,
+                                          @Param("status") ProductStatus status,
+                                          Pageable pageable);
+
+    // 회원: 가입한 여러 매장들의 활성 상품 목록
+    @Query(value = "SELECT p FROM Product p WHERE p.store IN :stores AND p.status = :status",
+           countQuery = "SELECT COUNT(p) FROM Product p WHERE p.store IN :stores AND p.status = :status")
+    Page<Product> findAllByStoreInAndStatus(@Param("stores") List<Store> stores,
+                                            @Param("status") ProductStatus status,
+                                            Pageable pageable);
 }

--- a/src/main/java/com/gongu/server/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/gongu/server/domain/product/repository/ProductRepository.java
@@ -39,4 +39,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     Page<Product> findAllByStoreInAndStatus(@Param("stores") List<Store> stores,
                                             @Param("status") ProductStatus status,
                                             Pageable pageable);
+
+    // 관리자: 매장 소속 상품 단건 조회 (소속 매장 검증 포함, 추가 Store 쿼리 제거)
+    @Query("SELECT p FROM Product p WHERE p.id = :id AND p.store = :store")
+    Optional<Product> findByIdAndStore(@Param("id") Long id, @Param("store") Store store);
 }

--- a/src/main/java/com/gongu/server/domain/product/service/ProductService.java
+++ b/src/main/java/com/gongu/server/domain/product/service/ProductService.java
@@ -1,0 +1,115 @@
+package com.gongu.server.domain.product.service;
+
+import com.gongu.server.domain.product.domain.Product;
+import com.gongu.server.domain.product.domain.ProductStatus;
+import com.gongu.server.domain.product.dto.ProductDetailResponse;
+import com.gongu.server.domain.product.dto.ProductSummaryResponse;
+import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.store.entity.MemberStore;
+import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.domain.store.entity.StoreAdmin;
+import com.gongu.server.domain.store.repository.MemberStoreRepository;
+import com.gongu.server.domain.store.repository.StoreAdminRepository;
+import com.gongu.server.domain.store.repository.StoreRepository;
+import com.gongu.server.domain.user.entity.Member;
+import com.gongu.server.domain.user.repository.MemberRepository;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.ProductErrorCode;
+import com.gongu.server.global.exception.errorcode.StoreErrorCode;
+import com.gongu.server.global.exception.errorcode.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProductService {
+
+    private final ProductRepository productRepository;
+    private final MemberRepository memberRepository;
+    private final MemberStoreRepository memberStoreRepository;
+    private final StoreRepository storeRepository;
+    private final StoreAdminRepository storeAdminRepository;
+
+    // 회원: 상품 목록 조회
+    public Page<ProductSummaryResponse> getProducts(Long memberId, Long storeId, Pageable pageable) {
+        Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        if (storeId != null) {
+            Store store = storeRepository.findByIdAndDeletedAtIsNull(storeId)
+                    .orElseThrow(() -> new BusinessException(StoreErrorCode.STORE_NOT_FOUND));
+
+            // 회원이 해당 매장에 가입됐는지 검증 (보안상 미가입 매장은 존재하지 않는 것처럼 처리)
+            if (!memberStoreRepository.existsByMemberAndStore(member, store)) {
+                throw new BusinessException(StoreErrorCode.STORE_NOT_FOUND);
+            }
+
+            return productRepository.findAllByStoreAndStatus(store, ProductStatus.ACTIVE, pageable)
+                    .map(ProductSummaryResponse::from);
+        }
+
+        // storeId 없는 경우: 가입한 모든 매장의 ACTIVE 상품 목록
+        List<MemberStore> memberStores = memberStoreRepository.findAllByMember(member);
+        if (memberStores.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        List<Store> stores = memberStores.stream()
+                .map(MemberStore::getStore)
+                .toList();
+
+        return productRepository.findAllByStoreInAndStatus(stores, ProductStatus.ACTIVE, pageable)
+                .map(ProductSummaryResponse::from);
+    }
+
+    // 회원: 상품 상세 조회
+    public ProductDetailResponse getProduct(Long memberId, Long productId) {
+        Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        // 상품 매장에 회원이 가입됐는지 검증 (보안 정보 노출 방지: 미가입 매장 상품도 존재하지 않는 것처럼 처리)
+        if (!memberStoreRepository.existsByMemberAndStore(member, product.getStore())) {
+            throw new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND);
+        }
+
+        return ProductDetailResponse.from(product);
+    }
+
+    // 관리자: 상품 목록 조회
+    public Page<ProductSummaryResponse> getAdminProducts(Long storeAdminId, Pageable pageable) {
+        StoreAdmin storeAdmin = storeAdminRepository.findByIdAndDeletedAtIsNull(storeAdminId)
+                .orElseThrow(() -> new BusinessException(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
+
+        Store store = storeAdmin.getStore();
+
+        return productRepository.findAllByStore(store, pageable)
+                .map(ProductSummaryResponse::from);
+    }
+
+    // 관리자: 상품 상세 조회
+    public ProductDetailResponse getAdminProduct(Long storeAdminId, Long productId) {
+        StoreAdmin storeAdmin = storeAdminRepository.findByIdAndDeletedAtIsNull(storeAdminId)
+                .orElseThrow(() -> new BusinessException(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
+
+        Store store = storeAdmin.getStore();
+
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        // 상품의 매장이 관리자의 매장과 다르면 존재하지 않는 것처럼 처리
+        if (!product.getStore().getId().equals(store.getId())) {
+            throw new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND);
+        }
+
+        return ProductDetailResponse.from(product);
+    }
+}

--- a/src/main/java/com/gongu/server/domain/product/service/ProductService.java
+++ b/src/main/java/com/gongu/server/domain/product/service/ProductService.java
@@ -102,13 +102,9 @@ public class ProductService {
 
         Store store = storeAdmin.getStore();
 
-        Product product = productRepository.findById(productId)
+        // findByIdAndStore: 소속 매장 검증을 DB에서 한 번에 처리 (추가 Store SELECT 제거)
+        Product product = productRepository.findByIdAndStore(productId, store)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
-
-        // 상품의 매장이 관리자의 매장과 다르면 존재하지 않는 것처럼 처리
-        if (!product.getStore().getId().equals(store.getId())) {
-            throw new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND);
-        }
 
         return ProductDetailResponse.from(product);
     }

--- a/src/main/java/com/gongu/server/domain/store/repository/MemberStoreRepository.java
+++ b/src/main/java/com/gongu/server/domain/store/repository/MemberStoreRepository.java
@@ -9,11 +9,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberStoreRepository extends JpaRepository<MemberStore, Long> {
 
     boolean existsByMemberAndStore(Member member, Store store);
+
+    List<MemberStore> findAllByMember(Member member);
 
     Optional<MemberStore> findByMemberAndStore(Member member, Store store);
 

--- a/src/main/java/com/gongu/server/domain/store/repository/MemberStoreRepository.java
+++ b/src/main/java/com/gongu/server/domain/store/repository/MemberStoreRepository.java
@@ -16,7 +16,8 @@ public interface MemberStoreRepository extends JpaRepository<MemberStore, Long> 
 
     boolean existsByMemberAndStore(Member member, Store store);
 
-    List<MemberStore> findAllByMember(Member member);
+    @Query("SELECT ms FROM MemberStore ms JOIN FETCH ms.store WHERE ms.member = :member")
+    List<MemberStore> findAllByMember(@Param("member") Member member);
 
     Optional<MemberStore> findByMemberAndStore(Member member, Store store);
 


### PR DESCRIPTION
## Issue ID
close #59

## 작업 내용
- `ProductStatus` enum을 API 설계 기준으로 수정: `UPCOMING` / `ACTIVE` / `SOLD_OUT` / `CLOSED`
- `ProductRepository` 쿼리 메서드 추가: `findAllByStore`, `findAllByStoreAndStatus`, `findAllByStoreInAndStatus`
- `MemberStoreRepository.findAllByMember()` 추가
- 응답 DTO: `ProductSummaryResponse` (목록), `ProductDetailResponse` (상세)
- `ProductService` — 회원/관리자 조회 4개 메서드 (`@Transactional(readOnly = true)`)
- `MemberProductController` — `GET /products`, `GET /products/{id}`
- `AdminProductController` — `GET /admin/products`, `GET /admin/products/{id}`

## 참고사항
- 회원: storeId 없으면 가입한 모든 매장의 ACTIVE 상품 반환
- 회원: 미가입 매장 상품 조회 시 `PRODUCT_NOT_FOUND` (보안 정보 노출 방지)
- 관리자: 타 매장 상품 조회 시 `PRODUCT_NOT_FOUND`
- `@PreAuthorize("hasRole('MEMBER')")` / `hasRole('STORE_ADMIN')` 인가 적용