### PR TITLE
[FEAT] OrderRepository, OrderItemRepository (#73)

### DIFF
--- a/src/main/java/com/gongu/server/domain/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/gongu/server/domain/order/repository/OrderItemRepository.java
@@ -1,0 +1,12 @@
+package com.gongu.server.domain.order.repository;
+
+import com.gongu.server.domain.order.entity.Order;
+import com.gongu.server.domain.order.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+
+    List<OrderItem> findAllByOrder(Order order);
+}

--- a/src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java
@@ -18,15 +18,9 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     Optional<Order> findByIdAndUser(Long orderId, User user);
 
-    @Query(value = "SELECT o FROM Order o WHERE o.user = :user ORDER BY o.createdAt DESC",
-           countQuery = "SELECT COUNT(o) FROM Order o WHERE o.user = :user")
-    Page<Order> findAllByUserOrderByCreatedAtDesc(@Param("user") User user, Pageable pageable);
+    Page<Order> findAllByUserOrderByCreatedAtDesc(User user, Pageable pageable);
 
-    @Query(value = "SELECT o FROM Order o WHERE o.user = :user AND o.status = :status ORDER BY o.createdAt DESC",
-           countQuery = "SELECT COUNT(o) FROM Order o WHERE o.user = :user AND o.status = :status")
-    Page<Order> findAllByUserAndStatusOrderByCreatedAtDesc(@Param("user") User user,
-                                                           @Param("status") OrderStatus status,
-                                                           Pageable pageable);
+    Page<Order> findAllByUserAndStatusOrderByCreatedAtDesc(User user, OrderStatus status, Pageable pageable);
 
     @Query(value = "SELECT o FROM Order o WHERE o.id IN (SELECT oi.order.id FROM OrderItem oi WHERE oi.product = :product)",
            countQuery = "SELECT COUNT(o) FROM Order o WHERE o.id IN (SELECT oi.order.id FROM OrderItem oi WHERE oi.product = :product)")

--- a/src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java
@@ -1,0 +1,38 @@
+package com.gongu.server.domain.order.repository;
+
+import com.gongu.server.domain.order.entity.Order;
+import com.gongu.server.domain.order.entity.OrderStatus;
+import com.gongu.server.domain.product.entity.Product;
+import com.gongu.server.domain.user.entity.User;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    Optional<Order> findByIdAndUser(Long orderId, User user);
+
+    @Query(value = "SELECT o FROM Order o WHERE o.user = :user ORDER BY o.createdAt DESC",
+           countQuery = "SELECT COUNT(o) FROM Order o WHERE o.user = :user")
+    Page<Order> findAllByUserOrderByCreatedAtDesc(@Param("user") User user, Pageable pageable);
+
+    @Query(value = "SELECT o FROM Order o WHERE o.user = :user AND o.status = :status ORDER BY o.createdAt DESC",
+           countQuery = "SELECT COUNT(o) FROM Order o WHERE o.user = :user AND o.status = :status")
+    Page<Order> findAllByUserAndStatusOrderByCreatedAtDesc(@Param("user") User user,
+                                                           @Param("status") OrderStatus status,
+                                                           Pageable pageable);
+
+    @Query(value = "SELECT o FROM Order o WHERE o.id IN (SELECT oi.order.id FROM OrderItem oi WHERE oi.product = :product)",
+           countQuery = "SELECT COUNT(o) FROM Order o WHERE o.id IN (SELECT oi.order.id FROM OrderItem oi WHERE oi.product = :product)")
+    Page<Order> findAllByProduct(@Param("product") Product product, Pageable pageable);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT o FROM Order o WHERE o.id = :id")
+    Optional<Order> findByIdWithLock(@Param("id") Long id);
+}

--- a/src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java
@@ -22,7 +22,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     Page<Order> findAllByUserAndStatusOrderByCreatedAtDesc(User user, OrderStatus status, Pageable pageable);
 
-    @Query(value = "SELECT o FROM Order o WHERE o.id IN (SELECT oi.order.id FROM OrderItem oi WHERE oi.product = :product)",
+    @Query(value = "SELECT o FROM Order o WHERE o.id IN (SELECT oi.order.id FROM OrderItem oi WHERE oi.product = :product) ORDER BY o.createdAt DESC",
            countQuery = "SELECT COUNT(o) FROM Order o WHERE o.id IN (SELECT oi.order.id FROM OrderItem oi WHERE oi.product = :product)")
     Page<Order> findAllByProduct(@Param("product") Product product, Pageable pageable);
 


### PR DESCRIPTION
## Issue ID
close #73

## 작업 내용

### OrderRepository
- `findByIdAndUser` — Derived query, 권한 검증 포함 단건 조회
- `findAllByUserOrderByCreatedAtDesc` — `@Query` + countQuery, 내 주문 목록
- `findAllByUserAndStatusOrderByCreatedAtDesc` — `@Query` + countQuery, 상태 필터 조회
- `findAllByProduct` — `@Query` 서브쿼리 + countQuery, 관리자 상품별 주문 (Order→OrderItem 단방향 구조 대응)
- `findByIdWithLock` — `@Lock(PESSIMISTIC_WRITE)`, 비관적 락 조회 (ADR-005)

### OrderItemRepository
- `findAllByOrder` — Derived query, 주문 아이템 목록

## 참고 사항
- Order 엔티티에 OrderItem 컬렉션 없음 (ADR-006 단방향) → `findAllByProduct`는 서브쿼리로 구현
- 페이지네이션 반환 타입(Page vs Slice) 논의는 #79에서 별도 진행