### PR TITLE
[CHORE] member 표현 전면 user로 통일 (#103)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,8 @@ src/main/resources/application-local.yml
 src/main/resources/index.html
 __pycache__/
 
+### macOS ###
+.DS_Store
+
 ### Claude ###
 .claude/worktrees/

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -83,7 +83,7 @@ paths:
                   refresh_token: eyJhbGci...
                   token_type: Bearer
                   expires_in: 3600
-                  member:
+                  user:
                     id: 1
                     name: 홍길동
                     role: CUSTOMER
@@ -202,7 +202,7 @@ paths:
   # User
   # ──────────────────────────────────────────
 
-  /members/me:
+  /users/me:
     get:
       tags: [User]
       summary: 내 정보 조회
@@ -218,7 +218,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserResponse'
               example:
-                code: MEMBER_FOUND
+                code: USER_FOUND
                 data:
                   id: 1
                   name: 홍길동
@@ -258,7 +258,7 @@ paths:
         '422':
           $ref: '#/components/responses/ValidationFailed'
 
-  /members/me/stores:
+  /users/me/stores:
     post:
       tags: [User]
       summary: 이용 매장 등록
@@ -280,7 +280,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/RegisterUserStoreResponse'
               example:
-                code: MEMBER_STORE_REGISTERED
+                code: USER_STORE_REGISTERED
                 data:
                   store_id: 1
                   store_name: 소도몰 강남점
@@ -305,7 +305,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
-                code: MEMBER_STORE_DUPLICATE
+                code: USER_STORE_DUPLICATE
                 errors:
                   - field: store_id
                     reason: 이미 등록된 매장입니다.
@@ -950,8 +950,8 @@ paths:
                     RECEIVED: 2
                   content:
                     - order_id: 1
-                      member_name: 홍길동
-                      member_phone: 010-1234-5678
+                      user_name: 홍길동
+                      user_phone: 010-1234-5678
                       quantity: 2
                       total_price: 50000
                       status: PAID
@@ -960,16 +960,16 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
-  /admin/members/{member_id}/orders:
+  /admin/users/{user_id}/orders:
     get:
       tags: [Admin]
       summary: 주문 현황 조회 — 고객별
       description: 특정 고객의 매장 내 전체 주문 이력을 조회합니다.
-      operationId: getOrdersByMember
+      operationId: getOrdersByUser
       security:
         - BearerAuth: []
       parameters:
-        - name: member_id
+        - name: user_id
           in: path
           required: true
           schema:
@@ -981,10 +981,10 @@ paths:
           content:
             application/json:
               example:
-                code: ADMIN_MEMBER_ORDER_LIST_FOUND
+                code: ADMIN_USER_ORDER_LIST_FOUND
                 data:
-                  member_id: 1
-                  member_name: 홍길동
+                  user_id: 1
+                  user_name: 홍길동
                   total_orders: 3
                   content:
                     - order_id: 1
@@ -998,7 +998,7 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
-  /admin/members:
+  /admin/users:
     get:
       tags: [Admin]
       summary: 고객 목록 조회
@@ -1021,7 +1021,7 @@ paths:
           content:
             application/json:
               example:
-                code: ADMIN_MEMBER_LIST_FOUND
+                code: ADMIN_USER_LIST_FOUND
                 data:
                   content:
                     - user_id: 1
@@ -1162,7 +1162,7 @@ components:
             expires_in:
               type: integer
               description: 만료 시간 (초)
-            member:
+            user:
               type: object
               properties:
                 id:

--- a/docs/schema/ddl.sql
+++ b/docs/schema/ddl.sql
@@ -84,7 +84,7 @@ CREATE TABLE `order_items` (
     `created_at` datetime NOT NULL
 );
 
-CREATE TABLE `member_stores` (
+CREATE TABLE `user_stores` (
     `id`           bigint   NOT NULL,
     `user_id`      bigint   NOT NULL,
     `store_id`     bigint   NOT NULL,
@@ -117,7 +117,7 @@ ALTER TABLE `user_social`  ADD CONSTRAINT `PK_USER_SOCIAL`  PRIMARY KEY (`id`);
 ALTER TABLE `products`     ADD CONSTRAINT `PK_PRODUCTS`     PRIMARY KEY (`id`);
 ALTER TABLE `orders`       ADD CONSTRAINT `PK_ORDERS`       PRIMARY KEY (`id`);
 ALTER TABLE `order_items`  ADD CONSTRAINT `PK_ORDER_ITEMS`  PRIMARY KEY (`id`);
-ALTER TABLE `member_stores` ADD CONSTRAINT `PK_MEMBER_STORES` PRIMARY KEY (`id`);
+ALTER TABLE `user_stores` ADD CONSTRAINT `PK_USER_STORES` PRIMARY KEY (`id`);
 ALTER TABLE `payments`     ADD CONSTRAINT `PK_PAYMENTS`     PRIMARY KEY (`id`);
 
 -- -------------------------------------------------------------
@@ -128,12 +128,12 @@ ALTER TABLE `store_admins`
     ADD CONSTRAINT `FK_STORE_ADMINS_STORE_ID`
     FOREIGN KEY (`store_id`) REFERENCES `stores` (`id`);
 
-ALTER TABLE `member_stores`
-    ADD CONSTRAINT `FK_MEMBER_STORES_USER_ID`
+ALTER TABLE `user_stores`
+    ADD CONSTRAINT `FK_USER_STORES_USER_ID`
     FOREIGN KEY (`user_id`) REFERENCES `users` (`id`);
 
-ALTER TABLE `member_stores`
-    ADD CONSTRAINT `FK_MEMBER_STORES_STORE_ID`
+ALTER TABLE `user_stores`
+    ADD CONSTRAINT `FK_USER_STORES_STORE_ID`
     FOREIGN KEY (`store_id`) REFERENCES `stores` (`id`);
 
 ALTER TABLE `user_social`
@@ -173,8 +173,8 @@ ALTER TABLE `user_social`
     UNIQUE (`user_id`, `provider`);
 
 -- 동일 회원의 중복 매장 등록 방지
-ALTER TABLE `member_stores`
-    ADD CONSTRAINT `UQ_MEMBER_STORES_USER_STORE`
+ALTER TABLE `user_stores`
+    ADD CONSTRAINT `UQ_USER_STORES_USER_STORE`
     UNIQUE (`user_id`, `store_id`);
 
 -- 결제 멱등키 / PG사 결제번호 / 서버 주문번호 중복 방지
@@ -187,8 +187,8 @@ ALTER TABLE `payments` ADD CONSTRAINT `UQ_PAYMENTS_MERCHANT_UID`    UNIQUE (`mer
 -- -------------------------------------------------------------
 
 CREATE INDEX `IDX_STORE_ADMINS_STORE_ID`   ON `store_admins` (`store_id`);
-CREATE INDEX `IDX_MEMBER_STORES_USER_ID`   ON `member_stores` (`user_id`);
-CREATE INDEX `IDX_MEMBER_STORES_STORE_ID`  ON `member_stores` (`store_id`);
+CREATE INDEX `IDX_USER_STORES_USER_ID`   ON `user_stores` (`user_id`);
+CREATE INDEX `IDX_USER_STORES_STORE_ID`  ON `user_stores` (`store_id`);
 CREATE INDEX `IDX_USER_SOCIAL_USER_ID`     ON `user_social`  (`user_id`);
 CREATE INDEX `IDX_PRODUCTS_STORE_ID`       ON `products`     (`store_id`);
 CREATE INDEX `IDX_ORDERS_USER_ID`          ON `orders`       (`user_id`);

--- a/docs/schema/table-definitions.md
+++ b/docs/schema/table-definitions.md
@@ -6,7 +6,7 @@
 
 - [stores](#stores)
 - [store_admins](#store_admins)
-- [member_stores](#member_stores)
+- [user_stores](#user_stores)
 - [users](#users)
 - [user_social](#user_social)
 - [products](#products)
@@ -71,7 +71,7 @@
 
 ---
 
-## member_stores
+## user_stores
 
 회원-매장 다대다 연결 테이블. 회원이 이용 중인 매장 목록을 관리.
 
@@ -87,10 +87,10 @@
 
 | 이름 | 대상 컬럼 | 종류 | 비고 |
 |------|-----------|------|------|
-| PK_MEMBER_STORES | id | PRIMARY | |
-| UQ_MEMBER_STORES_USER_STORE | (user_id, store_id) | UNIQUE | 동일 매장 중복 등록 방지 |
-| IDX_MEMBER_STORES_USER_ID | user_id | INDEX (FK) | |
-| IDX_MEMBER_STORES_STORE_ID | store_id | INDEX (FK) | |
+| PK_USER_STORES | id | PRIMARY | |
+| UQ_USER_STORES_USER_STORE | (user_id, store_id) | UNIQUE | 동일 매장 중복 등록 방지 |
+| IDX_USER_STORES_USER_ID | user_id | INDEX (FK) | |
+| IDX_USER_STORES_STORE_ID | store_id | INDEX (FK) | |
 
 **FK**
 
@@ -326,4 +326,4 @@ CANCELLED  CANCELLED
 | 날짜 | 내용 |
 |------|------|
 | 2026-04-19 | 최초 작성 |
-| 2026-04-25 | member_stores 테이블 추가 (#36) |
+| 2026-04-25 | user_stores 테이블 추가 (#36) |

--- a/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/gongu/server/domain/auth/service/AuthService.java
@@ -58,9 +58,9 @@ public class AuthService {
                 .map(UserSocial::getUser)
                 .orElseGet(() -> registerKakaoUser(userInfo, socialId));
 
-        String accessToken = jwtProvider.generateAccessToken(user.getId(), Role.MEMBER);
-        String refreshToken = jwtProvider.generateRefreshToken(user.getId(), Role.MEMBER);
-        refreshTokenStore.save(user.getId(), Role.MEMBER, refreshToken);
+        String accessToken = jwtProvider.generateAccessToken(user.getId(), Role.USER);
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId(), Role.USER);
+        refreshTokenStore.save(user.getId(), Role.USER, refreshToken);
 
         return new TokenResponse(accessToken, refreshToken);
     }
@@ -97,14 +97,14 @@ public class AuthService {
         }
 
         // Redis 저장 토큰과 일치 여부 확인 (재사용 공격 방지)
-        String storedToken = refreshTokenStore.get(claims.memberId(), claims.role())
+        String storedToken = refreshTokenStore.get(claims.userId(), claims.role())
                 .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN));
         if (!storedToken.equals(request.refreshToken())) {
-            log.warn("[보안] Refresh Token 불일치 감지 — 재사용 공격 의심. memberId={}, role={}", claims.memberId(), claims.role());
+            log.warn("[보안] Refresh Token 불일치 감지 — 재사용 공격 의심. userId={}, role={}", claims.userId(), claims.role());
             throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        return new AccessTokenResponse(jwtProvider.generateAccessToken(claims.memberId(), claims.role()));
+        return new AccessTokenResponse(jwtProvider.generateAccessToken(claims.userId(), claims.role()));
     }
 
     /**

--- a/src/main/java/com/gongu/server/domain/order/controller/AdminOrderController.java
+++ b/src/main/java/com/gongu/server/domain/order/controller/AdminOrderController.java
@@ -33,13 +33,13 @@ public class AdminOrderController {
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 
-    @GetMapping("/members/{memberId}/orders")
+    @GetMapping("/users/{userId}/orders")
     @PreAuthorize("hasRole('STORE_ADMIN')")
-    public ResponseEntity<ApiResponse<Page<OrderSummaryResponse>>> getOrdersByMember(
-            @PathVariable Long memberId,
+    public ResponseEntity<ApiResponse<Page<OrderSummaryResponse>>> getOrdersByUser(
+            @PathVariable Long userId,
             @PageableDefault(size = 20) Pageable pageable,
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        Page<OrderSummaryResponse> result = orderService.getOrdersByMember(userPrincipal.id(), memberId, pageable);
+        Page<OrderSummaryResponse> result = orderService.getOrdersByUser(userPrincipal.id(), userId, pageable);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/gongu/server/domain/order/controller/OrderController.java
+++ b/src/main/java/com/gongu/server/domain/order/controller/OrderController.java
@@ -33,7 +33,7 @@ public class OrderController {
     private final OrderService orderService;
 
     @PostMapping
-    @PreAuthorize("hasRole('MEMBER')")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ApiResponse<OrderDetailResponse>> createOrder(
             @Valid @RequestBody CreateOrderRequest request,
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
@@ -42,7 +42,7 @@ public class OrderController {
     }
 
     @GetMapping("/me")
-    @PreAuthorize("hasRole('MEMBER')")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ApiResponse<Page<OrderSummaryResponse>>> getMyOrders(
             @RequestParam(required = false) OrderStatus status,
             @PageableDefault(size = 20) Pageable pageable,
@@ -52,7 +52,7 @@ public class OrderController {
     }
 
     @GetMapping("/{orderId}")
-    @PreAuthorize("hasRole('MEMBER')")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ApiResponse<OrderDetailResponse>> getOrder(
             @PathVariable Long orderId,
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
@@ -61,7 +61,7 @@ public class OrderController {
     }
 
     @PostMapping("/{orderId}/cancel")
-    @PreAuthorize("hasRole('MEMBER')")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<Void> cancelOrder(
             @PathVariable Long orderId,
             @Valid @RequestBody CancelOrderRequest request,

--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -125,11 +125,11 @@ public class OrderService {
         });
     }
 
-    public Page<OrderSummaryResponse> getOrdersByMember(Long storeAdminId, Long memberId, Pageable pageable) {
+    public Page<OrderSummaryResponse> getOrdersByUser(Long storeAdminId, Long userId, Pageable pageable) {
         StoreAdmin storeAdmin = storeAdminRepository.findByIdAndDeletedAtIsNull(storeAdminId)
                 .orElseThrow(() -> new BusinessException(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
 
-        User user = userRepository.findByIdAndDeletedAtIsNull(memberId)
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
         Page<Order> orders = orderRepository.findAllByUserAndStore(user, storeAdmin.getStore(), pageable);

--- a/src/main/java/com/gongu/server/domain/product/controller/UserProductController.java
+++ b/src/main/java/com/gongu/server/domain/product/controller/UserProductController.java
@@ -26,7 +26,7 @@ public class UserProductController {
     private final ProductService productService;
 
     @GetMapping
-    @PreAuthorize("hasRole('MEMBER')")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ApiResponse<Page<ProductSummaryResponse>>> getProducts(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @RequestParam(required = false) Long storeId,
@@ -36,7 +36,7 @@ public class UserProductController {
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasRole('MEMBER')")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ApiResponse<ProductDetailResponse>> getProduct(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long id) {

--- a/src/main/java/com/gongu/server/domain/store/controller/StoreAdminController.java
+++ b/src/main/java/com/gongu/server/domain/store/controller/StoreAdminController.java
@@ -23,7 +23,7 @@ public class StoreAdminController {
 
     private final StoreAdminService storeAdminService;
 
-    @GetMapping("/members")
+    @GetMapping("/users")
     @PreAuthorize("hasRole('STORE_ADMIN')")
     public ResponseEntity<ApiResponse<Page<AdminUserResponse>>> getUsers(
             @AuthenticationPrincipal UserPrincipal userPrincipal,

--- a/src/main/java/com/gongu/server/domain/store/entity/UserStore.java
+++ b/src/main/java/com/gongu/server/domain/store/entity/UserStore.java
@@ -25,9 +25,9 @@ import java.time.LocalDateTime;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Table(
-        name = "member_stores",
+        name = "user_stores",
         uniqueConstraints = @UniqueConstraint(
-                name = "UQ_MEMBER_STORES_USER_STORE",
+                name = "UQ_USER_STORES_USER_STORE",
                 columnNames = {"user_id", "store_id"}
         )
 )

--- a/src/main/java/com/gongu/server/domain/store/service/StoreService.java
+++ b/src/main/java/com/gongu/server/domain/store/service/StoreService.java
@@ -47,7 +47,7 @@ public class StoreService {
                 .orElseThrow(() -> new BusinessException(StoreErrorCode.STORE_NOT_FOUND));
 
         if (userStoreRepository.existsByUserAndStore(user, store)) {
-            throw new BusinessException(StoreErrorCode.MEMBER_STORE_DUPLICATE);
+            throw new BusinessException(StoreErrorCode.USER_STORE_DUPLICATE);
         }
 
         if (Boolean.TRUE.equals(request.isPreferred())) {

--- a/src/main/java/com/gongu/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/gongu/server/domain/user/controller/UserController.java
@@ -17,14 +17,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/members")
+@RequestMapping("/users")
 @RequiredArgsConstructor
 public class UserController {
 
     private final StoreService storeService;
 
     @PostMapping("/me/stores")
-    @PreAuthorize("hasRole('MEMBER')")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ApiResponse<RegisterUserStoreResponse>> registerUserStore(
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody @Valid RegisterUserStoreRequest request) {

--- a/src/main/java/com/gongu/server/global/exception/errorcode/StoreErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/StoreErrorCode.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 public enum StoreErrorCode implements ErrorCode {
 
     STORE_NOT_FOUND("STORE_001", "존재하지 않는 매장입니다", 404),
-    MEMBER_STORE_DUPLICATE("STORE_002", "이미 등록된 매장입니다", 409),
+    USER_STORE_DUPLICATE("STORE_002", "이미 등록된 매장입니다", 409),
     STORE_ADMIN_NOT_FOUND("STORE_003", "존재하지 않는 매장 관리자입니다", 404);
 
     private final String code;

--- a/src/main/java/com/gongu/server/global/security/Role.java
+++ b/src/main/java/com/gongu/server/global/security/Role.java
@@ -1,6 +1,6 @@
 package com.gongu.server.global.security;
 
 public enum Role {
-    MEMBER,
+    USER,
     STORE_ADMIN
 }

--- a/src/main/java/com/gongu/server/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gongu/server/global/security/jwt/JwtAuthenticationFilter.java
@@ -40,10 +40,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         try {
-            Long memberId = jwtProvider.getMemberIdFromToken(token);
+            Long userId = jwtProvider.getUserIdFromToken(token);
             Role role = jwtProvider.getRoleFromToken(token);
 
-            UserPrincipal principal = new UserPrincipal(memberId, role);
+            UserPrincipal principal = new UserPrincipal(userId, role);
 
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                     principal,

--- a/src/main/java/com/gongu/server/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/gongu/server/global/security/jwt/JwtProvider.java
@@ -33,10 +33,10 @@ public class JwtProvider {
         this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
     }
 
-    public String generateAccessToken(Long memberId, Role role) {
+    public String generateAccessToken(Long userId, Role role) {
         long now = System.currentTimeMillis();
         return Jwts.builder()
-                .subject(String.valueOf(memberId))
+                .subject(String.valueOf(userId))
                 .claim("type", "access")
                 .claim("role", role.name())
                 .issuedAt(new Date(now))
@@ -45,10 +45,10 @@ public class JwtProvider {
                 .compact();
     }
 
-    public String generateRefreshToken(Long memberId, Role role) {
+    public String generateRefreshToken(Long userId, Role role) {
         long now = System.currentTimeMillis();
         return Jwts.builder()
-                .subject(String.valueOf(memberId))
+                .subject(String.valueOf(userId))
                 .claim("type", "refresh")
                 .claim("role", role.name())
                 .issuedAt(new Date(now))
@@ -103,7 +103,7 @@ public class JwtProvider {
         }
     }
 
-    public Long getMemberIdFromToken(String token) {
+    public Long getUserIdFromToken(String token) {
         String subject = Jwts.parser()
                 .verifyWith(secretKey)
                 .build()
@@ -113,7 +113,7 @@ public class JwtProvider {
         try {
             return Long.parseLong(subject);
         } catch (NumberFormatException e) {
-            throw new JwtException("Invalid member ID in token subject: " + subject, e);
+            throw new JwtException("Invalid user ID in token subject: " + subject, e);
         }
     }
 
@@ -138,7 +138,7 @@ public class JwtProvider {
     }
 
     /**
-     * Refresh Token을 파싱하여 memberId와 role을 한 번에 반환한다.
+     * Refresh Token을 파싱하여 userId와 role을 한 번에 반환한다.
      * 내부적으로 서명·만료·type=refresh 검증을 수행하며, JWT를 한 번만 파싱한다.
      * 검증 실패 또는 클레임 추출 실패 시 JwtException을 던진다.
      */
@@ -153,11 +153,11 @@ public class JwtProvider {
             throw new JwtException("Not a refresh token");
         }
 
-        Long memberId;
+        Long userId;
         try {
-            memberId = Long.parseLong(claims.getSubject());
+            userId = Long.parseLong(claims.getSubject());
         } catch (NumberFormatException e) {
-            throw new JwtException("Invalid member ID in token subject", e);
+            throw new JwtException("Invalid user ID in token subject", e);
         }
 
         String roleName = claims.get("role", String.class);
@@ -171,8 +171,8 @@ public class JwtProvider {
             throw new JwtException("Unknown role claim: " + roleName, e);
         }
 
-        return new RefreshTokenClaims(memberId, role);
+        return new RefreshTokenClaims(userId, role);
     }
 
-    public record RefreshTokenClaims(Long memberId, Role role) {}
+    public record RefreshTokenClaims(Long userId, Role role) {}
 }

--- a/src/main/java/com/gongu/server/global/security/jwt/RefreshTokenStore.java
+++ b/src/main/java/com/gongu/server/global/security/jwt/RefreshTokenStore.java
@@ -19,23 +19,23 @@ public class RefreshTokenStore {
     private long refreshExpiration;
 
     /**
-     * Redis 키에 role 접두사를 포함해 Member·StoreAdmin 간 ID 충돌을 방지한다.
-     * 예: "refresh:MEMBER:1", "refresh:STORE_ADMIN:1"
+     * Redis 키에 role 접두사를 포함해 User·StoreAdmin 간 ID 충돌을 방지한다.
+     * 예: "refresh:USER:1", "refresh:STORE_ADMIN:1"
      */
-    private String key(Long memberId, Role role) {
-        return "refresh:" + role.name() + ":" + memberId;
+    private String key(Long userId, Role role) {
+        return "refresh:" + role.name() + ":" + userId;
     }
 
-    public void save(Long memberId, Role role, String refreshToken) {
+    public void save(Long userId, Role role, String refreshToken) {
         stringRedisTemplate.opsForValue()
-                .set(key(memberId, role), refreshToken, refreshExpiration, TimeUnit.MILLISECONDS);
+                .set(key(userId, role), refreshToken, refreshExpiration, TimeUnit.MILLISECONDS);
     }
 
-    public Optional<String> get(Long memberId, Role role) {
-        return Optional.ofNullable(stringRedisTemplate.opsForValue().get(key(memberId, role)));
+    public Optional<String> get(Long userId, Role role) {
+        return Optional.ofNullable(stringRedisTemplate.opsForValue().get(key(userId, role)));
     }
 
-    public void delete(Long memberId, Role role) {
-        stringRedisTemplate.delete(key(memberId, role));
+    public void delete(Long userId, Role role) {
+        stringRedisTemplate.delete(key(userId, role));
     }
 }

--- a/src/test/java/com/gongu/server/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/auth/service/AuthServiceTest.java
@@ -131,11 +131,11 @@ class AuthServiceTest {
     void refreshToken_유효한_토큰_AccessTokenResponse_반환() {
         // given
         TokenRefreshRequest request = new TokenRefreshRequest("refresh-token");
-        JwtProvider.RefreshTokenClaims claims = new JwtProvider.RefreshTokenClaims(1L, Role.MEMBER);
+        JwtProvider.RefreshTokenClaims claims = new JwtProvider.RefreshTokenClaims(1L, Role.USER);
 
         given(jwtProvider.parseRefreshToken("refresh-token")).willReturn(claims);
-        given(refreshTokenStore.get(1L, Role.MEMBER)).willReturn(Optional.of("refresh-token"));
-        given(jwtProvider.generateAccessToken(1L, Role.MEMBER)).willReturn("new-access-token");
+        given(refreshTokenStore.get(1L, Role.USER)).willReturn(Optional.of("refresh-token"));
+        given(jwtProvider.generateAccessToken(1L, Role.USER)).willReturn("new-access-token");
 
         // when
         AccessTokenResponse response = authService.refreshToken(request);
@@ -165,10 +165,10 @@ class AuthServiceTest {
     void refreshToken_Redis에_토큰_없음_INVALID_REFRESH_TOKEN_예외() {
         // given
         TokenRefreshRequest request = new TokenRefreshRequest("refresh-token");
-        JwtProvider.RefreshTokenClaims claims = new JwtProvider.RefreshTokenClaims(1L, Role.MEMBER);
+        JwtProvider.RefreshTokenClaims claims = new JwtProvider.RefreshTokenClaims(1L, Role.USER);
 
         given(jwtProvider.parseRefreshToken("refresh-token")).willReturn(claims);
-        given(refreshTokenStore.get(1L, Role.MEMBER)).willReturn(Optional.empty());
+        given(refreshTokenStore.get(1L, Role.USER)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> authService.refreshToken(request))
@@ -182,10 +182,10 @@ class AuthServiceTest {
     void refreshToken_Redis_토큰과_요청_토큰_불일치_INVALID_REFRESH_TOKEN_예외() {
         // given
         TokenRefreshRequest request = new TokenRefreshRequest("refresh-token");
-        JwtProvider.RefreshTokenClaims claims = new JwtProvider.RefreshTokenClaims(1L, Role.MEMBER);
+        JwtProvider.RefreshTokenClaims claims = new JwtProvider.RefreshTokenClaims(1L, Role.USER);
 
         given(jwtProvider.parseRefreshToken("refresh-token")).willReturn(claims);
-        given(refreshTokenStore.get(1L, Role.MEMBER)).willReturn(Optional.of("stored-refresh-token"));
+        given(refreshTokenStore.get(1L, Role.USER)).willReturn(Optional.of("stored-refresh-token"));
 
         // when & then
         assertThatThrownBy(() -> authService.refreshToken(request))
@@ -205,8 +205,8 @@ class AuthServiceTest {
         given(kakaoApiClient.getUserInfo("kakao-access-token")).willReturn(userInfo);
         given(userSocialRepository.findByProviderAndSocialId(SocialProvider.KAKAO, "12345"))
                 .willReturn(Optional.of(userSocial));
-        given(jwtProvider.generateAccessToken(1L, Role.MEMBER)).willReturn("access-token");
-        given(jwtProvider.generateRefreshToken(1L, Role.MEMBER)).willReturn("refresh-token");
+        given(jwtProvider.generateAccessToken(1L, Role.USER)).willReturn("access-token");
+        given(jwtProvider.generateRefreshToken(1L, Role.USER)).willReturn("refresh-token");
 
         // when
         TokenResponse response = authService.kakaoLogin("kakao-access-token");
@@ -214,7 +214,7 @@ class AuthServiceTest {
         // then
         assertThat(response.accessToken()).isEqualTo("access-token");
         assertThat(response.refreshToken()).isEqualTo("refresh-token");
-        verify(refreshTokenStore).save(1L, Role.MEMBER, "refresh-token");
+        verify(refreshTokenStore).save(1L, Role.USER, "refresh-token");
         verify(userRepository, never()).save(any(User.class));
         verify(userSocialRepository, never()).save(any(UserSocial.class));
     }
@@ -235,8 +235,8 @@ class AuthServiceTest {
         });
         given(userSocialRepository.save(any(UserSocial.class)))
                 .willAnswer(invocation -> invocation.getArgument(0));
-        given(jwtProvider.generateAccessToken(1L, Role.MEMBER)).willReturn("access-token");
-        given(jwtProvider.generateRefreshToken(1L, Role.MEMBER)).willReturn("refresh-token");
+        given(jwtProvider.generateAccessToken(1L, Role.USER)).willReturn("access-token");
+        given(jwtProvider.generateRefreshToken(1L, Role.USER)).willReturn("refresh-token");
 
         // when
         TokenResponse response = authService.kakaoLogin("kakao-access-token");
@@ -251,7 +251,7 @@ class AuthServiceTest {
         assertThat(userCaptor.getValue().getName()).isEqualTo("홍길동");
         assertThat(userSocialCaptor.getValue().getProvider()).isEqualTo(SocialProvider.KAKAO);
         assertThat(userSocialCaptor.getValue().getSocialId()).isEqualTo("12345");
-        verify(refreshTokenStore).save(1L, Role.MEMBER, "refresh-token");
+        verify(refreshTokenStore).save(1L, Role.USER, "refresh-token");
     }
 
     private StoreAdmin createStoreAdmin(Long id) {

--- a/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
@@ -360,8 +360,8 @@ class OrderServiceTest {
     }
 
     @Test
-    @DisplayName("getOrdersByMember_정상_회원별_주문_목록_반환")
-    void getOrdersByMember_정상_회원별_주문_목록_반환() {
+    @DisplayName("getOrdersByUser_정상_회원별_주문_목록_반환")
+    void getOrdersByUser_정상_회원별_주문_목록_반환() {
         // given
         Store store = store(1L);
         StoreAdmin storeAdmin = storeAdmin(1L, store);
@@ -378,7 +378,7 @@ class OrderServiceTest {
         given(orderItemRepository.findAllByOrder(order)).willReturn(List.of(item));
 
         // when
-        Page<OrderSummaryResponse> result = orderService.getOrdersByMember(1L, 1L, pageable);
+        Page<OrderSummaryResponse> result = orderService.getOrdersByUser(1L, 1L, pageable);
 
         // then
         assertThat(result.getTotalElements()).isEqualTo(1);
@@ -386,22 +386,22 @@ class OrderServiceTest {
     }
 
     @Test
-    @DisplayName("getOrdersByMember_존재하지_않는_매장관리자_STORE_ADMIN_NOT_FOUND_예외")
-    void getOrdersByMember_존재하지_않는_매장관리자_STORE_ADMIN_NOT_FOUND_예외() {
+    @DisplayName("getOrdersByUser_존재하지_않는_매장관리자_STORE_ADMIN_NOT_FOUND_예외")
+    void getOrdersByUser_존재하지_않는_매장관리자_STORE_ADMIN_NOT_FOUND_예외() {
         // given
         Pageable pageable = PageRequest.of(0, 20);
         given(storeAdminRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> orderService.getOrdersByMember(999L, 1L, pageable))
+        assertThatThrownBy(() -> orderService.getOrdersByUser(999L, 1L, pageable))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
     }
 
     @Test
-    @DisplayName("getOrdersByMember_존재하지_않는_유저_USER_NOT_FOUND_예외")
-    void getOrdersByMember_존재하지_않는_유저_USER_NOT_FOUND_예외() {
+    @DisplayName("getOrdersByUser_존재하지_않는_유저_USER_NOT_FOUND_예외")
+    void getOrdersByUser_존재하지_않는_유저_USER_NOT_FOUND_예외() {
         // given
         Store store = store(1L);
         StoreAdmin storeAdmin = storeAdmin(1L, store);
@@ -411,7 +411,7 @@ class OrderServiceTest {
         given(userRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> orderService.getOrdersByMember(1L, 999L, pageable))
+        assertThatThrownBy(() -> orderService.getOrdersByUser(1L, 999L, pageable))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(UserErrorCode.USER_NOT_FOUND));

--- a/src/test/java/com/gongu/server/domain/store/controller/StoreAdminControllerTest.java
+++ b/src/test/java/com/gongu/server/domain/store/controller/StoreAdminControllerTest.java
@@ -72,13 +72,13 @@ class StoreAdminControllerTest {
         };
     }
 
-    private RequestPostProcessor asMember(Long userId) {
+    private RequestPostProcessor asUser(Long userId) {
         return (MockHttpServletRequest request) -> {
-            UserPrincipal principal = new UserPrincipal(userId, Role.MEMBER);
+            UserPrincipal principal = new UserPrincipal(userId, Role.USER);
             UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
                     principal,
                     null,
-                    List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+                    List.of(new SimpleGrantedAuthority("ROLE_USER"))
             );
             SecurityContext context = SecurityContextHolder.createEmptyContext();
             context.setAuthentication(auth);
@@ -88,7 +88,7 @@ class StoreAdminControllerTest {
     }
 
     @Test
-    @DisplayName("GET /admin/members 정상_200")
+    @DisplayName("GET /admin/users 정상_200")
     void getUsers_정상_200() throws Exception {
         // given
         Long storeAdminId = 1L;
@@ -103,7 +103,7 @@ class StoreAdminControllerTest {
         given(storeAdminService.getUsers(eq(storeAdminId), isNull(), any())).willReturn(page);
 
         // when & then
-        mockMvc.perform(get("/admin/members")
+        mockMvc.perform(get("/admin/users")
                         .with(asStoreAdmin(storeAdminId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("SUCCESS"))
@@ -115,7 +115,7 @@ class StoreAdminControllerTest {
     }
 
     @Test
-    @DisplayName("GET /admin/members?name=홍 필터_200")
+    @DisplayName("GET /admin/users?name=홍 필터_200")
     void getUsers_이름_필터_200() throws Exception {
         // given
         Long storeAdminId = 1L;
@@ -129,7 +129,7 @@ class StoreAdminControllerTest {
         given(storeAdminService.getUsers(eq(storeAdminId), eq("홍"), any())).willReturn(page);
 
         // when & then
-        mockMvc.perform(get("/admin/members")
+        mockMvc.perform(get("/admin/users")
                         .param("name", "홍")
                         .with(asStoreAdmin(storeAdminId)))
                 .andExpect(status().isOk())
@@ -139,7 +139,7 @@ class StoreAdminControllerTest {
     }
 
     @Test
-    @DisplayName("GET /admin/members 존재하지 않는 매장 관리자 → 404")
+    @DisplayName("GET /admin/users 존재하지 않는 매장 관리자 → 404")
     void getUsers_STORE_ADMIN_NOT_FOUND_404() throws Exception {
         // given
         Long storeAdminId = 999L;
@@ -148,24 +148,24 @@ class StoreAdminControllerTest {
                 .willThrow(new BusinessException(StoreErrorCode.STORE_ADMIN_NOT_FOUND));
 
         // when & then
-        mockMvc.perform(get("/admin/members")
+        mockMvc.perform(get("/admin/users")
                         .with(asStoreAdmin(storeAdminId)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("STORE_003"));
     }
 
     @Test
-    @DisplayName("GET /admin/members 인증 없는 요청 → 401")
+    @DisplayName("GET /admin/users 인증 없는 요청 → 401")
     void getUsers_인증없음_401() throws Exception {
-        mockMvc.perform(get("/admin/members"))
+        mockMvc.perform(get("/admin/users"))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
-    @DisplayName("GET /admin/members ROLE_STORE_ADMIN 없는 요청 → 403")
+    @DisplayName("GET /admin/users ROLE_STORE_ADMIN 없는 요청 → 403")
     void getUsers_권한없음_403() throws Exception {
-        mockMvc.perform(get("/admin/members")
-                        .with(asMember(1L)))
+        mockMvc.perform(get("/admin/users")
+                        .with(asUser(1L)))
                 .andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/com/gongu/server/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/store/service/StoreServiceTest.java
@@ -180,8 +180,8 @@ class StoreServiceTest {
     }
 
     @Test
-    @DisplayName("registerUserStore_중복_등록_MEMBER_STORE_DUPLICATE_예외")
-    void registerUserStore_중복_등록_MEMBER_STORE_DUPLICATE_예외() {
+    @DisplayName("registerUserStore_중복_등록_USER_STORE_DUPLICATE_예외")
+    void registerUserStore_중복_등록_USER_STORE_DUPLICATE_예외() {
         // given
         User user = User.of("홍길동", "010-1234-5678");
         Store store = Store.create("테스트매장", "서울시 강남구", "02-1234-5678");
@@ -195,7 +195,7 @@ class StoreServiceTest {
         assertThatThrownBy(() -> storeService.registerUserStore(1L, request))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
-                        .isEqualTo(StoreErrorCode.MEMBER_STORE_DUPLICATE));
+                        .isEqualTo(StoreErrorCode.USER_STORE_DUPLICATE));
     }
 
     @Test

--- a/src/test/java/com/gongu/server/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/gongu/server/domain/user/controller/UserControllerTest.java
@@ -62,13 +62,13 @@ class UserControllerTest {
      * addFilters=false 환경에서는 SecurityMockMvcRequestPostProcessors.authentication()이
      * SecurityContextHolder에 반영되지 않으므로, RequestPostProcessor에서 직접 설정한다.
      */
-    private RequestPostProcessor asMember(Long userId) {
+    private RequestPostProcessor asUser(Long userId) {
         return (MockHttpServletRequest request) -> {
-            UserPrincipal principal = new UserPrincipal(userId, Role.MEMBER);
+            UserPrincipal principal = new UserPrincipal(userId, Role.USER);
             UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
                     principal,
                     null,
-                    List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
+                    List.of(new SimpleGrantedAuthority("ROLE_USER"))
             );
             SecurityContext context = SecurityContextHolder.createEmptyContext();
             context.setAuthentication(auth);
@@ -93,7 +93,7 @@ class UserControllerTest {
     }
 
     @Test
-    @DisplayName("POST /members/me/stores 정상 요청 → 201 + storeId, storeName, isPreferred")
+    @DisplayName("POST /users/me/stores 정상 요청 → 201 + storeId, storeName, isPreferred")
     void registerUserStore_정상_201() throws Exception {
         // given
         Long userId = 1L;
@@ -104,8 +104,8 @@ class UserControllerTest {
                 .willReturn(response);
 
         // when & then
-        mockMvc.perform(post("/members/me/stores")
-                        .with(asMember(userId))
+        mockMvc.perform(post("/users/me/stores")
+                        .with(asUser(userId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -115,18 +115,18 @@ class UserControllerTest {
     }
 
     @Test
-    @DisplayName("POST /members/me/stores 중복 요청 → 409 + code: STORE_002")
+    @DisplayName("POST /users/me/stores 중복 요청 → 409 + code: STORE_002")
     void registerUserStore_중복_409() throws Exception {
         // given
         Long userId = 1L;
         RegisterUserStoreRequest request = new RegisterUserStoreRequest(2L, false);
 
         given(storeService.registerUserStore(eq(userId), any(RegisterUserStoreRequest.class)))
-                .willThrow(new BusinessException(StoreErrorCode.MEMBER_STORE_DUPLICATE));
+                .willThrow(new BusinessException(StoreErrorCode.USER_STORE_DUPLICATE));
 
         // when & then
-        mockMvc.perform(post("/members/me/stores")
-                        .with(asMember(userId))
+        mockMvc.perform(post("/users/me/stores")
+                        .with(asUser(userId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isConflict())
@@ -134,36 +134,36 @@ class UserControllerTest {
     }
 
     @Test
-    @DisplayName("POST /members/me/stores storeId 누락 → 400")
+    @DisplayName("POST /users/me/stores storeId 누락 → 400")
     void registerUserStore_storeId_누락_400() throws Exception {
         // given — storeId 없이 isPreferred만 전송
         String requestBody = "{\"isPreferred\": true}";
 
         // when & then
-        mockMvc.perform(post("/members/me/stores")
-                        .with(asMember(1L))
+        mockMvc.perform(post("/users/me/stores")
+                        .with(asUser(1L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isBadRequest());
     }
 
     @Test
-    @DisplayName("POST /members/me/stores 인증 없는 요청 → 401")
+    @DisplayName("POST /users/me/stores 인증 없는 요청 → 401")
     void registerUserStore_인증없음_401() throws Exception {
         String requestBody = "{\"storeId\": 1, \"isPreferred\": false}";
 
-        mockMvc.perform(post("/members/me/stores")
+        mockMvc.perform(post("/users/me/stores")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
-    @DisplayName("POST /members/me/stores ROLE_MEMBER 없는 요청 → 403")
+    @DisplayName("POST /users/me/stores ROLE_USER 없는 요청 → 403")
     void registerUserStore_권한없음_403() throws Exception {
         String requestBody = "{\"storeId\": 1, \"isPreferred\": false}";
 
-        mockMvc.perform(post("/members/me/stores")
+        mockMvc.perform(post("/users/me/stores")
                         .with(asStoreAdmin(1L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))


### PR DESCRIPTION
## 🔷 Github Issue ID
- close #103

## 📌 작업 내용 및 특이사항
- 코드베이스 전체에서 `member` 표현을 DDL 기준(`users`, `user_stores`)에 맞게 `user`로 통일
- 커밋 단위:
  1. `chore: DDL·OpenAPI·스키마 문서 member → user 네이밍 통일` — `ddl.sql`, `table-definitions.md`, `openapi.yaml`
  2. `chore: global 보안 레이어 member → user 네이밍 통일` — `Role.java`, `JwtProvider.java`, `JwtAuthenticationFilter.java`, `RefreshTokenStore.java`
  3. `chore: domain 레이어 member → user 네이밍 통일` — 컨트롤러·서비스·엔티티·에러코드 10개 파일
  4. `chore: 테스트 코드 member → user 네이밍 통일` — 테스트 5개 파일
- `Role.MEMBER` → `Role.USER` 변경으로 기존 발급 JWT 토큰 무효화됨 (수용)
- Redis Refresh Token 키 패턴 `"refresh:MEMBER:1"` → `"refresh:USER:1"` 변경으로 기존 세션 강제 만료됨 (수용)
- `member_stores` → `user_stores` 테이블명은 DDL 문서·엔티티 어노테이션만 수정 (실 DB 마이그레이션 스크립트는 별도 작업)

## 📚 참고사항
- 검증: `grep -rni "member" src/ --include="*.java"` → 0건
- 전체 테스트 통과 (`./gradlew test`)
- Hibernate가 `user_stores` 테이블명으로 정상 인식 확인