### PR TITLE
[FEAT] Order + OrderItem 엔티티 (#72)

### DIFF
--- a/docs/adr/연관관계_매핑_전략.md
+++ b/docs/adr/연관관계_매핑_전략.md
@@ -1,0 +1,83 @@
+# ADR-006: JPA 연관관계 매핑 전략
+
+- **날짜**: 2026-05-18
+- **상태**: 승인됨
+
+---
+
+## 결정
+
+**단방향 `@ManyToOne`만 사용한다. `@OneToMany` 컬렉션을 엔티티에 보유하지 않는다.**
+
+---
+
+## 배경
+
+양방향 연관관계(`@OneToMany` + `@ManyToOne`)는 아래 비용을 수반한다.
+
+- **동기화 의무**: 양쪽 컬렉션을 항상 함께 관리해야 한다. 헬퍼 메서드(`addChild()`) 누락 시 cascade persist 실패 또는 트랜잭션 내 조회 불일치 버그가 발생한다.
+- **순환 참조**: `toString()`, `hashCode()`, JSON 직렬화 시 `Parent → Child → Parent → ...` 무한 루프.
+- **N+1 위험**: `parent.getChildren()` 접근 시 예상치 못한 lazy loading 발생.
+- **인지 부담**: 관계의 주인(mappedBy), cascade, orphanRemoval 조합이 복잡해진다.
+
+단방향으로도 Rich Domain Model을 유지할 수 있다. 자식 컬렉션이 필요한 도메인 로직은 Repository 쿼리로 조회한 컬렉션을 메서드 인자로 전달하면 된다.
+
+---
+
+## 적용 규칙
+
+### 허용
+
+```java
+// 자식 엔티티에 @ManyToOne 단방향
+@ManyToOne(fetch = FetchType.LAZY)
+@JoinColumn(name = "order_id", nullable = false)
+private Order order;
+```
+
+### 금지
+
+```java
+// 부모 엔티티에 @OneToMany 컬렉션
+@OneToMany(mappedBy = "order", cascade = CascadeType.PERSIST)
+private List<OrderItem> orderItems = new ArrayList<>();
+```
+
+### 자식 저장 방식
+
+```java
+// Service에서 각각 명시적으로 저장
+Order order = Order.create(user, totalPrice);
+orderRepository.save(order);
+
+OrderItem item = OrderItem.create(order, product, quantity);
+orderItemRepository.save(item);
+```
+
+### 도메인 로직에서 자식 컬렉션이 필요한 경우
+
+```java
+// Repository에서 조회 후 인자로 전달
+List<OrderItem> items = orderItemRepository.findAllByOrder(order);
+order.validateItems(items);  // 도메인 메서드는 엔티티 안에 유지
+```
+
+---
+
+## 예외
+
+다음 조건을 **모두** 충족할 때만 `@OneToMany` 사용을 허용한다.
+
+1. 부모 도메인 메서드가 자식 컬렉션을 직접 순회하는 비즈니스 로직이 있다.
+2. 해당 컬렉션이 항상 부모와 함께 로딩되어야 한다 (생명주기 동일).
+3. 팀 리뷰에서 명시적으로 승인된다.
+
+---
+
+## 영향
+
+- `Order.orderItems` 필드 제거
+- `Order.addOrderItem()` 헬퍼 메서드 제거
+- `OrderItem.create()` 내 `order.addOrderItem()` 호출 제거
+- Service에서 `orderRepository.save(order)` + `orderItemRepository.save(item)` 분리 저장
+- 취소 플로우에서 `order.getOrderItems()` 대신 `orderItemRepository.findAllByOrder(order)` 사용

--- a/docs/superpowers/specs/2026-05-18-order-domain-design.md
+++ b/docs/superpowers/specs/2026-05-18-order-domain-design.md
@@ -1,0 +1,182 @@
+# Order 도메인 설계 스펙
+
+- **날짜**: 2026-05-18
+- **마일스톤**: #6 주문 도메인
+- **상태**: 승인됨
+
+---
+
+## 1. 범위
+
+### 이번 마일스톤 포함
+
+| API | 역할 | 상태 전이 |
+|-----|------|-----------|
+| `POST /orders` | 고객 — 상품 예약 | → RESERVED |
+| `GET /orders/me` | 고객 — 내 주문 목록 | 조회 전용 |
+| `GET /orders/{orderId}` | 고객 — 주문 상세 | 조회 전용 |
+| `POST /orders/{orderId}/cancel` | 고객 — 주문 취소 | RESERVED → CANCELLED |
+| `GET /admin/products/{productId}/orders` | 매장 관리자 — 상품별 주문 | 조회 전용 |
+| `GET /admin/members/{memberId}/orders` | 매장 관리자 — 회원 주문 이력 | 조회 전용 |
+
+### 이번 마일스톤 제외 (미래 마일스톤)
+
+| 항목 | 이유 |
+|------|------|
+| `POST /orders/{id}/receive` (ARRIVED → RECEIVED) | 결제 마일스톤 이후 |
+| `PUT /admin/products/{id}/arrive` (입고 처리) | Product 상태 변경 마일스톤 |
+| `PAID → CANCELLED` 취소 | 결제 마일스톤에서 보상 트랜잭션과 함께 |
+| Notification (입고 알림, 예약 확정) | 알림 마일스톤 (#8) |
+| Product 수동 마감 (ACTIVE → CLOSED) | Product 상태 변경 마일스톤 |
+| 재고 소진 자동 SOLD_OUT 전환 | Product 상태 변경 마일스톤 |
+
+---
+
+## 2. 상태 전이 다이어그램
+
+```
+         주문 생성
+            │
+            ▼
+        RESERVED ──────── 취소 가능 (이번 마일스톤)
+            │
+            │ 결제 완료 (결제 마일스톤)
+            ▼
+          PAID ─────────── 취소 가능 (결제 마일스톤)
+            │
+            │ 입고 처리 (Product 상태 변경 마일스톤)
+            ▼
+         ARRIVED
+            │
+            │ 수령 완료 (결제 마일스톤 이후)
+            ▼
+        RECEIVED
+
+       (취소 시 → CANCELLED)
+```
+
+---
+
+## 3. 엔티티 설계
+
+### Order (`orders` 테이블)
+
+| 필드 | 타입 | DDL 컬럼 | 비고 |
+|------|------|----------|------|
+| id | Long | id BIGINT PK | |
+| member | Member | user_id BIGINT FK | |
+| status | OrderStatus | status VARCHAR(20) | enum |
+| totalPrice | Long | total_price BIGINT | |
+| cancelledAt | LocalDateTime | cancelled_at DATETIME NULL | 취소 시 기록 |
+| cancelReason | String | cancel_reason VARCHAR(255) NULL | 취소 시 기록 |
+| createdAt | LocalDateTime | created_at DATETIME | BaseEntity |
+| updatedAt | LocalDateTime | updated_at DATETIME | BaseEntity |
+
+**도메인 메서드:**
+- `Order.create(member, totalPrice)` — 정적 팩토리, status = RESERVED
+- `cancel(reason)` — RESERVED 아니면 `ORDER_NOT_CANCELLABLE` throw
+- `pay()` — RESERVED → PAID (결제 마일스톤)
+- `arrive()` — PAID → ARRIVED (Product 상태 변경 마일스톤)
+- `receive()` — ARRIVED → RECEIVED (결제 마일스톤 이후)
+
+**연관관계:**
+단방향 `@ManyToOne`만 사용 (ADR-006). `Order`는 `OrderItem` 컬렉션을 보유하지 않는다.
+`orderItemRepository.save(item)`으로 별도 저장.
+
+### OrderItem (`order_items` 테이블)
+
+| 필드 | 타입 | DDL 컬럼 | 비고 |
+|------|------|----------|------|
+| id | Long | id BIGINT PK | |
+| order | Order | order_id BIGINT FK | |
+| product | Product | product_id BIGINT FK | |
+| quantity | int | quantity BIGINT | |
+| unitPrice | Long | unit_price BIGINT | 주문 시점 가격 스냅샷 |
+| createdAt | LocalDateTime | created_at DATETIME | |
+
+**도메인 메서드:**
+- `OrderItem.create(order, product, quantity)` — `product.getPrice()`를 unitPrice로 스냅샷
+
+### OrderStatus
+
+```java
+RESERVED, PAID, ARRIVED, RECEIVED, CANCELLED
+```
+
+---
+
+## 4. 트랜잭션 경계
+
+### 주문 생성 (`createOrder`)
+
+```
+@Transactional
+createOrder(memberId, productId, quantity):
+
+1. userRepository.findById(memberId)            ← User 조회
+2. productRepository.findById(productId)        ← 상태/존재 확인 (락 없이)
+3. productRepository.findByIdWithLock(productId) ← SELECT FOR UPDATE (락 획득)
+4. product.decreaseStock(quantity)              ← 재고 검증 + 차감
+5. Order order = Order.create(user, unitPrice * quantity)
+6. orderRepository.save(order)                 ← INSERT order (ID 확보)
+7. OrderItem item = OrderItem.create(order, product, quantity)
+   └─ unitPrice = product.getPrice() (락 보유 중이므로 일관성 보장)
+8. orderItemRepository.save(item)              ← INSERT order_item (ADR-006: 단방향, 별도 저장)
+9. Commit (락 해제)
+```
+
+> **주의**: 단계 3 이전에 Product를 락 없이 한 번 조회하는 이유는 상태 검증(ACTIVE 여부 등)과 존재 확인을 위해서다. 실제 재고 차감은 반드시 락을 잡은 단계 3 이후에만 수행한다.
+
+> **가격 스냅샷**: unitPrice는 락 획득 이후 읽은 `product.getPrice()`를 사용한다. 락 획득 전 가격을 사용하면 가격 변경과의 TOCTOU 문제가 발생할 수 있다.
+
+### 주문 취소 (`cancelOrder`)
+
+```
+@Transactional
+cancelOrder(memberId, orderId, reason):
+
+1. orderRepository.findByIdAndUser(orderId, user)     ← 권한 검증 + 조회
+2. order.cancel(reason)                              ← RESERVED 검증 + 상태 CANCELLED + cancelledAt 기록
+3. OrderItem item = orderItemRepository.findByOrder(order) ← 아이템 조회 (ADR-006: 단방향)
+4. productRepository.findByIdWithLock(item.getProduct().getId()) ← SELECT FOR UPDATE
+5. product.restoreStock(item.getQuantity())          ← 재고 복구
+6. Commit (락 해제)
+```
+
+> **재고 복구에도 비관적 락 사용**: 취소 + 동시 주문이 교차하는 경우 재고 일관성 보장. ADR-005 원칙 연장.
+
+---
+
+## 5. 비즈니스 규칙
+
+| 규칙 | 내용 |
+|------|------|
+| 중복 주문 | 제한 없음 — 동일 회원이 동일 상품을 여러 번 예약 가능 |
+| 최소 수량 | 1 이상 (컨트롤러 `@Min(1)` 검증) |
+| 취소 가능 상태 | RESERVED만 (이번 마일스톤) |
+| 재고 부족 | `INSUFFICIENT_STOCK` 에러 즉시 반환 |
+| 권한 검증 | `findByIdAndMember`로 타인 주문 접근 차단 |
+| 가격 스냅샷 | unitPrice는 주문 시점 고정, 이후 상품 가격 변경과 무관 |
+
+---
+
+## 6. 에러 코드 (OrderErrorCode)
+
+| 코드 | 상황 |
+|------|------|
+| ORDER_NOT_FOUND | 주문 없음 또는 접근 권한 없음 |
+| ORDER_NOT_CANCELLABLE | RESERVED 상태가 아닌 주문 취소 시도 |
+
+기존 `ProductErrorCode.INSUFFICIENT_STOCK`, `ProductErrorCode.PRODUCT_NOT_FOUND`도 활용.
+
+---
+
+## 7. 이슈 구성
+
+| 이슈 | 내용 |
+|------|------|
+| 이슈 1 | Order + OrderItem 엔티티, OrderStatus enum |
+| 이슈 2 | OrderRepository + OrderItemRepository  |
+| 이슈 3 | OrderService (생성/취소/조회 비즈니스 로직) |
+| 이슈 4 | 고객용 OrderController + DTO |
+| 이슈 5 | 관리자용 AdminOrderController + DTO |

--- a/src/main/java/com/gongu/server/domain/order/entity/Order.java
+++ b/src/main/java/com/gongu/server/domain/order/entity/Order.java
@@ -4,7 +4,6 @@ import com.gongu.server.domain.user.entity.User;
 import com.gongu.server.global.common.BaseEntity;
 import com.gongu.server.global.exception.BusinessException;
 import com.gongu.server.global.exception.errorcode.OrderErrorCode;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -15,15 +14,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -52,9 +48,6 @@ public class Order extends BaseEntity {
     @Column(name = "cancel_reason", length = 255)
     private String cancelReason;
 
-    @OneToMany(mappedBy = "order", cascade = CascadeType.PERSIST)
-    private List<OrderItem> orderItems = new ArrayList<>();
-
     public static Order create(User user, long totalPrice) {
         if (user == null) {
             throw new BusinessException(OrderErrorCode.INVALID_ORDER_DATA);
@@ -66,12 +59,7 @@ public class Order extends BaseEntity {
         order.user = user;
         order.totalPrice = totalPrice;
         order.status = OrderStatus.RESERVED;
-        order.orderItems = new ArrayList<>();
         return order;
-    }
-
-    public void addOrderItem(OrderItem item) {
-        this.orderItems.add(item);
     }
 
     public void cancel(String reason) {

--- a/src/main/java/com/gongu/server/domain/order/entity/Order.java
+++ b/src/main/java/com/gongu/server/domain/order/entity/Order.java
@@ -56,6 +56,9 @@ public class Order extends BaseEntity {
     private List<OrderItem> orderItems = new ArrayList<>();
 
     public static Order create(User user, long totalPrice) {
+        if (user == null) {
+            throw new BusinessException(OrderErrorCode.INVALID_ORDER_DATA);
+        }
         if (totalPrice <= 0) {
             throw new BusinessException(OrderErrorCode.INVALID_ORDER_DATA);
         }
@@ -65,6 +68,10 @@ public class Order extends BaseEntity {
         order.status = OrderStatus.RESERVED;
         order.orderItems = new ArrayList<>();
         return order;
+    }
+
+    public void addOrderItem(OrderItem item) {
+        this.orderItems.add(item);
     }
 
     public void cancel(String reason) {

--- a/src/main/java/com/gongu/server/domain/order/entity/Order.java
+++ b/src/main/java/com/gongu/server/domain/order/entity/Order.java
@@ -60,8 +60,6 @@ public class Order extends BaseEntity {
         order.user = user;
         order.totalPrice = totalPrice;
         order.status = OrderStatus.RESERVED;
-        order.cancelledAt = null;
-        order.cancelReason = null;
         return order;
     }
 
@@ -76,14 +74,14 @@ public class Order extends BaseEntity {
 
     public void pay() {
         if (this.status != OrderStatus.RESERVED) {
-            throw new BusinessException(OrderErrorCode.CANCEL_NOT_ALLOWED);
+            throw new BusinessException(OrderErrorCode.PAY_NOT_ALLOWED);
         }
         this.status = OrderStatus.PAID;
     }
 
     public void arrive() {
         if (this.status != OrderStatus.PAID) {
-            throw new BusinessException(OrderErrorCode.CANCEL_NOT_ALLOWED);
+            throw new BusinessException(OrderErrorCode.ARRIVE_NOT_ALLOWED);
         }
         this.status = OrderStatus.ARRIVED;
     }

--- a/src/main/java/com/gongu/server/domain/order/entity/Order.java
+++ b/src/main/java/com/gongu/server/domain/order/entity/Order.java
@@ -1,0 +1,97 @@
+package com.gongu.server.domain.order.entity;
+
+import com.gongu.server.domain.user.entity.User;
+import com.gongu.server.global.common.BaseEntity;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.OrderErrorCode;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "orders")
+public class Order extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OrderStatus status;
+
+    @Column(name = "total_price", nullable = false)
+    private Long totalPrice;
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
+
+    @Column(name = "cancel_reason", length = 255)
+    private String cancelReason;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.PERSIST)
+    private List<OrderItem> orderItems = new ArrayList<>();
+
+    public static Order create(User user, long totalPrice) {
+        Order order = new Order();
+        order.user = user;
+        order.totalPrice = totalPrice;
+        order.status = OrderStatus.RESERVED;
+        order.cancelledAt = null;
+        order.cancelReason = null;
+        return order;
+    }
+
+    public void cancel(String reason) {
+        if (this.status != OrderStatus.RESERVED) {
+            throw new BusinessException(OrderErrorCode.CANCEL_NOT_ALLOWED);
+        }
+        this.status = OrderStatus.CANCELLED;
+        this.cancelledAt = LocalDateTime.now();
+        this.cancelReason = reason;
+    }
+
+    public void pay() {
+        if (this.status != OrderStatus.RESERVED) {
+            throw new BusinessException(OrderErrorCode.CANCEL_NOT_ALLOWED);
+        }
+        this.status = OrderStatus.PAID;
+    }
+
+    public void arrive() {
+        if (this.status != OrderStatus.PAID) {
+            throw new BusinessException(OrderErrorCode.CANCEL_NOT_ALLOWED);
+        }
+        this.status = OrderStatus.ARRIVED;
+    }
+
+    public void receive() {
+        if (this.status != OrderStatus.ARRIVED) {
+            throw new BusinessException(OrderErrorCode.RECEIVE_NOT_ALLOWED);
+        }
+        this.status = OrderStatus.RECEIVED;
+    }
+}

--- a/src/main/java/com/gongu/server/domain/order/entity/Order.java
+++ b/src/main/java/com/gongu/server/domain/order/entity/Order.java
@@ -56,10 +56,14 @@ public class Order extends BaseEntity {
     private List<OrderItem> orderItems = new ArrayList<>();
 
     public static Order create(User user, long totalPrice) {
+        if (totalPrice <= 0) {
+            throw new BusinessException(OrderErrorCode.INVALID_ORDER_DATA);
+        }
         Order order = new Order();
         order.user = user;
         order.totalPrice = totalPrice;
         order.status = OrderStatus.RESERVED;
+        order.orderItems = new ArrayList<>();
         return order;
     }
 

--- a/src/main/java/com/gongu/server/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/gongu/server/domain/order/entity/OrderItem.java
@@ -1,0 +1,56 @@
+package com.gongu.server.domain.order.entity;
+
+import com.gongu.server.domain.product.entity.Product;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "order_items")
+public class OrderItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Column(name = "unit_price", nullable = false)
+    private Long unitPrice;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static OrderItem create(Order order, Product product, int quantity) {
+        OrderItem item = new OrderItem();
+        item.order = order;
+        item.product = product;
+        item.quantity = quantity;
+        item.unitPrice = product.getPrice();
+        return item;
+    }
+}

--- a/src/main/java/com/gongu/server/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/gongu/server/domain/order/entity/OrderItem.java
@@ -36,7 +36,7 @@ public class OrderItem {
     private Product product;
 
     @Column(nullable = false)
-    private int quantity;
+    private long quantity;
 
     @Column(name = "unit_price", nullable = false)
     private Long unitPrice;
@@ -45,7 +45,7 @@ public class OrderItem {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    public static OrderItem create(Order order, Product product, int quantity) {
+    public static OrderItem create(Order order, Product product, long quantity) {
         OrderItem item = new OrderItem();
         item.order = order;
         item.product = product;

--- a/src/main/java/com/gongu/server/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/gongu/server/domain/order/entity/OrderItem.java
@@ -1,6 +1,8 @@
 package com.gongu.server.domain.order.entity;
 
 import com.gongu.server.domain.product.entity.Product;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.OrderErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -49,11 +51,15 @@ public class OrderItem {
     private LocalDateTime createdAt;
 
     public static OrderItem create(Order order, Product product, Long quantity) {
+        if (quantity == null || quantity <= 0) {
+            throw new BusinessException(OrderErrorCode.INVALID_ORDER_DATA);
+        }
         OrderItem item = new OrderItem();
-        item.order = order;
         item.product = product;
         item.quantity = quantity;
         item.unitPrice = product.getPrice();
+        order.addOrderItem(item);
+        item.order = order;
         return item;
     }
 }

--- a/src/main/java/com/gongu/server/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/gongu/server/domain/order/entity/OrderItem.java
@@ -55,11 +55,10 @@ public class OrderItem {
             throw new BusinessException(OrderErrorCode.INVALID_ORDER_DATA);
         }
         OrderItem item = new OrderItem();
+        item.order = order;
         item.product = product;
         item.quantity = quantity;
         item.unitPrice = product.getPrice();
-        order.addOrderItem(item);
-        item.order = order;
         return item;
     }
 }

--- a/src/main/java/com/gongu/server/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/gongu/server/domain/order/entity/OrderItem.java
@@ -3,6 +3,7 @@ package com.gongu.server.domain.order.entity;
 import com.gongu.server.domain.product.entity.Product;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -13,7 +14,8 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -21,6 +23,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "order_items")
+@EntityListeners(AuditingEntityListener.class)
 public class OrderItem {
 
     @Id
@@ -36,16 +39,16 @@ public class OrderItem {
     private Product product;
 
     @Column(nullable = false)
-    private long quantity;
+    private Long quantity;
 
     @Column(name = "unit_price", nullable = false)
     private Long unitPrice;
 
-    @CreationTimestamp
+    @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    public static OrderItem create(Order order, Product product, long quantity) {
+    public static OrderItem create(Order order, Product product, Long quantity) {
         OrderItem item = new OrderItem();
         item.order = order;
         item.product = product;

--- a/src/main/java/com/gongu/server/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/gongu/server/domain/order/entity/OrderStatus.java
@@ -1,0 +1,9 @@
+package com.gongu.server.domain.order.entity;
+
+public enum OrderStatus {
+    RESERVED,
+    PAID,
+    ARRIVED,
+    RECEIVED,
+    CANCELLED
+}

--- a/src/main/java/com/gongu/server/global/exception/errorcode/OrderErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/OrderErrorCode.java
@@ -10,7 +10,8 @@ public enum OrderErrorCode implements ErrorCode {
     CANCEL_NOT_ALLOWED("ORDER_002", "취소할 수 없는 상태의 주문입니다", 409),
     RECEIVE_NOT_ALLOWED("ORDER_003", "수령할 수 없는 상태의 주문입니다", 409),
     PAY_NOT_ALLOWED("ORDER_004", "결제할 수 없는 상태의 주문입니다", 409),
-    ARRIVE_NOT_ALLOWED("ORDER_005", "입고 처리할 수 없는 상태의 주문입니다", 409);
+    ARRIVE_NOT_ALLOWED("ORDER_005", "입고 처리할 수 없는 상태의 주문입니다", 409),
+    INVALID_ORDER_DATA("ORDER_006", "유효하지 않은 주문 데이터입니다", 400);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/gongu/server/global/exception/errorcode/OrderErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/OrderErrorCode.java
@@ -8,7 +8,9 @@ public enum OrderErrorCode implements ErrorCode {
 
     ORDER_NOT_FOUND("ORDER_001", "존재하지 않는 주문입니다", 404),
     CANCEL_NOT_ALLOWED("ORDER_002", "취소할 수 없는 상태의 주문입니다", 409),
-    RECEIVE_NOT_ALLOWED("ORDER_003", "수령할 수 없는 상태의 주문입니다", 409);
+    RECEIVE_NOT_ALLOWED("ORDER_003", "수령할 수 없는 상태의 주문입니다", 409),
+    PAY_NOT_ALLOWED("ORDER_004", "결제할 수 없는 상태의 주문입니다", 409),
+    ARRIVE_NOT_ALLOWED("ORDER_005", "입고 처리할 수 없는 상태의 주문입니다", 409);
 
     private final String code;
     private final String message;


### PR DESCRIPTION
## Issue

close #72

## 작업 내용

- `OrderStatus` enum 구현 (`RESERVED, PAID, ARRIVED, RECEIVED, CANCELLED`)
- `Order` 엔티티 구현 (`orders` 테이블 매핑)
  - 정적 팩토리 `Order.create(User, long)`
  - 도메인 메서드: `cancel()`, `pay()`, `arrive()`, `receive()`
  - `@OneToMany(cascade = PERSIST)` → OrderItems
- `OrderItem` 엔티티 구현 (`order_items` 테이블 매핑)
  - 정적 팩토리 `OrderItem.create(Order, Product, Long)` — 주문 시점 unitPrice 스냅샷
  - `@CreatedDate` + `@EntityListeners` (Spring Data JPA Auditing 방식 준수)
- `OrderErrorCode`에 `PAY_NOT_ALLOWED`, `ARRIVE_NOT_ALLOWED` 추가

## 참고사항

- `pay()`, `arrive()`는 향후 결제/입고 마일스톤을 위한 선언. 이번 마일스톤에서는 호출되지 않음
- `order_items` 테이블에 `updated_at` 없음 → `BaseEntity` 미상속, `@CreatedDate` 직접 선언