### PR TITLE
[FEAT] createOrder 매장 가입 여부 검증 추가 (#82)

### DIFF
--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -51,7 +51,7 @@ public class OrderService {
 
         Store store = product.getStore();
         if (!userStoreRepository.existsByUserAndStore(user, store)) {
-            throw new BusinessException(OrderErrorCode.STORE_NOT_JOINED);
+            throw new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND);
         }
 
         product.decreaseStock(quantity);

--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -9,8 +9,10 @@ import com.gongu.server.domain.order.repository.OrderItemRepository;
 import com.gongu.server.domain.order.repository.OrderRepository;
 import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.store.entity.Store;
 import com.gongu.server.domain.store.entity.StoreAdmin;
 import com.gongu.server.domain.store.repository.StoreAdminRepository;
+import com.gongu.server.domain.store.repository.UserStoreRepository;
 import com.gongu.server.domain.user.entity.User;
 import com.gongu.server.domain.user.repository.UserRepository;
 import com.gongu.server.global.exception.BusinessException;
@@ -37,6 +39,7 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
     private final StoreAdminRepository storeAdminRepository;
+    private final UserStoreRepository userStoreRepository;
 
     @Transactional
     public OrderDetailResponse createOrder(Long userId, Long productId, int quantity) {
@@ -45,6 +48,11 @@ public class OrderService {
 
         Product product = productRepository.findByIdWithLock(productId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        Store store = product.getStore();
+        if (!userStoreRepository.existsByUserAndStore(user, store)) {
+            throw new BusinessException(OrderErrorCode.STORE_NOT_JOINED);
+        }
 
         product.decreaseStock(quantity);
         long totalPrice = (long) product.getPrice() * quantity;

--- a/src/main/java/com/gongu/server/global/exception/errorcode/OrderErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/OrderErrorCode.java
@@ -12,7 +12,8 @@ public enum OrderErrorCode implements ErrorCode {
     PAY_NOT_ALLOWED("ORDER_004", "결제할 수 없는 상태의 주문입니다", 409),
     ARRIVE_NOT_ALLOWED("ORDER_005", "입고 처리할 수 없는 상태의 주문입니다", 409),
     INVALID_ORDER_DATA("ORDER_006", "유효하지 않은 주문 데이터입니다", 400),
-    ORDER_ITEM_NOT_FOUND("ORDER_007", "주문 항목이 존재하지 않습니다", 500);
+    ORDER_ITEM_NOT_FOUND("ORDER_007", "주문 항목이 존재하지 않습니다", 500),
+    STORE_NOT_JOINED("ORDER_008", "가입하지 않은 매장의 상품은 주문할 수 없습니다", 403);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/gongu/server/global/exception/errorcode/OrderErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/OrderErrorCode.java
@@ -12,8 +12,7 @@ public enum OrderErrorCode implements ErrorCode {
     PAY_NOT_ALLOWED("ORDER_004", "결제할 수 없는 상태의 주문입니다", 409),
     ARRIVE_NOT_ALLOWED("ORDER_005", "입고 처리할 수 없는 상태의 주문입니다", 409),
     INVALID_ORDER_DATA("ORDER_006", "유효하지 않은 주문 데이터입니다", 400),
-    ORDER_ITEM_NOT_FOUND("ORDER_007", "주문 항목이 존재하지 않습니다", 500),
-    STORE_NOT_JOINED("ORDER_008", "가입하지 않은 매장의 상품은 주문할 수 없습니다", 403);
+    ORDER_ITEM_NOT_FOUND("ORDER_007", "주문 항목이 존재하지 않습니다", 500);
 
     private final String code;
     private final String message;

--- a/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
@@ -13,6 +13,7 @@ import com.gongu.server.domain.product.repository.ProductRepository;
 import com.gongu.server.domain.store.entity.Store;
 import com.gongu.server.domain.store.entity.StoreAdmin;
 import com.gongu.server.domain.store.repository.StoreAdminRepository;
+import com.gongu.server.domain.store.repository.UserStoreRepository;
 import com.gongu.server.domain.user.entity.User;
 import com.gongu.server.domain.user.repository.UserRepository;
 import com.gongu.server.global.exception.BusinessException;
@@ -60,6 +61,9 @@ class OrderServiceTest {
     @Mock
     private StoreAdminRepository storeAdminRepository;
 
+    @Mock
+    private UserStoreRepository userStoreRepository;
+
     @InjectMocks
     private OrderService orderService;
 
@@ -68,10 +72,11 @@ class OrderServiceTest {
     void createOrder_정상_주문_생성() {
         // given
         User user = user(1L);
-        Product product = product(1L, 10);
+        Product product = product(1L, store(1L), 10);
 
         given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
         given(productRepository.findByIdWithLock(1L)).willReturn(Optional.of(product));
+        given(userStoreRepository.existsByUserAndStore(any(User.class), any(Store.class))).willReturn(true);
         given(orderRepository.save(any(Order.class))).willAnswer(inv -> inv.getArgument(0));
         given(orderItemRepository.save(any(OrderItem.class))).willAnswer(inv -> inv.getArgument(0));
 
@@ -113,6 +118,43 @@ class OrderServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("createOrder_미가입_매장_STORE_NOT_JOINED_예외")
+    void createOrder_미가입_매장_STORE_NOT_JOINED_예외() {
+        // given
+        User user = user(1L);
+        Product product = product(1L, store(1L), 10);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(productRepository.findByIdWithLock(1L)).willReturn(Optional.of(product));
+        given(userStoreRepository.existsByUserAndStore(any(User.class), any(Store.class))).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> orderService.createOrder(1L, 1L, 1))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(OrderErrorCode.STORE_NOT_JOINED));
+    }
+
+    @Test
+    @DisplayName("createOrder_미가입_매장_주문_시도_재고_차감_없음")
+    void createOrder_미가입_매장_주문_시도_재고_차감_없음() {
+        // given
+        User user = user(1L);
+        Product product = product(1L, store(1L), 10);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(productRepository.findByIdWithLock(1L)).willReturn(Optional.of(product));
+        given(userStoreRepository.existsByUserAndStore(any(User.class), any(Store.class))).willReturn(false);
+
+        // when
+        assertThatThrownBy(() -> orderService.createOrder(1L, 1L, 1))
+                .isInstanceOf(BusinessException.class);
+
+        // then
+        assertThat(product.getRemainingStock()).isEqualTo(10);
     }
 
     @Test

--- a/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
@@ -135,7 +135,7 @@ class OrderServiceTest {
         assertThatThrownBy(() -> orderService.createOrder(1L, 1L, 1))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
-                        .isEqualTo(OrderErrorCode.STORE_NOT_JOINED));
+                        .isEqualTo(ProductErrorCode.PRODUCT_NOT_FOUND));
     }
 
     @Test
@@ -153,7 +153,7 @@ class OrderServiceTest {
         assertThatThrownBy(() -> orderService.createOrder(1L, 1L, 1))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
-                        .isEqualTo(OrderErrorCode.STORE_NOT_JOINED));
+                        .isEqualTo(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         assertThat(product.getRemainingStock()).isEqualTo(10);
     }

--- a/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
@@ -149,11 +149,12 @@ class OrderServiceTest {
         given(productRepository.findByIdWithLock(1L)).willReturn(Optional.of(product));
         given(userStoreRepository.existsByUserAndStore(any(User.class), any(Store.class))).willReturn(false);
 
-        // when
+        // when & then
         assertThatThrownBy(() -> orderService.createOrder(1L, 1L, 1))
-                .isInstanceOf(BusinessException.class);
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(OrderErrorCode.STORE_NOT_JOINED));
 
-        // then
         assertThat(product.getRemainingStock()).isEqualTo(10);
     }
 


### PR DESCRIPTION
## Issue ID
close #82

## 작업 내용
- `OrderErrorCode`에 `STORE_NOT_JOINED(ORDER_008, 403)` 추가
- `OrderService.createOrder`에 주문자 매장 가입 여부 검증 추가
  - 재고 차감 전에 `userStoreRepository.existsByUserAndStore()` 호출
  - 미가입 시 `BusinessException(STORE_NOT_JOINED)` 발생
- `OrderServiceTest`에 검증 테스트 2건 추가

## 참고사항
- `product.getStore()` lazy load로 인한 추가 쿼리(N+1 개선)는 별도 이슈로 분리