### PR TITLE
[DOCS] CLAUDE.md 워크플로우 요약 제거 — workflow.md 직접 참조 강제 (#94)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,17 +20,9 @@
 
 ---
 
-## 작업 흐름 요약
+## 작업 흐름
 
-자세한 12단계 흐름 → [`.claude/workflow.md`](.claude/workflow.md)
-
-```text
-1. GitHub Issue 확인  →  2. main 최신화  →  3. 이슈 브랜치 생성
-4. writing-plans 스킬로 계획 수립  →  5. Codex에 구현 위임
-6. 빌드 검증  →  7. 커밋  →  8. push + PR 생성
-9. /codex:review로 리뷰 위임  →  10. Claude 판정 + 사용자 합의  →  11. 완료 알림
-12. PR merge는 사용자가 직접
-```
+> **이슈 작업을 시작할 때 반드시 `Read` 도구로 [`.claude/workflow.md`](.claude/workflow.md)를 직접 읽어라. 요약본 없음 — 전체 단계를 문서에서 확인한다.**
 
 ---
 


### PR DESCRIPTION
## 작업 내용

CLAUDE.md에서 12단계 워크플로우 요약을 제거하고, 이슈 작업 시 `.claude/workflow.md`를 직접 Read 도구로 읽도록 강제

## 문제

CLAUDE.md에 요약본이 있어 Claude가 실제 workflow.md를 건너뛰는 현상 발생.
이번에 #78 처리 중 9~11단계(코드 리뷰 사이클)가 누락된 것이 직접 계기.

## 변경 내용

- 12단계 요약 블록 제거
- `workflow.md`를 직접 읽으라는 명시적 지시로 대체

Closes #94