### PR TITLE
[FEAT] 재고 차감 서비스 구현 - 비관적 락 (#61)

### DIFF
--- a/src/main/java/com/gongu/server/domain/product/domain/Product.java
+++ b/src/main/java/com/gongu/server/domain/product/domain/Product.java
@@ -90,6 +90,9 @@ public class Product extends BaseEntity {
     }
 
     public void decreaseStock(int quantity) {
+        if (this.status != ProductStatus.ACTIVE) {
+            throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_STATUS);
+        }
         if (this.remainingStock < quantity) {
             throw new BusinessException(ProductErrorCode.INSUFFICIENT_STOCK);
         }

--- a/src/main/java/com/gongu/server/domain/product/domain/Product.java
+++ b/src/main/java/com/gongu/server/domain/product/domain/Product.java
@@ -93,6 +93,9 @@ public class Product extends BaseEntity {
         if (this.status != ProductStatus.ACTIVE) {
             throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_STATUS);
         }
+        if (quantity <= 0) {
+            throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_DATA);
+        }
         if (this.remainingStock < quantity) {
             throw new BusinessException(ProductErrorCode.INSUFFICIENT_STOCK);
         }

--- a/src/main/java/com/gongu/server/domain/product/service/ProductService.java
+++ b/src/main/java/com/gongu/server/domain/product/service/ProductService.java
@@ -144,6 +144,14 @@ public class ProductService {
         return ProductDetailResponse.from(product);
     }
 
+    // 재고 차감 (비관적 락)
+    @Transactional
+    public void decreaseStock(Long productId, int quantity) {
+        Product product = productRepository.findByIdWithLock(productId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+        product.decreaseStock(quantity);
+    }
+
     // 관리자: 상품 종료 (소프트 클로즈)
     @Transactional
     public void closeProduct(Long storeAdminId, Long productId) {

--- a/src/test/java/com/gongu/server/domain/product/domain/ProductTest.java
+++ b/src/test/java/com/gongu/server/domain/product/domain/ProductTest.java
@@ -1,0 +1,74 @@
+package com.gongu.server.domain.product.domain;
+
+import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.ProductErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+class ProductTest {
+
+    @Mock
+    private Store store;
+
+    private final LocalDateTime now = LocalDateTime.now();
+    private final LocalDateTime later = now.plusDays(7);
+
+    @Test
+    @DisplayName("ACTIVE 상태가 아닌 상품의 재고를 차감하면 INVALID_PRODUCT_STATUS 예외가 발생한다")
+    void decreaseStock_notActive_throwsException() {
+        // given — Product.create() 로 생성 시 UPCOMING 상태 지정
+        Product product = Product.create(store, "테스트상품", "설명", 1000L, 10,
+                ProductStatus.UPCOMING, now, later);
+
+        // when & then
+        assertThatThrownBy(() -> product.decreaseStock(1))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode().getCode())
+                            .isEqualTo(ProductErrorCode.INVALID_PRODUCT_STATUS.getCode());
+                });
+    }
+
+    @Test
+    @DisplayName("재고가 부족하면 INSUFFICIENT_STOCK 예외가 발생한다")
+    void decreaseStock_insufficientStock_throwsException() {
+        // given — ACTIVE 상태로 생성, 재고 3
+        Product product = Product.create(store, "테스트상품", "설명", 1000L, 3,
+                ProductStatus.ACTIVE, now, later);
+
+        // when & then
+        assertThatThrownBy(() -> product.decreaseStock(5))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode().getCode())
+                            .isEqualTo(ProductErrorCode.INSUFFICIENT_STOCK.getCode());
+                });
+    }
+
+    @Test
+    @DisplayName("ACTIVE 상태 상품의 재고가 정상 차감된다")
+    void decreaseStock_success() {
+        // given — ACTIVE 상태로 생성, 재고 10
+        Product product = Product.create(store, "테스트상품", "설명", 1000L, 10,
+                ProductStatus.ACTIVE, now, later);
+
+        // when
+        product.decreaseStock(3);
+
+        // then
+        assertThat(product.getRemainingStock()).isEqualTo(7);
+    }
+}

--- a/src/test/java/com/gongu/server/domain/product/service/ProductStockConcurrencyTest.java
+++ b/src/test/java/com/gongu/server/domain/product/service/ProductStockConcurrencyTest.java
@@ -14,12 +14,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -104,11 +101,10 @@ class ProductStockConcurrencyTest {
         CountDownLatch startLatch = new CountDownLatch(1);
         CountDownLatch doneLatch = new CountDownLatch(threadCount);
         AtomicInteger exceptionCount = new AtomicInteger(0);
-        List<Future<?>> futures = new ArrayList<>();
 
         // when
         for (int i = 0; i < threadCount; i++) {
-            futures.add(executor.submit(() -> {
+            executor.submit(() -> {
                 try {
                     startLatch.await();
                     productService.decreaseStock(productId, 1);
@@ -121,7 +117,7 @@ class ProductStockConcurrencyTest {
                 } finally {
                     doneLatch.countDown();
                 }
-            }));
+            });
         }
 
         startLatch.countDown();

--- a/src/test/java/com/gongu/server/domain/product/service/ProductStockConcurrencyTest.java
+++ b/src/test/java/com/gongu/server/domain/product/service/ProductStockConcurrencyTest.java
@@ -1,0 +1,129 @@
+package com.gongu.server.domain.product.service;
+
+import com.gongu.server.domain.product.domain.Product;
+import com.gongu.server.domain.product.domain.ProductStatus;
+import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.domain.store.repository.StoreRepository;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.ProductErrorCode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class ProductStockConcurrencyTest {
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @AfterEach
+    void tearDown() {
+        productRepository.deleteAll();
+        storeRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("재고_10_스레드_10개_각_1씩_차감_최종재고_0")
+    void 재고_10_스레드_10개_각_1씩_차감_최종재고_0() throws InterruptedException {
+        // given
+        Store store = storeRepository.save(Store.create("테스트매장", "서울시 강남구", "02-1234-5678"));
+        Product product = productRepository.save(
+                Product.create(store, "테스트상품", "설명", 1000L, 10, ProductStatus.ACTIVE,
+                        LocalDateTime.now(), LocalDateTime.now().plusDays(7))
+        );
+        Long productId = product.getId();
+
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    productService.decreaseStock(productId, 1);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        doneLatch.await();
+        executor.shutdown();
+
+        // then
+        Product result = productRepository.findById(productId).orElseThrow();
+        assertThat(result.getRemainingStock()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("재고_5_스레드_10개_각_1씩_차감_예외_발생_재고_음수_아님")
+    void 재고_5_스레드_10개_각_1씩_차감_예외_발생_재고_음수_아님() throws InterruptedException {
+        // given
+        Store store = storeRepository.save(Store.create("테스트매장2", "서울시 서초구", "02-9876-5432"));
+        Product product = productRepository.save(
+                Product.create(store, "재고부족상품", "설명", 2000L, 5, ProductStatus.ACTIVE,
+                        LocalDateTime.now(), LocalDateTime.now().plusDays(7))
+        );
+        Long productId = product.getId();
+
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicInteger exceptionCount = new AtomicInteger(0);
+        List<Future<?>> futures = new ArrayList<>();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    productService.decreaseStock(productId, 1);
+                } catch (BusinessException e) {
+                    if (ProductErrorCode.INSUFFICIENT_STOCK.getCode().equals(e.getErrorCode().getCode())) {
+                        exceptionCount.incrementAndGet();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                }
+            }));
+        }
+
+        startLatch.countDown();
+        doneLatch.await();
+        executor.shutdown();
+
+        // then
+        Product result = productRepository.findById(productId).orElseThrow();
+        assertThat(exceptionCount.get()).isGreaterThan(0);
+        assertThat(result.getRemainingStock()).isGreaterThanOrEqualTo(0);
+    }
+}

--- a/src/test/java/com/gongu/server/domain/product/service/ProductStockConcurrencyTest.java
+++ b/src/test/java/com/gongu/server/domain/product/service/ProductStockConcurrencyTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -57,6 +58,7 @@ class ProductStockConcurrencyTest {
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
         CountDownLatch startLatch = new CountDownLatch(1);
         CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicReference<Throwable> unexpectedException = new AtomicReference<>();
 
         // when
         for (int i = 0; i < threadCount; i++) {
@@ -64,8 +66,12 @@ class ProductStockConcurrencyTest {
                 try {
                     startLatch.await();
                     productService.decreaseStock(productId, 1);
+                } catch (BusinessException e) {
+                    // 예상된 예외 (재고 부족 등) — 무시
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
+                } catch (Throwable e) {
+                    unexpectedException.set(e);
                 } finally {
                     doneLatch.countDown();
                 }
@@ -79,6 +85,7 @@ class ProductStockConcurrencyTest {
         // then
         Product result = productRepository.findById(productId).orElseThrow();
         assertThat(result.getRemainingStock()).isEqualTo(0);
+        assertThat(unexpectedException.get()).isNull();
     }
 
     @Test
@@ -123,7 +130,7 @@ class ProductStockConcurrencyTest {
 
         // then
         Product result = productRepository.findById(productId).orElseThrow();
-        assertThat(exceptionCount.get()).isGreaterThan(0);
-        assertThat(result.getRemainingStock()).isGreaterThanOrEqualTo(0);
+        assertThat(result.getRemainingStock()).isEqualTo(0);
+        assertThat(exceptionCount.get()).isEqualTo(5);
     }
 }


### PR DESCRIPTION
## Issue ID

close #61

## 작업 내용

- `ProductService.decreaseStock(Long productId, int quantity)` 구현
  - `@Transactional` + `findByIdWithLock` (`SELECT FOR UPDATE`) 조합으로 overselling 원천 차단
  - 상품 미존재 시 `PRODUCT_NOT_FOUND`, 재고 부족 시 `INSUFFICIENT_STOCK` 예외 발생
  - 트랜잭션 내 외부 API 호출 없음 (ADR-005 트랜잭션 경계 원칙 준수)
- `ProductStockConcurrencyTest` 동시성 통합 테스트 추가
  - 재고 10, 스레드 10개 × 수량 1 → 최종 재고 0 검증
  - 재고 5, 스레드 10개 × 수량 1 → `INSUFFICIENT_STOCK` 예외 발생 + 재고 음수 방지 검증

## 참고사항

- ADR-005: 비관적 락 (`SELECT FOR UPDATE`) 채택 — `ProductRepository.findByIdWithLock` 기존 구현 활용
- ADR-002: 재고 차감 비즈니스 로직은 `Product.decreaseStock()` 도메인 메서드에 캡슐화 (기존 구현 유지)
- `Product`의 `@Version` (낙관적 락)은 상품 수정 플로우용으로 기존 그대로 유지