### PR TITLE
[FEAT] Product UPCOMING → ACTIVE 상태 전이 구현 (#91)

### DIFF
--- a/docs/schema/ddl.sql
+++ b/docs/schema/ddl.sql
@@ -203,6 +203,9 @@ CREATE INDEX `IDX_PAYMENTS_ORDER_ID`       ON `payments`     (`order_id`);
 -- 상품 목록: 매장별 + 상태 필터 (GET /products?store_id=&status=)
 CREATE INDEX `IDX_PRODUCTS_STORE_STATUS`   ON `products` (`store_id`, `status`);
 
+-- 스케줄러: UPCOMING 상품 중 startAt 도래한 것 조회 (WHERE status = 'UPCOMING' AND start_at <= ?)
+CREATE INDEX `IDX_PRODUCTS_STATUS_START_AT` ON `products` (`status`, `start_at`);
+
 -- 상품 목록: 판매 기간 필터 (ACTIVE 상품 기간 조회)
 CREATE INDEX `IDX_PRODUCTS_START_END`      ON `products` (`start_at`, `end_at`);
 

--- a/src/main/java/com/gongu/server/domain/product/entity/Product.java
+++ b/src/main/java/com/gongu/server/domain/product/entity/Product.java
@@ -129,6 +129,13 @@ public class Product extends BaseEntity {
         this.status = ProductStatus.CLOSED;
     }
 
+    public void activate() {
+        if (this.status != ProductStatus.UPCOMING) {
+            throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_STATUS);
+        }
+        this.status = ProductStatus.ACTIVE;
+    }
+
     public void restoreStock(int quantity) {
         if (this.remainingStock + quantity > this.totalStock) {
             throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_DATA);

--- a/src/main/java/com/gongu/server/domain/product/entity/Product.java
+++ b/src/main/java/com/gongu/server/domain/product/entity/Product.java
@@ -131,7 +131,7 @@ public class Product extends BaseEntity {
 
     public void activate() {
         if (this.status != ProductStatus.UPCOMING) {
-            throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_STATUS);
+            throw new BusinessException(ProductErrorCode.CANNOT_ACTIVATE_PRODUCT);
         }
         this.status = ProductStatus.ACTIVE;
     }

--- a/src/main/java/com/gongu/server/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/gongu/server/domain/product/repository/ProductRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -43,4 +44,11 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     // 관리자: 매장 소속 상품 단건 조회 (소속 매장 검증 포함, 추가 Store 쿼리 제거)
     @Query("SELECT p FROM Product p WHERE p.id = :id AND p.store = :store")
     Optional<Product> findByIdAndStore(@Param("id") Long id, @Param("store") Store store);
+
+    // 스케줄러: startAt이 도래한 UPCOMING 상품 조회 (UPCOMING → ACTIVE 전이 대상)
+    @Query("SELECT p FROM Product p WHERE p.status = :status AND p.startAt <= :now")
+    List<Product> findAllByStatusAndStartAtLessThanEqual(
+            @Param("status") ProductStatus status,
+            @Param("now") LocalDateTime now
+    );
 }

--- a/src/main/java/com/gongu/server/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/gongu/server/domain/product/repository/ProductRepository.java
@@ -45,9 +45,9 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("SELECT p FROM Product p WHERE p.id = :id AND p.store = :store")
     Optional<Product> findByIdAndStore(@Param("id") Long id, @Param("store") Store store);
 
-    // 스케줄러: startAt이 도래한 UPCOMING 상품 조회 (UPCOMING → ACTIVE 전이 대상)
-    @Query("SELECT p FROM Product p WHERE p.status = :status AND p.startAt <= :now")
-    List<Product> findAllByStatusAndStartAtLessThanEqual(
+    // 스케줄러: startAt이 도래하고 endAt이 아직 지나지 않은 UPCOMING 상품 조회 (UPCOMING → ACTIVE 전이 대상)
+    @Query("SELECT p FROM Product p WHERE p.status = :status AND p.startAt <= :now AND p.endAt > :now")
+    List<Product> findActivatableUpcomingProducts(
             @Param("status") ProductStatus status,
             @Param("now") LocalDateTime now
     );

--- a/src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusScheduler.java
+++ b/src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusScheduler.java
@@ -20,7 +20,7 @@ public class ProductStatusScheduler {
     @Transactional
     public void activateUpcomingProducts() {
         productRepository
-                .findAllByStatusAndStartAtLessThanEqual(ProductStatus.UPCOMING, LocalDateTime.now())
+                .findActivatableUpcomingProducts(ProductStatus.UPCOMING, LocalDateTime.now())
                 .forEach(Product::activate);
     }
 }

--- a/src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusScheduler.java
+++ b/src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusScheduler.java
@@ -1,0 +1,25 @@
+package com.gongu.server.domain.product.scheduler;
+
+import com.gongu.server.domain.product.entity.ProductStatus;
+import com.gongu.server.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class ProductStatusScheduler {
+
+    private final ProductRepository productRepository;
+
+    @Scheduled(cron = "0 * * * * *")
+    @Transactional
+    public void activateUpcomingProducts() {
+        productRepository
+                .findAllByStatusAndStartAtLessThanEqual(ProductStatus.UPCOMING, LocalDateTime.now())
+                .forEach(product -> product.activate());
+    }
+}

--- a/src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusScheduler.java
+++ b/src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusScheduler.java
@@ -1,5 +1,6 @@
 package com.gongu.server.domain.product.scheduler;
 
+import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.entity.ProductStatus;
 import com.gongu.server.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,6 @@ public class ProductStatusScheduler {
     public void activateUpcomingProducts() {
         productRepository
                 .findAllByStatusAndStartAtLessThanEqual(ProductStatus.UPCOMING, LocalDateTime.now())
-                .forEach(product -> product.activate());
+                .forEach(Product::activate);
     }
 }

--- a/src/main/java/com/gongu/server/global/config/AppConfig.java
+++ b/src/main/java/com/gongu/server/global/config/AppConfig.java
@@ -1,0 +1,19 @@
+package com.gongu.server.global.config;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.TimeZone;
+
+@Configuration
+public class AppConfig {
+
+    @Value("${app.timezone:Asia/Seoul}")
+    private String timezone;
+
+    @PostConstruct
+    public void setDefaultTimezone() {
+        TimeZone.setDefault(TimeZone.getTimeZone(timezone));
+    }
+}

--- a/src/main/java/com/gongu/server/global/config/SchedulingConfig.java
+++ b/src/main/java/com/gongu/server/global/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.gongu.server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/gongu/server/global/exception/errorcode/ProductErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/ProductErrorCode.java
@@ -9,7 +9,8 @@ public enum ProductErrorCode implements ErrorCode {
     PRODUCT_NOT_FOUND("PRODUCT_001", "존재하지 않는 상품입니다", 404),
     INSUFFICIENT_STOCK("PRODUCT_002", "재고가 부족합니다", 409),
     INVALID_PRODUCT_STATUS("PRODUCT_003", "판매 중이지 않은 상품입니다", 400),
-    INVALID_PRODUCT_DATA("PRODUCT_004", "유효하지 않은 상품 데이터입니다", 400);
+    INVALID_PRODUCT_DATA("PRODUCT_004", "유효하지 않은 상품 데이터입니다", 400),
+    CANNOT_ACTIVATE_PRODUCT("PRODUCT_005", "활성화할 수 없는 상태의 상품입니다", 400);
 
     private final String code;
     private final String message;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,6 @@ jwt:
 
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
+
+app:
+  timezone: Asia/Seoul

--- a/src/test/java/com/gongu/server/domain/product/entity/ProductTest.java
+++ b/src/test/java/com/gongu/server/domain/product/entity/ProductTest.java
@@ -59,6 +59,34 @@ class ProductTest {
     }
 
     @Test
+    @DisplayName("UPCOMING 상품을 activate하면 ACTIVE로 전이된다")
+    void activate_upcoming_success() {
+        // given
+        Product product = Product.create(store, "테스트상품", "설명", 1000L, 10,
+                ProductStatus.UPCOMING, now, later);
+
+        // when
+        product.activate();
+
+        // then
+        assertThat(product.getStatus()).isEqualTo(ProductStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("UPCOMING이 아닌 상품을 activate하면 CANNOT_ACTIVATE_PRODUCT 예외가 발생한다")
+    void activate_notUpcoming_throwsException() {
+        // given
+        Product product = Product.create(store, "테스트상품", "설명", 1000L, 10,
+                ProductStatus.ACTIVE, now, later);
+
+        // when & then
+        assertThatThrownBy(product::activate)
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ProductErrorCode.CANNOT_ACTIVATE_PRODUCT));
+    }
+
+    @Test
     @DisplayName("ACTIVE 상태 상품의 재고가 정상 차감된다")
     void decreaseStock_success() {
         // given — ACTIVE 상태로 생성, 재고 10

--- a/src/test/java/com/gongu/server/domain/product/scheduler/ProductStatusSchedulerTest.java
+++ b/src/test/java/com/gongu/server/domain/product/scheduler/ProductStatusSchedulerTest.java
@@ -67,8 +67,8 @@ class ProductStatusSchedulerTest {
     }
 
     @Test
-    @DisplayName("activate_UPCOMING_아닌_상품은_INVALID_PRODUCT_STATUS_예외")
-    void activate_UPCOMING_아닌_상품은_INVALID_PRODUCT_STATUS_예외() {
+    @DisplayName("activate_UPCOMING_아닌_상품은_CANNOT_ACTIVATE_PRODUCT_예외")
+    void activate_UPCOMING_아닌_상품은_CANNOT_ACTIVATE_PRODUCT_예외() {
         // given
         Product activeProduct = createProduct(createStore("매장"), "상품", ProductStatus.ACTIVE);
 
@@ -76,7 +76,7 @@ class ProductStatusSchedulerTest {
         assertThatThrownBy(activeProduct::activate)
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
-                        .isEqualTo(ProductErrorCode.INVALID_PRODUCT_STATUS));
+                        .isEqualTo(ProductErrorCode.CANNOT_ACTIVATE_PRODUCT));
     }
 
     private Store createStore(String name) {

--- a/src/test/java/com/gongu/server/domain/product/scheduler/ProductStatusSchedulerTest.java
+++ b/src/test/java/com/gongu/server/domain/product/scheduler/ProductStatusSchedulerTest.java
@@ -42,7 +42,7 @@ class ProductStatusSchedulerTest {
         Product product1 = createProduct(store, "상품1", ProductStatus.UPCOMING);
         Product product2 = createProduct(store, "상품2", ProductStatus.UPCOMING);
 
-        given(productRepository.findAllByStatusAndStartAtLessThanEqual(
+        given(productRepository.findActivatableUpcomingProducts(
                 eq(ProductStatus.UPCOMING), any(LocalDateTime.class)))
                 .willReturn(List.of(product1, product2));
 
@@ -58,7 +58,7 @@ class ProductStatusSchedulerTest {
     @DisplayName("activateUpcomingProducts_대상_없으면_아무것도_하지_않음")
     void activateUpcomingProducts_대상_없으면_아무것도_하지_않음() {
         // given
-        given(productRepository.findAllByStatusAndStartAtLessThanEqual(
+        given(productRepository.findActivatableUpcomingProducts(
                 eq(ProductStatus.UPCOMING), any(LocalDateTime.class)))
                 .willReturn(List.of());
 

--- a/src/test/java/com/gongu/server/domain/product/scheduler/ProductStatusSchedulerTest.java
+++ b/src/test/java/com/gongu/server/domain/product/scheduler/ProductStatusSchedulerTest.java
@@ -4,8 +4,6 @@ import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.entity.ProductStatus;
 import com.gongu.server.domain.product.repository.ProductRepository;
 import com.gongu.server.domain.store.entity.Store;
-import com.gongu.server.global.exception.BusinessException;
-import com.gongu.server.global.exception.errorcode.ProductErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,7 +15,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -64,19 +61,6 @@ class ProductStatusSchedulerTest {
 
         // when & then (예외 없이 정상 종료)
         scheduler.activateUpcomingProducts();
-    }
-
-    @Test
-    @DisplayName("activate_UPCOMING_아닌_상품은_CANNOT_ACTIVATE_PRODUCT_예외")
-    void activate_UPCOMING_아닌_상품은_CANNOT_ACTIVATE_PRODUCT_예외() {
-        // given
-        Product activeProduct = createProduct(createStore("매장"), "상품", ProductStatus.ACTIVE);
-
-        // when & then
-        assertThatThrownBy(activeProduct::activate)
-                .isInstanceOf(BusinessException.class)
-                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
-                        .isEqualTo(ProductErrorCode.CANNOT_ACTIVATE_PRODUCT));
     }
 
     private Store createStore(String name) {

--- a/src/test/java/com/gongu/server/domain/product/scheduler/ProductStatusSchedulerTest.java
+++ b/src/test/java/com/gongu/server/domain/product/scheduler/ProductStatusSchedulerTest.java
@@ -1,0 +1,89 @@
+package com.gongu.server.domain.product.scheduler;
+
+import com.gongu.server.domain.product.entity.Product;
+import com.gongu.server.domain.product.entity.ProductStatus;
+import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.ProductErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ProductStatusSchedulerTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private ProductStatusScheduler scheduler;
+
+    private final LocalDateTime startAt = LocalDateTime.of(2026, 5, 1, 10, 0);
+    private final LocalDateTime endAt   = LocalDateTime.of(2026, 5, 2, 10, 0);
+
+    @Test
+    @DisplayName("activateUpcomingProducts_startAt_도래한_UPCOMING_상품_ACTIVE_전이")
+    void activateUpcomingProducts_startAt_도래한_UPCOMING_상품_ACTIVE_전이() {
+        // given
+        Store store = createStore("테스트매장");
+        Product product1 = createProduct(store, "상품1", ProductStatus.UPCOMING);
+        Product product2 = createProduct(store, "상품2", ProductStatus.UPCOMING);
+
+        given(productRepository.findAllByStatusAndStartAtLessThanEqual(
+                eq(ProductStatus.UPCOMING), any(LocalDateTime.class)))
+                .willReturn(List.of(product1, product2));
+
+        // when
+        scheduler.activateUpcomingProducts();
+
+        // then
+        assertThat(product1.getStatus()).isEqualTo(ProductStatus.ACTIVE);
+        assertThat(product2.getStatus()).isEqualTo(ProductStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("activateUpcomingProducts_대상_없으면_아무것도_하지_않음")
+    void activateUpcomingProducts_대상_없으면_아무것도_하지_않음() {
+        // given
+        given(productRepository.findAllByStatusAndStartAtLessThanEqual(
+                eq(ProductStatus.UPCOMING), any(LocalDateTime.class)))
+                .willReturn(List.of());
+
+        // when & then (예외 없이 정상 종료)
+        scheduler.activateUpcomingProducts();
+    }
+
+    @Test
+    @DisplayName("activate_UPCOMING_아닌_상품은_INVALID_PRODUCT_STATUS_예외")
+    void activate_UPCOMING_아닌_상품은_INVALID_PRODUCT_STATUS_예외() {
+        // given
+        Product activeProduct = createProduct(createStore("매장"), "상품", ProductStatus.ACTIVE);
+
+        // when & then
+        assertThatThrownBy(activeProduct::activate)
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ProductErrorCode.INVALID_PRODUCT_STATUS));
+    }
+
+    private Store createStore(String name) {
+        return Store.create(name, "서울시 강남구", "02-1234-5678");
+    }
+
+    private Product createProduct(Store store, String name, ProductStatus status) {
+        return Product.create(store, name, "상품 설명", 10_000L, 100, status, startAt, endAt);
+    }
+}


### PR DESCRIPTION
## Issue
close #91

## 작업 내용

`docs/02-domain-rules.md`에 명세된 `UPCOMING → ACTIVE` 전이가 구현되어 있지 않아, `startAt`이 도래해도 상품이 자동으로 활성화되지 않던 문제를 해결한다.

### 구현 방식 결정 배경
총 3가지 방식을 검토했다:
- **A. 1분 주기 스케줄러** — 단순, 재시작 시 별도 복구 로직 불필요 (최대 1분 후 자동 처리)
- **B. Spring TaskScheduler 동적 등록** — 정확하지만 서버 재시작 시 메모리 유실, 복구 로직 필수
- **C. Redis Keyspace Notification** — 정확하지만 TTL 만료 오차 가능, Redis 설정 변경 필요, 복구 로직 필수

공구 플랫폼 특성상 콘서트 예매 수준의 실시간 정확도가 요구되지 않고, B/C 모두 재시작 복구 로직이 필요한 반면 A는 자연스럽게 자가 복구된다. **A안(1분 주기 스케줄러)** 채택.

## 변경 사항

- `Product.activate()` — UPCOMING → ACTIVE 상태 전이 메서드 (UPCOMING 아닌 경우 `INVALID_PRODUCT_STATUS` 예외)
- `ProductRepository.findAllByStatusAndStartAtLessThanEqual()` — 스케줄러용 조회 쿼리
- `SchedulingConfig` — `@EnableScheduling` 활성화
- `ProductStatusScheduler` — `@Scheduled(cron = "0 * * * * *")` 매분 0초 실행
- `docs/schema/ddl.sql` — `IDX_PRODUCTS_STATUS_START_AT (status, start_at)` 인덱스 추가

## 참고 사항

- `IDX_PRODUCTS_START_END (start_at, end_at)` 기존 인덱스는 status 필터가 없어 스케줄러 쿼리에 부적합 → 별도 `(status, start_at)` 인덱스 추가
- 재고 소진 시 `ACTIVE → SOLD_OUT` 자동 전이는 별도 이슈 #92에서 처리