### PR TITLE
[CHORE] Order, OrderItem, Product 엔티티 @Builder(access=PRIVATE) 적용 (#78)

### DIFF
--- a/src/main/java/com/gongu/server/domain/order/entity/Order.java
+++ b/src/main/java/com/gongu/server/domain/order/entity/Order.java
@@ -16,6 +16,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,6 +25,8 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 @Entity
 @Table(name = "orders")
 public class Order extends BaseEntity {
@@ -55,11 +59,11 @@ public class Order extends BaseEntity {
         if (totalPrice <= 0) {
             throw new BusinessException(OrderErrorCode.INVALID_ORDER_DATA);
         }
-        Order order = new Order();
-        order.user = user;
-        order.totalPrice = totalPrice;
-        order.status = OrderStatus.RESERVED;
-        return order;
+        return Order.builder()
+                .user(user)
+                .totalPrice(totalPrice)
+                .status(OrderStatus.RESERVED)
+                .build();
     }
 
     public void cancel(String reason) {

--- a/src/main/java/com/gongu/server/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/gongu/server/domain/order/entity/OrderItem.java
@@ -14,6 +14,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -23,6 +25,8 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 @Entity
 @Table(name = "order_items")
 @EntityListeners(AuditingEntityListener.class)
@@ -54,11 +58,11 @@ public class OrderItem {
         if (quantity == null || quantity <= 0) {
             throw new BusinessException(OrderErrorCode.INVALID_ORDER_DATA);
         }
-        OrderItem item = new OrderItem();
-        item.order = order;
-        item.product = product;
-        item.quantity = quantity;
-        item.unitPrice = product.getPrice();
-        return item;
+        return OrderItem.builder()
+                .order(order)
+                .product(product)
+                .quantity(quantity)
+                .unitPrice(product.getPrice())
+                .build();
     }
 }

--- a/src/main/java/com/gongu/server/domain/product/entity/Product.java
+++ b/src/main/java/com/gongu/server/domain/product/entity/Product.java
@@ -17,6 +17,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,6 +26,8 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 @Entity
 @Table(name = "products")
 public class Product extends BaseEntity {
@@ -76,17 +80,17 @@ public class Product extends BaseEntity {
         if (startAt.isAfter(endAt)) {
             throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_DATA);
         }
-        Product product = new Product();
-        product.store = store;
-        product.name = name;
-        product.description = description;
-        product.price = price;
-        product.totalStock = totalStock;
-        product.remainingStock = totalStock;
-        product.status = status;
-        product.startAt = startAt;
-        product.endAt = endAt;
-        return product;
+        return Product.builder()
+                .store(store)
+                .name(name)
+                .description(description)
+                .price(price)
+                .totalStock(totalStock)
+                .remainingStock(totalStock)
+                .status(status)
+                .startAt(startAt)
+                .endAt(endAt)
+                .build();
     }
 
     public void decreaseStock(int quantity) {


### PR DESCRIPTION
## Summary

- `Order`, `OrderItem`, `Product` 엔티티에 `@Builder(access = AccessLevel.PRIVATE)` 및 `@AllArgsConstructor(access = AccessLevel.PRIVATE)` 추가
- 기존 `new 클래스명()` + 직접 필드 할당 방식 → 팩토리 메서드 내 `builder()...build()` 패턴으로 교체
- ADR-002(아키텍처_및_코드_컨벤션) 준수

## 변경 파일

- `Order.java`
- `OrderItem.java`
- `Product.java`

## 비고

- `@NoArgsConstructor(access = PROTECTED)` 기존 유지 (JPA 요구)
- `@AllArgsConstructor(access = PRIVATE)` 추가 (`@Builder`와 `@NoArgsConstructor` 충돌 방지)
- 기존 유효성 검사 로직(Guard clause) 보존

Closes #78