### PR TITLE
[CHORE] email 필드 optional 처리, email-availability API 제거 (#67)

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -57,63 +57,6 @@ paths:
   # Auth
   # ──────────────────────────────────────────
 
-  /auth/email-availability:
-    get:
-      tags: [Auth]
-      summary: 이메일 중복 검사
-      description: 이메일 중복 검사를 실행하는 API입니다.
-      operationId: checkEmailAvailability
-      parameters:
-        - name: email
-          in: query
-          required: true
-          description: 이메일 주소
-          schema:
-            type: string
-            format: email
-            example: hong@example.com
-      responses:
-        '200':
-          description: 이메일 사용 가능 여부 반환
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EmailAvailabilityResponse'
-              example:
-                code: USER_EMAIL_AVAILABLE
-                data:
-                  available: true
-        '409':
-          description: 이미 사용 중인 이메일
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              example:
-                code: USER_EMAIL_DUPLICATED
-                errors:
-                  - field: email
-                    reason: 이미 사용 중인 이메일입니다.
-        '422':
-          description: 유효성 검사 실패
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                이메일_필수:
-                  value:
-                    code: VALIDATION_FAILED
-                    errors:
-                      - field: email
-                        reason: 이메일은 필수입니다.
-                이메일_형식_오류:
-                  value:
-                    code: VALIDATION_FAILED
-                    errors:
-                      - field: email
-                        reason: 올바른 이메일 형식을 입력해주세요.
-
   /auth/oauth2/login:
     post:
       tags: [Auth]
@@ -1185,19 +1128,6 @@ components:
           type: integer
         total_pages:
           type: integer
-
-    # ── Auth ──────────────────────────────
-    EmailAvailabilityResponse:
-      type: object
-      properties:
-        code:
-          type: string
-        data:
-          type: object
-          properties:
-            available:
-              type: boolean
-              description: 사용 가능하면 true, 사용 불가능하면 false
 
     OAuthLoginRequest:
       type: object

--- a/docs/schema/ddl.sql
+++ b/docs/schema/ddl.sql
@@ -32,7 +32,7 @@ CREATE TABLE `store_admins` (
 CREATE TABLE `users` (
     `id`         bigint       NOT NULL,
     `name`       varchar(50)  NOT NULL,
-    `email`      varchar(255) NOT NULL,
+    `email`      varchar(255) NULL,
     `phone`      varchar(20)  NOT NULL,
     `is_active`  boolean      NOT NULL,
     `created_at` datetime     NOT NULL,
@@ -165,7 +165,6 @@ ALTER TABLE `payments`
 -- -------------------------------------------------------------
 
 -- 이메일 중복 가입 방지
-ALTER TABLE `users`        ADD CONSTRAINT `UQ_USERS_EMAIL`        UNIQUE (`email`);
 ALTER TABLE `store_admins` ADD CONSTRAINT `UQ_STORE_ADMINS_EMAIL` UNIQUE (`email`);
 
 -- 같은 소셜 제공자로 중복 연결 방지

--- a/docs/schema/table-definitions.md
+++ b/docs/schema/table-definitions.md
@@ -109,7 +109,7 @@
 |------|------|------|--------|------|
 | id | bigint | NO | — | PK |
 | name | varchar(50) | NO | — | 회원명 |
-| email | varchar(255) | NO | — | 이메일 (UNIQUE) |
+| email | varchar(255) | YES | NULL | 이메일 (선택) |
 | phone | varchar(20) | NO | — | 전화번호 |
 | is_active | boolean | NO | — | 계정 활성 여부 |
 | created_at | datetime | NO | — | 생성일시 |
@@ -121,7 +121,6 @@
 | 이름 | 대상 컬럼 | 종류 |
 |------|-----------|------|
 | PK_USERS | id | PRIMARY |
-| UQ_USERS_EMAIL | email | UNIQUE |
 
 ---
 

--- a/src/main/java/com/gongu/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/gongu/server/domain/auth/controller/AuthController.java
@@ -4,27 +4,20 @@ import com.gongu.server.domain.auth.dto.request.KakaoLoginRequest;
 import com.gongu.server.domain.auth.dto.request.StoreAdminLoginRequest;
 import com.gongu.server.domain.auth.dto.request.TokenRefreshRequest;
 import com.gongu.server.domain.auth.dto.response.AccessTokenResponse;
-import com.gongu.server.domain.auth.dto.response.EmailAvailabilityResponse;
 import com.gongu.server.domain.auth.dto.response.TokenResponse;
 import com.gongu.server.domain.auth.service.AuthService;
 import com.gongu.server.global.common.ApiResponse;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
-@Validated
 public class AuthController {
 
     private final AuthService authService;
@@ -46,9 +39,4 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success(authService.refreshToken(request)));
     }
 
-    @GetMapping("/email-availability")
-    public ResponseEntity<ApiResponse<EmailAvailabilityResponse>> checkEmailAvailability(
-            @RequestParam @NotBlank @Email String email) {
-        return ResponseEntity.ok(ApiResponse.success(authService.checkEmailAvailability(email)));
-    }
 }

--- a/src/main/java/com/gongu/server/domain/auth/dto/response/EmailAvailabilityResponse.java
+++ b/src/main/java/com/gongu/server/domain/auth/dto/response/EmailAvailabilityResponse.java
@@ -1,3 +1,0 @@
-package com.gongu.server.domain.auth.dto.response;
-
-public record EmailAvailabilityResponse(boolean available) {}

--- a/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
@@ -5,7 +5,6 @@ import com.gongu.server.domain.auth.client.dto.KakaoUserInfo;
 import com.gongu.server.domain.auth.dto.request.StoreAdminLoginRequest;
 import com.gongu.server.domain.auth.dto.request.TokenRefreshRequest;
 import com.gongu.server.domain.auth.dto.response.AccessTokenResponse;
-import com.gongu.server.domain.auth.dto.response.EmailAvailabilityResponse;
 import com.gongu.server.domain.auth.dto.response.TokenResponse;
 import com.gongu.server.domain.store.entity.StoreAdmin;
 import com.gongu.server.domain.store.repository.StoreAdminRepository;
@@ -115,20 +114,16 @@ public class AuthService {
      */
     private User registerKakaoUser(KakaoUserInfo userInfo, String socialId) {
         String nickname = "";
-        String email = "kakao-" + socialId + "@noemail.local";
 
         if (userInfo.kakaoAccount() != null) {
             KakaoUserInfo.KakaoAccount account = userInfo.kakaoAccount();
             if (account.profile() != null && account.profile().nickname() != null) {
                 nickname = account.profile().nickname();
             }
-            if (account.email() != null) {
-                email = account.email();
-            }
         }
 
         try {
-            User newUser = userRepository.save(User.of(nickname, email, ""));
+            User newUser = userRepository.save(User.of(nickname, ""));
             userSocialRepository.save(UserSocial.of(newUser, SocialProvider.KAKAO, socialId));
             return newUser;
         } catch (DataIntegrityViolationException e) {
@@ -136,15 +131,5 @@ public class AuthService {
                     .map(UserSocial::getUser)
                     .orElseThrow(() -> e);
         }
-    }
-
-    /**
-     * 이메일 사용 가능 여부를 반환한다.
-     * DDL의 UNIQUE 제약 조건(UQ_USERS_EMAIL)에 따라 이메일은 전체 고유 — deletedAt 조건 없이 existsByEmail 사용.
-     */
-    @Transactional(readOnly = true)
-    public EmailAvailabilityResponse checkEmailAvailability(String email) {
-        boolean available = !userRepository.existsByEmail(email);
-        return new EmailAvailabilityResponse(available);
     }
 }

--- a/src/main/java/com/gongu/server/domain/user/entity/User.java
+++ b/src/main/java/com/gongu/server/domain/user/entity/User.java
@@ -23,7 +23,7 @@ public class User extends SoftDeleteEntity {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = true)
     private String email;
 
     @Column(nullable = false)
@@ -32,10 +32,9 @@ public class User extends SoftDeleteEntity {
     @Column(nullable = false)
     private boolean isActive;
 
-    public static User of(String name, String email, String phone) {
+    public static User of(String name, String phone) {
         User user = new User();
         user.name = name;
-        user.email = email;
         user.phone = phone;
         user.isActive = true;
         return user;

--- a/src/main/java/com/gongu/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gongu/server/domain/user/repository/UserRepository.java
@@ -7,9 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByEmailAndDeletedAtIsNull(String email);
-
     Optional<User> findByIdAndDeletedAtIsNull(Long id);
-
-    boolean existsByEmail(String email);
 }

--- a/src/test/java/com/gongu/server/domain/store/repository/UserStoreRepositoryTest.java
+++ b/src/test/java/com/gongu/server/domain/store/repository/UserStoreRepositoryTest.java
@@ -35,7 +35,7 @@ class UserStoreRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        user = em.persist(User.of("테스터", "test@test.com", "010-0000-0000"));
+        user = em.persist(User.of("테스터", "010-0000-0000"));
         store = em.persist(Store.create("테스트매장", "서울시", "02-1234-5678"));
         em.flush();
     }

--- a/src/test/java/com/gongu/server/domain/store/service/StoreAdminServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/store/service/StoreAdminServiceTest.java
@@ -47,8 +47,8 @@ class StoreAdminServiceTest {
         Store store = Store.create("테스트매장", "서울시 강남구", "02-1234-5678");
         StoreAdmin storeAdmin = StoreAdmin.of(store, "admin@test.com", "encoded", "관리자");
 
-        User user1 = User.of("홍길동", "hong@test.com", "010-1111-2222");
-        User user2 = User.of("김철수", "kim@test.com", "010-3333-4444");
+        User user1 = User.of("홍길동", "010-1111-2222");
+        User user2 = User.of("김철수", "010-3333-4444");
         UserStore userStore1 = UserStore.create(user1, store, false);
         UserStore userStore2 = UserStore.create(user2, store, false);
 
@@ -75,7 +75,7 @@ class StoreAdminServiceTest {
         Store store = Store.create("테스트매장", "서울시 강남구", "02-1234-5678");
         StoreAdmin storeAdmin = StoreAdmin.of(store, "admin@test.com", "encoded", "관리자");
 
-        User user1 = User.of("홍길동", "hong@test.com", "010-1111-2222");
+        User user1 = User.of("홍길동", "010-1111-2222");
         UserStore userStore1 = UserStore.create(user1, store, false);
 
         Pageable pageable = PageRequest.of(0, 20);

--- a/src/test/java/com/gongu/server/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/store/service/StoreServiceTest.java
@@ -120,7 +120,7 @@ class StoreServiceTest {
     @DisplayName("registerUserStore_성공_비선호매장")
     void registerUserStore_성공_비선호매장() {
         // given
-        User user = User.of("홍길동", "hong@test.com", "010-1234-5678");
+        User user = User.of("홍길동", "010-1234-5678");
         Store store = Store.create("테스트매장", "서울시 강남구", "02-1234-5678");
         RegisterUserStoreRequest request = new RegisterUserStoreRequest(1L, false);
 
@@ -143,7 +143,7 @@ class StoreServiceTest {
     @DisplayName("registerUserStore_성공_선호매장_기존선호_해제")
     void registerUserStore_성공_선호매장_기존선호_해제() {
         // given
-        User user = User.of("홍길동", "hong@test.com", "010-1234-5678");
+        User user = User.of("홍길동", "010-1234-5678");
         Store store = Store.create("테스트매장", "서울시 강남구", "02-1234-5678");
         Store oldStore = Store.create("기존선호매장", "서울시 서초구", "02-9999-8888");
         UserStore existingPreferred = UserStore.create(user, oldStore, true);
@@ -183,7 +183,7 @@ class StoreServiceTest {
     @DisplayName("registerUserStore_중복_등록_MEMBER_STORE_DUPLICATE_예외")
     void registerUserStore_중복_등록_MEMBER_STORE_DUPLICATE_예외() {
         // given
-        User user = User.of("홍길동", "hong@test.com", "010-1234-5678");
+        User user = User.of("홍길동", "010-1234-5678");
         Store store = Store.create("테스트매장", "서울시 강남구", "02-1234-5678");
         RegisterUserStoreRequest request = new RegisterUserStoreRequest(1L, false);
 
@@ -202,7 +202,7 @@ class StoreServiceTest {
     @DisplayName("registerUserStore_존재하지_않는_매장_STORE_NOT_FOUND_예외")
     void registerUserStore_존재하지_않는_매장_STORE_NOT_FOUND_예외() {
         // given
-        User user = User.of("홍길동", "hong@test.com", "010-1234-5678");
+        User user = User.of("홍길동", "010-1234-5678");
         RegisterUserStoreRequest request = new RegisterUserStoreRequest(999L, false);
 
         given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));


### PR DESCRIPTION
## Issue ID
close #67

## 작업 내용
- `users.email` DDL: NOT NULL 제거, UNIQUE 제약(`UQ_USERS_EMAIL`) 제거
- `User.email`: `@Column(nullable = true)`, `of()` 팩토리 email 파라미터 제거
- 카카오 OAuth 가입 시 이메일 폴백 로직(`kakao-{id}@noemail.local`) 제거
- `GET /auth/email-availability` 엔드포인트 및 `EmailAvailabilityResponse` DTO 삭제
- 관련 테스트 코드 `User.of()` 3인자 → 2인자 수정
- 관련 문서(`table-definitions.md`, `openapi.yaml`) 반영

## 참고사항
- `store_admins.email`의 UNIQUE/NOT NULL은 변경 없음 — `users.email`만 해당
- 카카오 비즈니스 앱 등록 완료 시 email 수집 여부 재검토 예정