### PR TITLE
[FEAT] 상품 등록·수정·종료 API 구현 (#60)

### DIFF
--- a/src/main/java/com/gongu/server/domain/product/controller/AdminProductController.java
+++ b/src/main/java/com/gongu/server/domain/product/controller/AdminProductController.java
@@ -1,19 +1,27 @@
 package com.gongu.server.domain.product.controller;
 
+import com.gongu.server.domain.product.dto.CreateProductRequest;
 import com.gongu.server.domain.product.dto.ProductDetailResponse;
 import com.gongu.server.domain.product.dto.ProductSummaryResponse;
+import com.gongu.server.domain.product.dto.UpdateProductRequest;
 import com.gongu.server.domain.product.service.ProductService;
 import com.gongu.server.global.common.ApiResponse;
 import com.gongu.server.global.security.UserPrincipal;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -40,5 +48,33 @@ public class AdminProductController {
             @PathVariable Long id) {
         ProductDetailResponse result = productService.getAdminProduct(userPrincipal.id(), id);
         return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('STORE_ADMIN')")
+    public ResponseEntity<ApiResponse<ProductDetailResponse>> createProduct(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody CreateProductRequest request) {
+        ProductDetailResponse result = productService.createProduct(userPrincipal.id(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(result));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('STORE_ADMIN')")
+    public ResponseEntity<ApiResponse<ProductDetailResponse>> updateProduct(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long id,
+            @RequestBody UpdateProductRequest request) {
+        ProductDetailResponse result = productService.updateProduct(userPrincipal.id(), id, request);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('STORE_ADMIN')")
+    public ResponseEntity<Void> closeProduct(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long id) {
+        productService.closeProduct(userPrincipal.id(), id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/gongu/server/domain/product/controller/AdminProductController.java
+++ b/src/main/java/com/gongu/server/domain/product/controller/AdminProductController.java
@@ -64,7 +64,7 @@ public class AdminProductController {
     public ResponseEntity<ApiResponse<ProductDetailResponse>> updateProduct(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long id,
-            @RequestBody UpdateProductRequest request) {
+            @Valid @RequestBody UpdateProductRequest request) {
         ProductDetailResponse result = productService.updateProduct(userPrincipal.id(), id, request);
         return ResponseEntity.ok(ApiResponse.success(result));
     }

--- a/src/main/java/com/gongu/server/domain/product/domain/Product.java
+++ b/src/main/java/com/gongu/server/domain/product/domain/Product.java
@@ -95,4 +95,38 @@ public class Product extends BaseEntity {
         }
         this.remainingStock -= quantity;
     }
+
+    public void update(String name, String description, Long price,
+                       Integer totalStock, LocalDateTime startAt, LocalDateTime endAt) {
+        if (this.status != ProductStatus.UPCOMING) {
+            throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_STATUS);
+        }
+        if (name != null) this.name = name;
+        if (description != null) this.description = description;
+        if (price != null) {
+            if (price <= 0) throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_DATA);
+            this.price = price;
+        }
+        if (totalStock != null) {
+            if (totalStock <= 0) throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_DATA);
+            this.remainingStock += (totalStock - this.totalStock);
+            this.totalStock = totalStock;
+        }
+        if (startAt != null) this.startAt = startAt;
+        if (endAt != null) this.endAt = endAt;
+        if (this.startAt.isAfter(this.endAt)) {
+            throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_DATA);
+        }
+    }
+
+    public void close() {
+        this.status = ProductStatus.CLOSED;
+    }
+
+    public void restoreStock(int quantity) {
+        if (this.remainingStock + quantity > this.totalStock) {
+            throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_DATA);
+        }
+        this.remainingStock += quantity;
+    }
 }

--- a/src/main/java/com/gongu/server/domain/product/dto/CreateProductRequest.java
+++ b/src/main/java/com/gongu/server/domain/product/dto/CreateProductRequest.java
@@ -1,0 +1,16 @@
+package com.gongu.server.domain.product.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.time.LocalDateTime;
+
+public record CreateProductRequest(
+        @NotBlank String name,
+        @NotBlank String description,
+        @Positive Long price,
+        @Positive int totalStock,
+        @NotNull LocalDateTime startAt,
+        @NotNull LocalDateTime endAt
+) {}

--- a/src/main/java/com/gongu/server/domain/product/dto/UpdateProductRequest.java
+++ b/src/main/java/com/gongu/server/domain/product/dto/UpdateProductRequest.java
@@ -1,0 +1,14 @@
+package com.gongu.server.domain.product.dto;
+
+import jakarta.validation.constraints.Positive;
+
+import java.time.LocalDateTime;
+
+public record UpdateProductRequest(
+        String name,
+        String description,
+        @Positive Long price,
+        @Positive Integer totalStock,
+        LocalDateTime startAt,
+        LocalDateTime endAt
+) {}

--- a/src/main/java/com/gongu/server/domain/product/service/ProductService.java
+++ b/src/main/java/com/gongu/server/domain/product/service/ProductService.java
@@ -2,8 +2,10 @@ package com.gongu.server.domain.product.service;
 
 import com.gongu.server.domain.product.domain.Product;
 import com.gongu.server.domain.product.domain.ProductStatus;
+import com.gongu.server.domain.product.dto.CreateProductRequest;
 import com.gongu.server.domain.product.dto.ProductDetailResponse;
 import com.gongu.server.domain.product.dto.ProductSummaryResponse;
+import com.gongu.server.domain.product.dto.UpdateProductRequest;
 import com.gongu.server.domain.product.repository.ProductRepository;
 import com.gongu.server.domain.store.entity.MemberStore;
 import com.gongu.server.domain.store.entity.Store;
@@ -107,5 +109,52 @@ public class ProductService {
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         return ProductDetailResponse.from(product);
+    }
+
+    // 관리자: 상품 등록
+    @Transactional
+    public ProductDetailResponse createProduct(Long storeAdminId, CreateProductRequest request) {
+        StoreAdmin storeAdmin = storeAdminRepository.findByIdAndDeletedAtIsNull(storeAdminId)
+                .orElseThrow(() -> new BusinessException(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
+
+        Store store = storeAdmin.getStore();
+
+        Product product = Product.create(store, request.name(), request.description(),
+                request.price(), request.totalStock(), ProductStatus.UPCOMING,
+                request.startAt(), request.endAt());
+        productRepository.save(product);
+
+        return ProductDetailResponse.from(product);
+    }
+
+    // 관리자: 상품 수정
+    @Transactional
+    public ProductDetailResponse updateProduct(Long storeAdminId, Long productId, UpdateProductRequest request) {
+        StoreAdmin storeAdmin = storeAdminRepository.findByIdAndDeletedAtIsNull(storeAdminId)
+                .orElseThrow(() -> new BusinessException(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
+
+        Store store = storeAdmin.getStore();
+
+        Product product = productRepository.findByIdAndStore(productId, store)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        product.update(request.name(), request.description(), request.price(),
+                request.totalStock(), request.startAt(), request.endAt());
+
+        return ProductDetailResponse.from(product);
+    }
+
+    // 관리자: 상품 종료 (소프트 클로즈)
+    @Transactional
+    public void closeProduct(Long storeAdminId, Long productId) {
+        StoreAdmin storeAdmin = storeAdminRepository.findByIdAndDeletedAtIsNull(storeAdminId)
+                .orElseThrow(() -> new BusinessException(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
+
+        Store store = storeAdmin.getStore();
+
+        Product product = productRepository.findByIdAndStore(productId, store)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        product.close();
     }
 }

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>$Title$</title>
+</head>
+<body>
+$END$
+</body>
+</html>


### PR DESCRIPTION
## Issue ID
close #60

## 작업 내용
- `Product` 엔티티에 도메인 메서드 추가
  - `update()` — UPCOMING 상태 전제, 부분 수정 지원, 불변식 재검증, remainingStock 동기화
  - `close()` — 상태를 CLOSED로 전이 (멱등)
  - `restoreStock()` — 주문 취소 시 재고 복구용 (#61 대비)
- 요청 DTO: `CreateProductRequest` (@Valid 제약), `UpdateProductRequest` (전체 null 허용)
- `ProductService` — `createProduct`, `updateProduct`, `closeProduct` 추가
- `AdminProductController` — `POST /admin/products`, `PUT /admin/products/{id}`, `DELETE /admin/products/{id}`

## 참고사항
- Product DDL에 deletedAt 없음 → 삭제는 status를 CLOSED로 전환
- 수정(update)은 UPCOMING 상태일 때만 허용 — 판매 시작 후 변경 차단
- `PUT /admin/products/{id}/arrive` (입고 처리)는 Order 도메인 연동이 필요해 별도 처리