### PR TITLE
[TEST] 누락된 Service 단위 테스트 작성 — Order, Product, Auth (#88)

### DIFF
--- a/src/test/java/com/gongu/server/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,279 @@
+package com.gongu.server.domain.auth.service;
+
+import com.gongu.server.domain.auth.client.KakaoApiClient;
+import com.gongu.server.domain.auth.client.dto.KakaoUserInfo;
+import com.gongu.server.domain.auth.dto.request.StoreAdminLoginRequest;
+import com.gongu.server.domain.auth.dto.request.TokenRefreshRequest;
+import com.gongu.server.domain.auth.dto.response.AccessTokenResponse;
+import com.gongu.server.domain.auth.dto.response.TokenResponse;
+import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.domain.store.entity.StoreAdmin;
+import com.gongu.server.domain.store.repository.StoreAdminRepository;
+import com.gongu.server.domain.user.entity.SocialProvider;
+import com.gongu.server.domain.user.entity.User;
+import com.gongu.server.domain.user.entity.UserSocial;
+import com.gongu.server.domain.user.repository.UserRepository;
+import com.gongu.server.domain.user.repository.UserSocialRepository;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.AuthErrorCode;
+import com.gongu.server.global.security.Role;
+import com.gongu.server.global.security.jwt.JwtProvider;
+import com.gongu.server.global.security.jwt.RefreshTokenStore;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private KakaoApiClient kakaoApiClient;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserSocialRepository userSocialRepository;
+
+    @Mock
+    private StoreAdminRepository storeAdminRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private RefreshTokenStore refreshTokenStore;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    @DisplayName("storeAdminLogin_이메일_비밀번호_일치_TokenResponse_반환")
+    void storeAdminLogin_이메일_비밀번호_일치_TokenResponse_반환() {
+        // given
+        StoreAdmin storeAdmin = createStoreAdmin(1L);
+        StoreAdminLoginRequest request = new StoreAdminLoginRequest("admin@gongu.com", "password");
+
+        given(storeAdminRepository.findByEmailAndIsActiveTrueAndDeletedAtIsNull("admin@gongu.com"))
+                .willReturn(Optional.of(storeAdmin));
+        given(passwordEncoder.matches("password", "encodedPassword")).willReturn(true);
+        given(jwtProvider.generateAccessToken(1L, Role.STORE_ADMIN)).willReturn("access-token");
+        given(jwtProvider.generateRefreshToken(1L, Role.STORE_ADMIN)).willReturn("refresh-token");
+
+        // when
+        TokenResponse response = authService.storeAdminLogin(request);
+
+        // then
+        assertThat(response.accessToken()).isEqualTo("access-token");
+        assertThat(response.refreshToken()).isEqualTo("refresh-token");
+        verify(refreshTokenStore).save(1L, Role.STORE_ADMIN, "refresh-token");
+    }
+
+    @Test
+    @DisplayName("storeAdminLogin_존재하지_않는_이메일_INVALID_CREDENTIALS_예외")
+    void storeAdminLogin_존재하지_않는_이메일_INVALID_CREDENTIALS_예외() {
+        // given
+        StoreAdminLoginRequest request = new StoreAdminLoginRequest("missing@gongu.com", "password");
+
+        given(storeAdminRepository.findByEmailAndIsActiveTrueAndDeletedAtIsNull("missing@gongu.com"))
+                .willReturn(Optional.empty());
+        given(passwordEncoder.matches(eq("password"), any(String.class))).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> authService.storeAdminLogin(request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(AuthErrorCode.INVALID_CREDENTIALS));
+        verify(refreshTokenStore, never()).save(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("storeAdminLogin_비밀번호_불일치_INVALID_CREDENTIALS_예외")
+    void storeAdminLogin_비밀번호_불일치_INVALID_CREDENTIALS_예외() {
+        // given
+        StoreAdmin storeAdmin = createStoreAdmin(1L);
+        StoreAdminLoginRequest request = new StoreAdminLoginRequest("admin@gongu.com", "wrongPassword");
+
+        given(storeAdminRepository.findByEmailAndIsActiveTrueAndDeletedAtIsNull("admin@gongu.com"))
+                .willReturn(Optional.of(storeAdmin));
+        given(passwordEncoder.matches("wrongPassword", "encodedPassword")).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> authService.storeAdminLogin(request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(AuthErrorCode.INVALID_CREDENTIALS));
+        verify(refreshTokenStore, never()).save(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("refreshToken_유효한_토큰_AccessTokenResponse_반환")
+    void refreshToken_유효한_토큰_AccessTokenResponse_반환() {
+        // given
+        TokenRefreshRequest request = new TokenRefreshRequest("refresh-token");
+        JwtProvider.RefreshTokenClaims claims = new JwtProvider.RefreshTokenClaims(1L, Role.MEMBER);
+
+        given(jwtProvider.parseRefreshToken("refresh-token")).willReturn(claims);
+        given(refreshTokenStore.get(1L, Role.MEMBER)).willReturn(Optional.of("refresh-token"));
+        given(jwtProvider.generateAccessToken(1L, Role.MEMBER)).willReturn("new-access-token");
+
+        // when
+        AccessTokenResponse response = authService.refreshToken(request);
+
+        // then
+        assertThat(response.accessToken()).isEqualTo("new-access-token");
+    }
+
+    @Test
+    @DisplayName("refreshToken_parseRefreshToken_JwtException_INVALID_REFRESH_TOKEN_예외")
+    void refreshToken_parseRefreshToken_JwtException_INVALID_REFRESH_TOKEN_예외() {
+        // given
+        TokenRefreshRequest request = new TokenRefreshRequest("invalid-refresh-token");
+
+        given(jwtProvider.parseRefreshToken("invalid-refresh-token"))
+                .willThrow(new JwtException("invalid token"));
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(AuthErrorCode.INVALID_REFRESH_TOKEN));
+    }
+
+    @Test
+    @DisplayName("refreshToken_Redis에_토큰_없음_INVALID_REFRESH_TOKEN_예외")
+    void refreshToken_Redis에_토큰_없음_INVALID_REFRESH_TOKEN_예외() {
+        // given
+        TokenRefreshRequest request = new TokenRefreshRequest("refresh-token");
+        JwtProvider.RefreshTokenClaims claims = new JwtProvider.RefreshTokenClaims(1L, Role.MEMBER);
+
+        given(jwtProvider.parseRefreshToken("refresh-token")).willReturn(claims);
+        given(refreshTokenStore.get(1L, Role.MEMBER)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(AuthErrorCode.INVALID_REFRESH_TOKEN));
+    }
+
+    @Test
+    @DisplayName("refreshToken_Redis_토큰과_요청_토큰_불일치_INVALID_REFRESH_TOKEN_예외")
+    void refreshToken_Redis_토큰과_요청_토큰_불일치_INVALID_REFRESH_TOKEN_예외() {
+        // given
+        TokenRefreshRequest request = new TokenRefreshRequest("refresh-token");
+        JwtProvider.RefreshTokenClaims claims = new JwtProvider.RefreshTokenClaims(1L, Role.MEMBER);
+
+        given(jwtProvider.parseRefreshToken("refresh-token")).willReturn(claims);
+        given(refreshTokenStore.get(1L, Role.MEMBER)).willReturn(Optional.of("stored-refresh-token"));
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(AuthErrorCode.INVALID_REFRESH_TOKEN));
+    }
+
+    @Test
+    @DisplayName("kakaoLogin_기존_회원_TokenResponse_반환")
+    void kakaoLogin_기존_회원_TokenResponse_반환() {
+        // given
+        KakaoUserInfo userInfo = createKakaoUserInfo(12345L, "홍길동");
+        User user = createUser(1L, "홍길동");
+        UserSocial userSocial = UserSocial.of(user, SocialProvider.KAKAO, "12345");
+
+        given(kakaoApiClient.getUserInfo("kakao-access-token")).willReturn(userInfo);
+        given(userSocialRepository.findByProviderAndSocialId(SocialProvider.KAKAO, "12345"))
+                .willReturn(Optional.of(userSocial));
+        given(jwtProvider.generateAccessToken(1L, Role.MEMBER)).willReturn("access-token");
+        given(jwtProvider.generateRefreshToken(1L, Role.MEMBER)).willReturn("refresh-token");
+
+        // when
+        TokenResponse response = authService.kakaoLogin("kakao-access-token");
+
+        // then
+        assertThat(response.accessToken()).isEqualTo("access-token");
+        assertThat(response.refreshToken()).isEqualTo("refresh-token");
+        verify(refreshTokenStore).save(1L, Role.MEMBER, "refresh-token");
+        verify(userRepository, never()).save(any(User.class));
+        verify(userSocialRepository, never()).save(any(UserSocial.class));
+    }
+
+    @Test
+    @DisplayName("kakaoLogin_신규_회원_User_UserSocial_저장_후_TokenResponse_반환")
+    void kakaoLogin_신규_회원_User_UserSocial_저장_후_TokenResponse_반환() {
+        // given
+        KakaoUserInfo userInfo = createKakaoUserInfo(12345L, "홍길동");
+
+        given(kakaoApiClient.getUserInfo("kakao-access-token")).willReturn(userInfo);
+        given(userSocialRepository.findByProviderAndSocialId(SocialProvider.KAKAO, "12345"))
+                .willReturn(Optional.empty());
+        given(userRepository.save(any(User.class))).willAnswer(invocation -> {
+            User user = invocation.getArgument(0);
+            ReflectionTestUtils.setField(user, "id", 1L);
+            return user;
+        });
+        given(userSocialRepository.save(any(UserSocial.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+        given(jwtProvider.generateAccessToken(1L, Role.MEMBER)).willReturn("access-token");
+        given(jwtProvider.generateRefreshToken(1L, Role.MEMBER)).willReturn("refresh-token");
+
+        // when
+        TokenResponse response = authService.kakaoLogin("kakao-access-token");
+
+        // then
+        assertThat(response.accessToken()).isEqualTo("access-token");
+        assertThat(response.refreshToken()).isEqualTo("refresh-token");
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        ArgumentCaptor<UserSocial> userSocialCaptor = ArgumentCaptor.forClass(UserSocial.class);
+        verify(userRepository).save(userCaptor.capture());
+        verify(userSocialRepository).save(userSocialCaptor.capture());
+        assertThat(userCaptor.getValue().getName()).isEqualTo("홍길동");
+        assertThat(userSocialCaptor.getValue().getProvider()).isEqualTo(SocialProvider.KAKAO);
+        assertThat(userSocialCaptor.getValue().getSocialId()).isEqualTo("12345");
+        verify(refreshTokenStore).save(1L, Role.MEMBER, "refresh-token");
+    }
+
+    private StoreAdmin createStoreAdmin(Long id) {
+        Store store = Store.create("테스트매장", "서울시 강남구", "02-1234-5678");
+        StoreAdmin storeAdmin = StoreAdmin.of(store, "admin@gongu.com", "encodedPassword", "관리자");
+        ReflectionTestUtils.setField(storeAdmin, "id", id);
+        return storeAdmin;
+    }
+
+    private User createUser(Long id, String name) {
+        User user = User.of(name, "010-1234-5678");
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private KakaoUserInfo createKakaoUserInfo(Long id, String nickname) {
+        return new KakaoUserInfo(
+                id,
+                new KakaoUserInfo.KakaoAccount(
+                        "user@gongu.com",
+                        new KakaoUserInfo.Profile(nickname)
+                )
+        );
+    }
+}

--- a/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
@@ -1,0 +1,472 @@
+package com.gongu.server.domain.order.service;
+
+import com.gongu.server.domain.order.dto.response.OrderDetailResponse;
+import com.gongu.server.domain.order.dto.response.OrderSummaryResponse;
+import com.gongu.server.domain.order.entity.Order;
+import com.gongu.server.domain.order.entity.OrderItem;
+import com.gongu.server.domain.order.entity.OrderStatus;
+import com.gongu.server.domain.order.repository.OrderItemRepository;
+import com.gongu.server.domain.order.repository.OrderRepository;
+import com.gongu.server.domain.product.entity.Product;
+import com.gongu.server.domain.product.entity.ProductStatus;
+import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.domain.store.entity.StoreAdmin;
+import com.gongu.server.domain.store.repository.StoreAdminRepository;
+import com.gongu.server.domain.user.entity.User;
+import com.gongu.server.domain.user.repository.UserRepository;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.OrderErrorCode;
+import com.gongu.server.global.exception.errorcode.ProductErrorCode;
+import com.gongu.server.global.exception.errorcode.StoreErrorCode;
+import com.gongu.server.global.exception.errorcode.UserErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private OrderItemRepository orderItemRepository;
+
+    @Mock
+    private StoreAdminRepository storeAdminRepository;
+
+    @InjectMocks
+    private OrderService orderService;
+
+    @Test
+    @DisplayName("createOrder_정상_주문_생성")
+    void createOrder_정상_주문_생성() {
+        // given
+        User user = user(1L);
+        Product product = product(1L, 10);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(productRepository.findByIdWithLock(1L)).willReturn(Optional.of(product));
+        given(orderRepository.save(any(Order.class))).willAnswer(inv -> inv.getArgument(0));
+        given(orderItemRepository.save(any(OrderItem.class))).willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        OrderDetailResponse result = orderService.createOrder(1L, 1L, 2);
+
+        // then
+        assertThat(result.getStatus()).isEqualTo(OrderStatus.RESERVED);
+        assertThat(result.getTotalPrice()).isEqualTo(20_000L);
+        assertThat(product.getRemainingStock()).isEqualTo(8);
+        verify(orderRepository).save(any(Order.class));
+        verify(orderItemRepository).save(any(OrderItem.class));
+    }
+
+    @Test
+    @DisplayName("createOrder_존재하지_않는_유저_USER_NOT_FOUND_예외")
+    void createOrder_존재하지_않는_유저_USER_NOT_FOUND_예외() {
+        // given
+        given(userRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.createOrder(999L, 1L, 1))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("createOrder_존재하지_않는_상품_PRODUCT_NOT_FOUND_예외")
+    void createOrder_존재하지_않는_상품_PRODUCT_NOT_FOUND_예외() {
+        // given
+        User user = user(1L);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(productRepository.findByIdWithLock(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.createOrder(1L, 999L, 1))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("cancelOrder_정상_주문_취소_및_재고_복원")
+    void cancelOrder_정상_주문_취소_및_재고_복원() {
+        // given
+        User user = user(1L);
+        Product product = product(1L, 10);
+        product.decreaseStock(2);
+        Order order = order(1L, user, 20_000L);
+        OrderItem item = orderItem(order, product, 2L);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(orderRepository.findByIdWithLock(1L)).willReturn(Optional.of(order));
+        given(orderItemRepository.findAllByOrder(order)).willReturn(List.of(item));
+        given(productRepository.findByIdWithLock(1L)).willReturn(Optional.of(product));
+
+        // when
+        orderService.cancelOrder(1L, 1L, "단순 변심");
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+        assertThat(order.getCancelReason()).isEqualTo("단순 변심");
+        assertThat(product.getRemainingStock()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("cancelOrder_존재하지_않는_유저_USER_NOT_FOUND_예외")
+    void cancelOrder_존재하지_않는_유저_USER_NOT_FOUND_예외() {
+        // given
+        given(userRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.cancelOrder(999L, 1L, "취소"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("cancelOrder_존재하지_않는_주문_ORDER_NOT_FOUND_예외")
+    void cancelOrder_존재하지_않는_주문_ORDER_NOT_FOUND_예외() {
+        // given
+        User user = user(1L);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(orderRepository.findByIdWithLock(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.cancelOrder(1L, 999L, "취소"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(OrderErrorCode.ORDER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("cancelOrder_타인_주문_ORDER_NOT_FOUND_예외")
+    void cancelOrder_타인_주문_ORDER_NOT_FOUND_예외() {
+        // given
+        User user = user(1L);
+        User anotherUser = user(2L);
+        Order order = order(1L, anotherUser, 10_000L);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(orderRepository.findByIdWithLock(1L)).willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> orderService.cancelOrder(1L, 1L, "취소"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(OrderErrorCode.ORDER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("getOrder_정상_주문_상세_반환")
+    void getOrder_정상_주문_상세_반환() {
+        // given
+        User user = user(1L);
+        Product product = product(1L, 10);
+        Order order = order(1L, user, 10_000L);
+        OrderItem item = orderItem(order, product, 1L);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(orderRepository.findByIdAndUser(1L, user)).willReturn(Optional.of(order));
+        given(orderItemRepository.findAllByOrder(order)).willReturn(List.of(item));
+
+        // when
+        OrderDetailResponse result = orderService.getOrder(1L, 1L);
+
+        // then
+        assertThat(result.getOrderId()).isEqualTo(1L);
+        assertThat(result.getStatus()).isEqualTo(OrderStatus.RESERVED);
+        assertThat(result.getItems()).hasSize(1);
+        assertThat(result.getItems().getFirst().getProductName()).isEqualTo("상품1");
+    }
+
+    @Test
+    @DisplayName("getOrder_존재하지_않는_유저_USER_NOT_FOUND_예외")
+    void getOrder_존재하지_않는_유저_USER_NOT_FOUND_예외() {
+        // given
+        given(userRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.getOrder(999L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("getOrder_존재하지_않는_주문_ORDER_NOT_FOUND_예외")
+    void getOrder_존재하지_않는_주문_ORDER_NOT_FOUND_예외() {
+        // given
+        User user = user(1L);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(orderRepository.findByIdAndUser(999L, user)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.getOrder(1L, 999L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(OrderErrorCode.ORDER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("getMyOrders_정상_status_null_내_주문_목록_반환")
+    void getMyOrders_정상_status_null_내_주문_목록_반환() {
+        // given
+        User user = user(1L);
+        Product product = product(1L, 10);
+        Order order = order(1L, user, 10_000L);
+        OrderItem item = orderItem(order, product, 1L);
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Order> orderPage = new PageImpl<>(List.of(order), pageable, 1);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(orderRepository.findAllByUserOrderByCreatedAtDesc(user, pageable)).willReturn(orderPage);
+        given(orderItemRepository.findAllByOrder(order)).willReturn(List.of(item));
+
+        // when
+        Page<OrderSummaryResponse> result = orderService.getMyOrders(1L, null, pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent()).extracting("productName").containsExactly("상품1");
+        verify(orderRepository).findAllByUserOrderByCreatedAtDesc(user, pageable);
+    }
+
+    @Test
+    @DisplayName("getMyOrders_정상_status_RESERVED_내_주문_목록_반환")
+    void getMyOrders_정상_status_RESERVED_내_주문_목록_반환() {
+        // given
+        User user = user(1L);
+        Product product = product(1L, 10);
+        Order order = order(1L, user, 10_000L);
+        OrderItem item = orderItem(order, product, 1L);
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Order> orderPage = new PageImpl<>(List.of(order), pageable, 1);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(orderRepository.findAllByUserAndStatusOrderByCreatedAtDesc(user, OrderStatus.RESERVED, pageable))
+                .willReturn(orderPage);
+        given(orderItemRepository.findAllByOrder(order)).willReturn(List.of(item));
+
+        // when
+        Page<OrderSummaryResponse> result = orderService.getMyOrders(1L, OrderStatus.RESERVED, pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent()).extracting("status").containsExactly(OrderStatus.RESERVED);
+        verify(orderRepository).findAllByUserAndStatusOrderByCreatedAtDesc(user, OrderStatus.RESERVED, pageable);
+    }
+
+    @Test
+    @DisplayName("getMyOrders_존재하지_않는_유저_USER_NOT_FOUND_예외")
+    void getMyOrders_존재하지_않는_유저_USER_NOT_FOUND_예외() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+        given(userRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.getMyOrders(999L, null, pageable))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("getOrdersByProduct_정상_상품별_주문_목록_반환")
+    void getOrdersByProduct_정상_상품별_주문_목록_반환() {
+        // given
+        Store store = store(1L);
+        StoreAdmin storeAdmin = storeAdmin(1L, store);
+        User user = user(1L);
+        Product product = product(1L, store, 10);
+        Order order = order(1L, user, 10_000L);
+        OrderItem item = orderItem(order, product, 1L);
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Order> orderPage = new PageImpl<>(List.of(order), pageable, 1);
+
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(storeAdmin));
+        given(productRepository.findByIdAndStore(1L, store)).willReturn(Optional.of(product));
+        given(orderRepository.findAllByProduct(product, pageable)).willReturn(orderPage);
+        given(orderItemRepository.findAllByOrder(order)).willReturn(List.of(item));
+
+        // when
+        Page<OrderSummaryResponse> result = orderService.getOrdersByProduct(1L, 1L, pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent()).extracting("productName").containsExactly("상품1");
+    }
+
+    @Test
+    @DisplayName("getOrdersByProduct_존재하지_않는_매장관리자_STORE_ADMIN_NOT_FOUND_예외")
+    void getOrdersByProduct_존재하지_않는_매장관리자_STORE_ADMIN_NOT_FOUND_예외() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.getOrdersByProduct(999L, 1L, pageable))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("getOrdersByProduct_존재하지_않는_상품_PRODUCT_NOT_FOUND_예외")
+    void getOrdersByProduct_존재하지_않는_상품_PRODUCT_NOT_FOUND_예외() {
+        // given
+        Store store = store(1L);
+        StoreAdmin storeAdmin = storeAdmin(1L, store);
+        Pageable pageable = PageRequest.of(0, 20);
+
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(storeAdmin));
+        given(productRepository.findByIdAndStore(999L, store)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.getOrdersByProduct(1L, 999L, pageable))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("getOrdersByMember_정상_회원별_주문_목록_반환")
+    void getOrdersByMember_정상_회원별_주문_목록_반환() {
+        // given
+        Store store = store(1L);
+        StoreAdmin storeAdmin = storeAdmin(1L, store);
+        User user = user(1L);
+        Product product = product(1L, store, 10);
+        Order order = order(1L, user, 10_000L);
+        OrderItem item = orderItem(order, product, 1L);
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Order> orderPage = new PageImpl<>(List.of(order), pageable, 1);
+
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(storeAdmin));
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(orderRepository.findAllByUserAndStore(user, store, pageable)).willReturn(orderPage);
+        given(orderItemRepository.findAllByOrder(order)).willReturn(List.of(item));
+
+        // when
+        Page<OrderSummaryResponse> result = orderService.getOrdersByMember(1L, 1L, pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent()).extracting("productName").containsExactly("상품1");
+    }
+
+    @Test
+    @DisplayName("getOrdersByMember_존재하지_않는_매장관리자_STORE_ADMIN_NOT_FOUND_예외")
+    void getOrdersByMember_존재하지_않는_매장관리자_STORE_ADMIN_NOT_FOUND_예외() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.getOrdersByMember(999L, 1L, pageable))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("getOrdersByMember_존재하지_않는_유저_USER_NOT_FOUND_예외")
+    void getOrdersByMember_존재하지_않는_유저_USER_NOT_FOUND_예외() {
+        // given
+        Store store = store(1L);
+        StoreAdmin storeAdmin = storeAdmin(1L, store);
+        Pageable pageable = PageRequest.of(0, 20);
+
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(storeAdmin));
+        given(userRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.getOrdersByMember(1L, 999L, pageable))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    private User user(Long id) {
+        User user = User.of("홍길동" + id, "010-1234-567" + id);
+        setId(user, id);
+        return user;
+    }
+
+    private Store store(Long id) {
+        Store store = Store.create("매장" + id, "서울시 강남구", "02-1234-5678");
+        setId(store, id);
+        return store;
+    }
+
+    private StoreAdmin storeAdmin(Long id, Store store) {
+        StoreAdmin storeAdmin = StoreAdmin.of(store, "admin" + id + "@test.com", "password", "관리자" + id);
+        setId(storeAdmin, id);
+        return storeAdmin;
+    }
+
+    private Product product(Long id, int totalStock) {
+        return product(id, store(1L), totalStock);
+    }
+
+    private Product product(Long id, Store store, int totalStock) {
+        Product product = Product.create(
+                store,
+                "상품" + id,
+                "상품 설명",
+                10_000L,
+                totalStock,
+                ProductStatus.ACTIVE,
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(1)
+        );
+        setId(product, id);
+        return product;
+    }
+
+    private Order order(Long id, User user, long totalPrice) {
+        Order order = Order.create(user, totalPrice);
+        setId(order, id);
+        return order;
+    }
+
+    private OrderItem orderItem(Order order, Product product, Long quantity) {
+        OrderItem item = OrderItem.create(order, product, quantity);
+        setId(item, 1L);
+        return item;
+    }
+
+    private void setId(Object target, Long id) {
+        ReflectionTestUtils.setField(target, "id", id);
+    }
+}

--- a/src/test/java/com/gongu/server/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/product/service/ProductServiceTest.java
@@ -1,0 +1,528 @@
+package com.gongu.server.domain.product.service;
+
+import com.gongu.server.domain.product.dto.CreateProductRequest;
+import com.gongu.server.domain.product.dto.ProductDetailResponse;
+import com.gongu.server.domain.product.dto.ProductSummaryResponse;
+import com.gongu.server.domain.product.dto.UpdateProductRequest;
+import com.gongu.server.domain.product.entity.Product;
+import com.gongu.server.domain.product.entity.ProductStatus;
+import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.domain.store.entity.StoreAdmin;
+import com.gongu.server.domain.store.entity.UserStore;
+import com.gongu.server.domain.store.repository.StoreAdminRepository;
+import com.gongu.server.domain.store.repository.StoreRepository;
+import com.gongu.server.domain.store.repository.UserStoreRepository;
+import com.gongu.server.domain.user.entity.User;
+import com.gongu.server.domain.user.repository.UserRepository;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.ProductErrorCode;
+import com.gongu.server.global.exception.errorcode.StoreErrorCode;
+import com.gongu.server.global.exception.errorcode.UserErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ProductServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserStoreRepository userStoreRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private StoreAdminRepository storeAdminRepository;
+
+    @InjectMocks
+    private ProductService productService;
+
+    private final LocalDateTime startAt = LocalDateTime.of(2026, 6, 1, 10, 0);
+    private final LocalDateTime endAt = LocalDateTime.of(2026, 6, 2, 10, 0);
+
+    @Test
+    @DisplayName("getProduct_가입_매장_상품_상세_반환")
+    void getProduct_가입_매장_상품_상세_반환() {
+        // given
+        User user = createUser();
+        Store store = createStore("테스트매장");
+        Product product = createProduct(store, "테스트상품", ProductStatus.ACTIVE);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(productRepository.findById(1L)).willReturn(Optional.of(product));
+        given(userStoreRepository.existsByUserAndStore(user, store)).willReturn(true);
+
+        // when
+        ProductDetailResponse response = productService.getProduct(1L, 1L);
+
+        // then
+        assertThat(response.name()).isEqualTo("테스트상품");
+        assertThat(response.description()).isEqualTo("상품 설명");
+        assertThat(response.price()).isEqualTo(10_000L);
+        assertThat(response.status()).isEqualTo(ProductStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("getProduct_존재하지_않는_회원_USER_NOT_FOUND_예외")
+    void getProduct_존재하지_않는_회원_USER_NOT_FOUND_예외() {
+        // given
+        given(userRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> productService.getProduct(999L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("getProduct_존재하지_않는_상품_PRODUCT_NOT_FOUND_예외")
+    void getProduct_존재하지_않는_상품_PRODUCT_NOT_FOUND_예외() {
+        // given
+        User user = createUser();
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(productRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> productService.getProduct(1L, 999L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("getProduct_미가입_매장_상품_PRODUCT_NOT_FOUND_예외")
+    void getProduct_미가입_매장_상품_PRODUCT_NOT_FOUND_예외() {
+        // given
+        User user = createUser();
+        Store store = createStore("테스트매장");
+        Product product = createProduct(store, "테스트상품", ProductStatus.ACTIVE);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(productRepository.findById(1L)).willReturn(Optional.of(product));
+        given(userStoreRepository.existsByUserAndStore(user, store)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> productService.getProduct(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("getAdminProduct_관리자_상품_상세_반환")
+    void getAdminProduct_관리자_상품_상세_반환() {
+        // given
+        Store store = createStore("테스트매장");
+        StoreAdmin storeAdmin = createStoreAdmin(store);
+        Product product = createProduct(store, "관리자상품", ProductStatus.UPCOMING);
+
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(storeAdmin));
+        given(productRepository.findByIdAndStore(1L, store)).willReturn(Optional.of(product));
+
+        // when
+        ProductDetailResponse response = productService.getAdminProduct(1L, 1L);
+
+        // then
+        assertThat(response.name()).isEqualTo("관리자상품");
+        assertThat(response.status()).isEqualTo(ProductStatus.UPCOMING);
+    }
+
+    @Test
+    @DisplayName("getAdminProduct_존재하지_않는_관리자_STORE_ADMIN_NOT_FOUND_예외")
+    void getAdminProduct_존재하지_않는_관리자_STORE_ADMIN_NOT_FOUND_예외() {
+        // given
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> productService.getAdminProduct(999L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("getAdminProduct_타매장_상품_PRODUCT_NOT_FOUND_예외")
+    void getAdminProduct_타매장_상품_PRODUCT_NOT_FOUND_예외() {
+        // given
+        Store store = createStore("테스트매장");
+        StoreAdmin storeAdmin = createStoreAdmin(store);
+
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(storeAdmin));
+        given(productRepository.findByIdAndStore(999L, store)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> productService.getAdminProduct(1L, 999L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("getProducts_storeId_없음_가입_매장_전체_상품_목록_반환")
+    void getProducts_storeId_없음_가입_매장_전체_상품_목록_반환() {
+        // given
+        User user = createUser();
+        Store store1 = createStore("매장1");
+        Store store2 = createStore("매장2");
+        Product product1 = createProduct(store1, "상품1", ProductStatus.ACTIVE);
+        Product product2 = createProduct(store2, "상품2", ProductStatus.ACTIVE);
+        Pageable pageable = PageRequest.of(0, 20);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(userStoreRepository.findAllByUser(user))
+                .willReturn(List.of(UserStore.create(user, store1, false), UserStore.create(user, store2, true)));
+        given(productRepository.findAllByStoreInAndStatus(List.of(store1, store2), ProductStatus.ACTIVE, pageable))
+                .willReturn(new PageImpl<>(List.of(product1, product2), pageable, 2));
+
+        // when
+        Page<ProductSummaryResponse> result = productService.getProducts(1L, null, pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent()).extracting(ProductSummaryResponse::name)
+                .containsExactly("상품1", "상품2");
+    }
+
+    @Test
+    @DisplayName("getProducts_storeId_지정_상품_목록_반환")
+    void getProducts_storeId_지정_상품_목록_반환() {
+        // given
+        User user = createUser();
+        Store store = createStore("테스트매장");
+        Product product = createProduct(store, "상품1", ProductStatus.ACTIVE);
+        Pageable pageable = PageRequest.of(0, 20);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(storeRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(store));
+        given(userStoreRepository.existsByUserAndStore(user, store)).willReturn(true);
+        given(productRepository.findAllByStoreAndStatus(store, ProductStatus.ACTIVE, pageable))
+                .willReturn(new PageImpl<>(List.of(product), pageable, 1));
+
+        // when
+        Page<ProductSummaryResponse> result = productService.getProducts(1L, 1L, pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent()).extracting(ProductSummaryResponse::name)
+                .containsExactly("상품1");
+    }
+
+    @Test
+    @DisplayName("getProducts_가입_매장_없음_empty_page_반환")
+    void getProducts_가입_매장_없음_empty_page_반환() {
+        // given
+        User user = createUser();
+        Pageable pageable = PageRequest.of(0, 20);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(userStoreRepository.findAllByUser(user)).willReturn(List.of());
+
+        // when
+        Page<ProductSummaryResponse> result = productService.getProducts(1L, null, pageable);
+
+        // then
+        assertThat(result).isEmpty();
+        assertThat(result.getPageable()).isEqualTo(pageable);
+    }
+
+    @Test
+    @DisplayName("getProducts_존재하지_않는_회원_USER_NOT_FOUND_예외")
+    void getProducts_존재하지_않는_회원_USER_NOT_FOUND_예외() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+        given(userRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> productService.getProducts(999L, null, pageable))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("getProducts_storeId_지정_존재하지_않는_매장_STORE_NOT_FOUND_예외")
+    void getProducts_storeId_지정_존재하지_않는_매장_STORE_NOT_FOUND_예외() {
+        // given
+        User user = createUser();
+        Pageable pageable = PageRequest.of(0, 20);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(storeRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> productService.getProducts(1L, 999L, pageable))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(StoreErrorCode.STORE_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("getProducts_storeId_지정_미가입_매장_STORE_NOT_FOUND_예외")
+    void getProducts_storeId_지정_미가입_매장_STORE_NOT_FOUND_예외() {
+        // given
+        User user = createUser();
+        Store store = createStore("테스트매장");
+        Pageable pageable = PageRequest.of(0, 20);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(storeRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(store));
+        given(userStoreRepository.existsByUserAndStore(user, store)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> productService.getProducts(1L, 1L, pageable))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(StoreErrorCode.STORE_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("getAdminProducts_관리자_상품_목록_반환")
+    void getAdminProducts_관리자_상품_목록_반환() {
+        // given
+        Store store = createStore("테스트매장");
+        StoreAdmin storeAdmin = createStoreAdmin(store);
+        Product product = createProduct(store, "상품1", ProductStatus.CLOSED);
+        Pageable pageable = PageRequest.of(0, 20);
+
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(storeAdmin));
+        given(productRepository.findAllByStore(store, pageable))
+                .willReturn(new PageImpl<>(List.of(product), pageable, 1));
+
+        // when
+        Page<ProductSummaryResponse> result = productService.getAdminProducts(1L, pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent()).extracting(ProductSummaryResponse::name)
+                .containsExactly("상품1");
+    }
+
+    @Test
+    @DisplayName("getAdminProducts_존재하지_않는_관리자_STORE_ADMIN_NOT_FOUND_예외")
+    void getAdminProducts_존재하지_않는_관리자_STORE_ADMIN_NOT_FOUND_예외() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> productService.getAdminProducts(999L, pageable))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("createProduct_관리자_상품_등록_UPCOMING_상태로_저장")
+    void createProduct_관리자_상품_등록_UPCOMING_상태로_저장() {
+        // given
+        Store store = createStore("테스트매장");
+        StoreAdmin storeAdmin = createStoreAdmin(store);
+        CreateProductRequest request = createProductRequest();
+
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(storeAdmin));
+        given(productRepository.save(any(Product.class))).willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        ProductDetailResponse response = productService.createProduct(1L, request);
+
+        // then
+        assertThat(response.name()).isEqualTo("신규상품");
+        assertThat(response.status()).isEqualTo(ProductStatus.UPCOMING);
+        assertThat(response.remainingStock()).isEqualTo(100);
+        verify(productRepository).save(any(Product.class));
+    }
+
+    @Test
+    @DisplayName("createProduct_존재하지_않는_관리자_STORE_ADMIN_NOT_FOUND_예외")
+    void createProduct_존재하지_않는_관리자_STORE_ADMIN_NOT_FOUND_예외() {
+        // given
+        CreateProductRequest request = createProductRequest();
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> productService.createProduct(999L, request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("updateProduct_관리자_상품_수정")
+    void updateProduct_관리자_상품_수정() {
+        // given
+        Store store = createStore("테스트매장");
+        StoreAdmin storeAdmin = createStoreAdmin(store);
+        Product product = createProduct(store, "기존상품", ProductStatus.UPCOMING);
+        UpdateProductRequest request = new UpdateProductRequest(
+                "수정상품", "수정 설명", 20_000L, 150, startAt.plusDays(1), endAt.plusDays(1)
+        );
+
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(storeAdmin));
+        given(productRepository.findByIdAndStore(1L, store)).willReturn(Optional.of(product));
+
+        // when
+        ProductDetailResponse response = productService.updateProduct(1L, 1L, request);
+
+        // then
+        assertThat(response.name()).isEqualTo("수정상품");
+        assertThat(response.description()).isEqualTo("수정 설명");
+        assertThat(response.price()).isEqualTo(20_000L);
+        assertThat(response.totalStock()).isEqualTo(150);
+        assertThat(product.getName()).isEqualTo("수정상품");
+    }
+
+    @Test
+    @DisplayName("updateProduct_존재하지_않는_관리자_STORE_ADMIN_NOT_FOUND_예외")
+    void updateProduct_존재하지_않는_관리자_STORE_ADMIN_NOT_FOUND_예외() {
+        // given
+        UpdateProductRequest request = new UpdateProductRequest("수정상품", null, null, null, null, null);
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> productService.updateProduct(999L, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("updateProduct_존재하지_않는_상품_PRODUCT_NOT_FOUND_예외")
+    void updateProduct_존재하지_않는_상품_PRODUCT_NOT_FOUND_예외() {
+        // given
+        Store store = createStore("테스트매장");
+        StoreAdmin storeAdmin = createStoreAdmin(store);
+        UpdateProductRequest request = new UpdateProductRequest("수정상품", null, null, null, null, null);
+
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(storeAdmin));
+        given(productRepository.findByIdAndStore(999L, store)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> productService.updateProduct(1L, 999L, request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("closeProduct_관리자_상품_종료")
+    void closeProduct_관리자_상품_종료() {
+        // given
+        Store store = createStore("테스트매장");
+        StoreAdmin storeAdmin = createStoreAdmin(store);
+        Product product = createProduct(store, "상품1", ProductStatus.ACTIVE);
+
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(storeAdmin));
+        given(productRepository.findByIdAndStore(1L, store)).willReturn(Optional.of(product));
+
+        // when
+        productService.closeProduct(1L, 1L);
+
+        // then
+        assertThat(product.getStatus()).isEqualTo(ProductStatus.CLOSED);
+    }
+
+    @Test
+    @DisplayName("closeProduct_존재하지_않는_관리자_STORE_ADMIN_NOT_FOUND_예외")
+    void closeProduct_존재하지_않는_관리자_STORE_ADMIN_NOT_FOUND_예외() {
+        // given
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> productService.closeProduct(999L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("closeProduct_존재하지_않는_상품_PRODUCT_NOT_FOUND_예외")
+    void closeProduct_존재하지_않는_상품_PRODUCT_NOT_FOUND_예외() {
+        // given
+        Store store = createStore("테스트매장");
+        StoreAdmin storeAdmin = createStoreAdmin(store);
+
+        given(storeAdminRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(storeAdmin));
+        given(productRepository.findByIdAndStore(999L, store)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> productService.closeProduct(1L, 999L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("decreaseStock_상품_재고_차감")
+    void decreaseStock_상품_재고_차감() {
+        // given
+        Store store = createStore("테스트매장");
+        Product product = createProduct(store, "상품1", ProductStatus.ACTIVE);
+
+        given(productRepository.findByIdWithLock(1L)).willReturn(Optional.of(product));
+
+        // when
+        productService.decreaseStock(1L, 3);
+
+        // then
+        assertThat(product.getRemainingStock()).isEqualTo(97);
+    }
+
+    @Test
+    @DisplayName("decreaseStock_존재하지_않는_상품_PRODUCT_NOT_FOUND_예외")
+    void decreaseStock_존재하지_않는_상품_PRODUCT_NOT_FOUND_예외() {
+        // given
+        given(productRepository.findByIdWithLock(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> productService.decreaseStock(999L, 1))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    private User createUser() {
+        return User.of("홍길동", "010-1234-5678");
+    }
+
+    private Store createStore(String name) {
+        return Store.create(name, "서울시 강남구", "02-1234-5678");
+    }
+
+    private StoreAdmin createStoreAdmin(Store store) {
+        return StoreAdmin.of(store, "admin@gongu.com", "encodedPassword", "관리자");
+    }
+
+    private Product createProduct(Store store, String name, ProductStatus status) {
+        return Product.create(store, name, "상품 설명", 10_000L, 100, status, startAt, endAt);
+    }
+
+    private CreateProductRequest createProductRequest() {
+        return new CreateProductRequest("신규상품", "신규 상품 설명", 10_000L, 100, startAt, endAt);
+    }
+}


### PR DESCRIPTION
## Issue ID
close #88

## 작업 내용
- `OrderServiceTest`: createOrder, cancelOrder, getOrder, getMyOrders, getOrdersByProduct, getOrdersByMember — 19개 테스트
- `ProductServiceTest`: getProduct, getAdminProduct, getProducts, getAdminProducts, createProduct, updateProduct, closeProduct, decreaseStock — 25개 테스트
- `AuthServiceTest`: storeAdminLogin, refreshToken, kakaoLogin — 단위 테스트

모든 테스트 `@ExtendWith(MockitoExtension.class)` + BDD 스타일, `./gradlew test` BUILD SUCCESSFUL 확인

## 참고사항
- PR #87 (JaCoCo 80% 커버리지 강제) 병합 전 이 PR 먼저 병합 필요