### PR TITLE
[FEAT] OrderService 구현 (#74)

### DIFF
--- a/src/main/java/com/gongu/server/domain/order/dto/response/OrderDetailResponse.java
+++ b/src/main/java/com/gongu/server/domain/order/dto/response/OrderDetailResponse.java
@@ -1,0 +1,40 @@
+package com.gongu.server.domain.order.dto.response;
+
+import com.gongu.server.domain.order.entity.Order;
+import com.gongu.server.domain.order.entity.OrderItem;
+import com.gongu.server.domain.order.entity.OrderStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderDetailResponse {
+
+    private Long orderId;
+    private OrderStatus status;
+    private Long totalPrice;
+    private LocalDateTime cancelledAt;
+    private String cancelReason;
+    private LocalDateTime createdAt;
+    private List<OrderItemResponse> items;
+
+    public static OrderDetailResponse of(Order order, List<OrderItem> items) {
+        return OrderDetailResponse.builder()
+                .orderId(order.getId())
+                .status(order.getStatus())
+                .totalPrice(order.getTotalPrice())
+                .cancelledAt(order.getCancelledAt())
+                .cancelReason(order.getCancelReason())
+                .createdAt(order.getCreatedAt())
+                .items(items.stream()
+                        .map(OrderItemResponse::of)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/gongu/server/domain/order/dto/response/OrderItemResponse.java
+++ b/src/main/java/com/gongu/server/domain/order/dto/response/OrderItemResponse.java
@@ -1,0 +1,27 @@
+package com.gongu.server.domain.order.dto.response;
+
+import com.gongu.server.domain.order.entity.OrderItem;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderItemResponse {
+
+    private Long productId;
+    private String productName;
+    private Long quantity;
+    private Long unitPrice;
+
+    public static OrderItemResponse of(OrderItem item) {
+        return OrderItemResponse.builder()
+                .productId(item.getProduct().getId())
+                .productName(item.getProduct().getName())
+                .quantity(item.getQuantity())
+                .unitPrice(item.getUnitPrice())
+                .build();
+    }
+}

--- a/src/main/java/com/gongu/server/domain/order/dto/response/OrderSummaryResponse.java
+++ b/src/main/java/com/gongu/server/domain/order/dto/response/OrderSummaryResponse.java
@@ -1,0 +1,35 @@
+package com.gongu.server.domain.order.dto.response;
+
+import com.gongu.server.domain.order.entity.Order;
+import com.gongu.server.domain.order.entity.OrderItem;
+import com.gongu.server.domain.order.entity.OrderStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderSummaryResponse {
+
+    private Long orderId;
+    private String productName;
+    private Long quantity;
+    private Long totalPrice;
+    private OrderStatus status;
+    private LocalDateTime createdAt;
+
+    public static OrderSummaryResponse of(Order order, OrderItem item) {
+        return OrderSummaryResponse.builder()
+                .orderId(order.getId())
+                .productName(item.getProduct().getName())
+                .quantity(item.getQuantity())
+                .totalPrice(order.getTotalPrice())
+                .status(order.getStatus())
+                .createdAt(order.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java
@@ -3,6 +3,7 @@ package com.gongu.server.domain.order.repository;
 import com.gongu.server.domain.order.entity.Order;
 import com.gongu.server.domain.order.entity.OrderStatus;
 import com.gongu.server.domain.product.entity.Product;
+import com.gongu.server.domain.store.entity.Store;
 import com.gongu.server.domain.user.entity.User;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
@@ -25,6 +26,10 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     @Query(value = "SELECT o FROM Order o WHERE o.id IN (SELECT oi.order.id FROM OrderItem oi WHERE oi.product = :product) ORDER BY o.createdAt DESC",
            countQuery = "SELECT COUNT(o) FROM Order o WHERE o.id IN (SELECT oi.order.id FROM OrderItem oi WHERE oi.product = :product)")
     Page<Order> findAllByProduct(@Param("product") Product product, Pageable pageable);
+
+    @Query(value = "SELECT o FROM Order o WHERE o.user = :user AND o.id IN (SELECT oi.order.id FROM OrderItem oi WHERE oi.product.store = :store) ORDER BY o.createdAt DESC",
+           countQuery = "SELECT COUNT(o) FROM Order o WHERE o.user = :user AND o.id IN (SELECT oi.order.id FROM OrderItem oi WHERE oi.product.store = :store)")
+    Page<Order> findAllByUserAndStore(@Param("user") User user, @Param("store") Store store, Pageable pageable);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT o FROM Order o WHERE o.id = :id")

--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -68,9 +68,8 @@ public class OrderService {
         if (!order.getUser().getId().equals(user.getId())) {
             throw new BusinessException(OrderErrorCode.ORDER_NOT_FOUND);
         }
-        if (order.getStatus() != OrderStatus.RESERVED) {
-            throw new BusinessException(OrderErrorCode.CANCEL_NOT_ALLOWED);
-        }
+
+        order.cancel(reason);
 
         List<OrderItem> items = orderItemRepository.findAllByOrder(order);
         items.stream()
@@ -80,8 +79,6 @@ public class OrderService {
                             .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
                     product.restoreStock(Math.toIntExact(item.getQuantity()));
                 });
-
-        order.cancel(reason);
     }
 
     public Page<OrderSummaryResponse> getMyOrders(Long userId, OrderStatus status, Pageable pageable) {

--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -94,7 +94,8 @@ public class OrderService {
 
         return orders.map(order -> {
             List<OrderItem> items = orderItemRepository.findAllByOrder(order);
-            return OrderSummaryResponse.of(order, items.isEmpty() ? null : items.get(0));
+            return OrderSummaryResponse.of(order, items.stream().findFirst()
+                    .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_ITEM_NOT_FOUND)));
         });
     }
 
@@ -119,7 +120,8 @@ public class OrderService {
         Page<Order> orders = orderRepository.findAllByProduct(product, pageable);
         return orders.map(order -> {
             List<OrderItem> items = orderItemRepository.findAllByOrder(order);
-            return OrderSummaryResponse.of(order, items.isEmpty() ? null : items.get(0));
+            return OrderSummaryResponse.of(order, items.stream().findFirst()
+                    .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_ITEM_NOT_FOUND)));
         });
     }
 
@@ -133,7 +135,8 @@ public class OrderService {
         Page<Order> orders = orderRepository.findAllByUserAndStore(user, storeAdmin.getStore(), pageable);
         return orders.map(order -> {
             List<OrderItem> items = orderItemRepository.findAllByOrder(order);
-            return OrderSummaryResponse.of(order, items.isEmpty() ? null : items.get(0));
+            return OrderSummaryResponse.of(order, items.stream().findFirst()
+                    .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_ITEM_NOT_FOUND)));
         });
     }
 }

--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -63,8 +63,11 @@ public class OrderService {
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        Order order = orderRepository.findByIdAndUser(orderId, user)
+        Order order = orderRepository.findByIdWithLock(orderId)
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+        if (!order.getUser().getId().equals(user.getId())) {
+            throw new BusinessException(OrderErrorCode.ORDER_NOT_FOUND);
+        }
 
         List<OrderItem> items = orderItemRepository.findAllByOrder(order);
         items.stream()
@@ -121,13 +124,13 @@ public class OrderService {
     }
 
     public Page<OrderSummaryResponse> getOrdersByMember(Long storeAdminId, Long memberId, Pageable pageable) {
-        storeAdminRepository.findByIdAndDeletedAtIsNull(storeAdminId)
+        StoreAdmin storeAdmin = storeAdminRepository.findByIdAndDeletedAtIsNull(storeAdminId)
                 .orElseThrow(() -> new BusinessException(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
 
         User user = userRepository.findByIdAndDeletedAtIsNull(memberId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        Page<Order> orders = orderRepository.findAllByUserOrderByCreatedAtDesc(user, pageable);
+        Page<Order> orders = orderRepository.findAllByUserAndStore(user, storeAdmin.getStore(), pageable);
         return orders.map(order -> {
             List<OrderItem> items = orderItemRepository.findAllByOrder(order);
             return OrderSummaryResponse.of(order, items.isEmpty() ? null : items.get(0));

--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -68,6 +68,9 @@ public class OrderService {
         if (!order.getUser().getId().equals(user.getId())) {
             throw new BusinessException(OrderErrorCode.ORDER_NOT_FOUND);
         }
+        if (order.getStatus() != OrderStatus.RESERVED) {
+            throw new BusinessException(OrderErrorCode.CANCEL_NOT_ALLOWED);
+        }
 
         List<OrderItem> items = orderItemRepository.findAllByOrder(order);
         items.stream()

--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -1,0 +1,72 @@
+package com.gongu.server.domain.order.service;
+
+import com.gongu.server.domain.order.dto.response.OrderDetailResponse;
+import com.gongu.server.domain.order.entity.Order;
+import com.gongu.server.domain.order.entity.OrderItem;
+import com.gongu.server.domain.order.repository.OrderItemRepository;
+import com.gongu.server.domain.order.repository.OrderRepository;
+import com.gongu.server.domain.product.entity.Product;
+import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.user.entity.User;
+import com.gongu.server.domain.user.repository.UserRepository;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.OrderErrorCode;
+import com.gongu.server.global.exception.errorcode.ProductErrorCode;
+import com.gongu.server.global.exception.errorcode.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+
+    private final UserRepository userRepository;
+    private final ProductRepository productRepository;
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+
+    @Transactional
+    public OrderDetailResponse createOrder(Long userId, Long productId, int quantity) {
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        Product product = productRepository.findByIdWithLock(productId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        product.decreaseStock(quantity);
+        long totalPrice = (long) product.getPrice() * quantity;
+
+        Order order = Order.create(user, totalPrice);
+        orderRepository.save(order);
+
+        OrderItem item = OrderItem.create(order, product, Long.valueOf(quantity));
+        orderItemRepository.save(item);
+
+        return OrderDetailResponse.of(order, List.of(item));
+    }
+
+    @Transactional
+    public void cancelOrder(Long userId, Long orderId, String reason) {
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        Order order = orderRepository.findByIdAndUser(orderId, user)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        List<OrderItem> items = orderItemRepository.findAllByOrder(order);
+        items.stream()
+                .sorted(Comparator.comparingLong(item -> item.getProduct().getId()))
+                .forEach(item -> {
+                    Product product = productRepository.findByIdWithLock(item.getProduct().getId())
+                            .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+                    product.restoreStock(Math.toIntExact(item.getQuantity()));
+                });
+
+        order.cancel(reason);
+    }
+}

--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -1,19 +1,26 @@
 package com.gongu.server.domain.order.service;
 
 import com.gongu.server.domain.order.dto.response.OrderDetailResponse;
+import com.gongu.server.domain.order.dto.response.OrderSummaryResponse;
 import com.gongu.server.domain.order.entity.Order;
 import com.gongu.server.domain.order.entity.OrderItem;
+import com.gongu.server.domain.order.entity.OrderStatus;
 import com.gongu.server.domain.order.repository.OrderItemRepository;
 import com.gongu.server.domain.order.repository.OrderRepository;
 import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.store.entity.StoreAdmin;
+import com.gongu.server.domain.store.repository.StoreAdminRepository;
 import com.gongu.server.domain.user.entity.User;
 import com.gongu.server.domain.user.repository.UserRepository;
 import com.gongu.server.global.exception.BusinessException;
 import com.gongu.server.global.exception.errorcode.OrderErrorCode;
 import com.gongu.server.global.exception.errorcode.ProductErrorCode;
+import com.gongu.server.global.exception.errorcode.StoreErrorCode;
 import com.gongu.server.global.exception.errorcode.UserErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +36,7 @@ public class OrderService {
     private final ProductRepository productRepository;
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
+    private final StoreAdminRepository storeAdminRepository;
 
     @Transactional
     public OrderDetailResponse createOrder(Long userId, Long productId, int quantity) {
@@ -68,5 +76,61 @@ public class OrderService {
                 });
 
         order.cancel(reason);
+    }
+
+    public Page<OrderSummaryResponse> getMyOrders(Long userId, OrderStatus status, Pageable pageable) {
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        Page<Order> orders;
+        if (status == null) {
+            orders = orderRepository.findAllByUserOrderByCreatedAtDesc(user, pageable);
+        } else {
+            orders = orderRepository.findAllByUserAndStatusOrderByCreatedAtDesc(user, status, pageable);
+        }
+
+        return orders.map(order -> {
+            List<OrderItem> items = orderItemRepository.findAllByOrder(order);
+            return OrderSummaryResponse.of(order, items.isEmpty() ? null : items.get(0));
+        });
+    }
+
+    public OrderDetailResponse getOrder(Long userId, Long orderId) {
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        Order order = orderRepository.findByIdAndUser(orderId, user)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        List<OrderItem> items = orderItemRepository.findAllByOrder(order);
+        return OrderDetailResponse.of(order, items);
+    }
+
+    public Page<OrderSummaryResponse> getOrdersByProduct(Long storeAdminId, Long productId, Pageable pageable) {
+        StoreAdmin storeAdmin = storeAdminRepository.findByIdAndDeletedAtIsNull(storeAdminId)
+                .orElseThrow(() -> new BusinessException(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
+
+        Product product = productRepository.findByIdAndStore(productId, storeAdmin.getStore())
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        Page<Order> orders = orderRepository.findAllByProduct(product, pageable);
+        return orders.map(order -> {
+            List<OrderItem> items = orderItemRepository.findAllByOrder(order);
+            return OrderSummaryResponse.of(order, items.isEmpty() ? null : items.get(0));
+        });
+    }
+
+    public Page<OrderSummaryResponse> getOrdersByMember(Long storeAdminId, Long memberId, Pageable pageable) {
+        storeAdminRepository.findByIdAndDeletedAtIsNull(storeAdminId)
+                .orElseThrow(() -> new BusinessException(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
+
+        User user = userRepository.findByIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        Page<Order> orders = orderRepository.findAllByUserOrderByCreatedAtDesc(user, pageable);
+        return orders.map(order -> {
+            List<OrderItem> items = orderItemRepository.findAllByOrder(order);
+            return OrderSummaryResponse.of(order, items.isEmpty() ? null : items.get(0));
+        });
     }
 }

--- a/src/main/java/com/gongu/server/global/exception/errorcode/OrderErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/OrderErrorCode.java
@@ -11,7 +11,8 @@ public enum OrderErrorCode implements ErrorCode {
     RECEIVE_NOT_ALLOWED("ORDER_003", "수령할 수 없는 상태의 주문입니다", 409),
     PAY_NOT_ALLOWED("ORDER_004", "결제할 수 없는 상태의 주문입니다", 409),
     ARRIVE_NOT_ALLOWED("ORDER_005", "입고 처리할 수 없는 상태의 주문입니다", 409),
-    INVALID_ORDER_DATA("ORDER_006", "유효하지 않은 주문 데이터입니다", 400);
+    INVALID_ORDER_DATA("ORDER_006", "유효하지 않은 주문 데이터입니다", 400),
+    ORDER_ITEM_NOT_FOUND("ORDER_007", "주문 항목이 존재하지 않습니다", 500);
 
     private final String code;
     private final String message;


### PR DESCRIPTION
## Issue ID
close #74

## 작업 내용
- `OrderDetailResponse`, `OrderSummaryResponse`, `OrderItemResponse` 응답 DTO 추가
- `OrderService.createOrder`: 비관적 락으로 재고 차감 후 주문 생성
- `OrderService.cancelOrder`: 재고 복원(productId 오름차순 정렬 후 락 획득) 후 주문 취소
- `OrderService.getMyOrders`: 상태 필터 옵션 포함 내 주문 목록 페이지네이션 조회
- `OrderService.getOrder`: 주문 상세 조회 (권한 검증 포함)
- `OrderService.getOrdersByProduct`: 관리자 상품별 주문 조회 (매장 소유권 검증)
- `OrderService.getOrdersByMember`: 관리자 회원별 주문 조회 (StoreAdmin 존재 검증)

## 참고사항
- ADR-005: 재고 동시성 제어 — 비관적 락(`findByIdWithLock`) 적용
- ADR-006: Order → OrderItem 단방향 설계 — `orderItemRepository.findAllByOrder()` 사용
- cancelOrder 데드락 방지: items를 productId 오름차순 정렬 후 순서 보장 락 획득
- totalPrice 오버플로 방지: `(long) product.getPrice() * quantity`