### PR TITLE
[REFACTOR] 주문 목록 조회 N+1 제거 — IN절 벌크 쿼리 적용 (#83)

### DIFF
--- a/docs/superpowers/specs/2026-05-23-order-list-n-plus-one-fix-design.md
+++ b/docs/superpowers/specs/2026-05-23-order-list-n-plus-one-fix-design.md
@@ -1,0 +1,121 @@
+# 주문 목록 조회 N+1 해결 설계
+
+- **날짜**: 2026-05-23
+- **이슈**: [#83](https://github.com/hkjbrian/gongu/issues/83)
+- **상태**: 승인됨
+
+---
+
+## 문제
+
+`getMyOrders`, `getOrdersByProduct`, `getOrdersByUser` 세 메서드에서 페이지당 N건의 주문을 조회할 때:
+
+```
+1 query  — Page<Order> 조회
+N query  — orderItemRepository.findAllByOrder(order) (각 Order마다)
+N query  — item.getProduct().getName() 에서 Product lazy 로딩
+```
+
+페이지 20건 기준 **41 queries** 발생.
+
+---
+
+## 결정: C안 — IN절 벌크 쿼리
+
+### 선택 이유
+
+| 선택지 | 판단 |
+|--------|------|
+| A안 (fetch join + DTO projection) | 페이지네이션과 JOIN FETCH 병용 시 Hibernate가 전체 데이터를 메모리에 올린 뒤 자름. ADR-006 하에서 Order에 orderItems 컬렉션 자체가 없어 fetch join 대상 없음. |
+| B안 (@BatchSize) | 현재 코드는 명시적 루프 호출이므로 @BatchSize 미적용. 적용하려면 Order에 @OneToMany 추가 필요 → ADR-006 위반. |
+| **C안 (IN절 벌크 쿼리)** | **ADR-006 완전 준수. 2 queries 고정. 코드 이해 명확.** |
+
+---
+
+## 변경 범위
+
+총 2개 파일만 수정. 엔티티, DTO, Controller 무변경.
+
+| 레이어 | 파일 |
+|--------|------|
+| Repository | `OrderItemRepository` |
+| Service | `OrderService` |
+
+---
+
+## 설계 상세
+
+### OrderItemRepository — 쿼리 메서드 추가
+
+```java
+@Query("SELECT oi FROM OrderItem oi JOIN FETCH oi.product WHERE oi.order IN :orders")
+List<OrderItem> findAllByOrderInWithProduct(@Param("orders") List<Order> orders);
+```
+
+- `JOIN FETCH oi.product` → Product lazy 로딩 방지
+- 반환 타입 `List` → 페이지네이션 간섭 없음
+
+### OrderService — 공통 헬퍼 추출
+
+3개 목록 조회 메서드의 반복 로직을 private 헬퍼로 통합:
+
+```java
+private Page<OrderSummaryResponse> toSummaryPage(Page<Order> orders) {
+    if (orders.isEmpty()) return orders.map(o -> null);
+
+    List<OrderItem> items = orderItemRepository
+        .findAllByOrderInWithProduct(orders.getContent());
+
+    Map<Long, OrderItem> itemByOrderId = items.stream()
+        .collect(Collectors.toMap(item -> item.getOrder().getId(), item -> item));
+
+    return orders.map(order -> {
+        OrderItem item = itemByOrderId.get(order.getId());
+        if (item == null) throw new BusinessException(OrderErrorCode.ORDER_ITEM_NOT_FOUND);
+        return OrderSummaryResponse.of(order, item);
+    });
+}
+```
+
+**빈 페이지 처리**: `orders.getContent()`가 비어있을 때 IN절에 빈 리스트를 넘기면 일부 DB/JPA 구현체에서 오류 발생 가능 → early return.
+
+### 호출부 (3곳 동일)
+
+```java
+// before
+return orders.map(order -> {
+    List<OrderItem> items = orderItemRepository.findAllByOrder(order);
+    return OrderSummaryResponse.of(order, items.stream().findFirst()
+            .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_ITEM_NOT_FOUND)));
+});
+
+// after
+return toSummaryPage(orders);
+```
+
+---
+
+## 쿼리 수 비교
+
+| 메서드 | 기존 (페이지 20건) | 변경 후 |
+|--------|-------------------|---------|
+| `getMyOrders` | 41 | **2** |
+| `getOrdersByProduct` | 41 | **2** |
+| `getOrdersByUser` | 41 | **2** |
+
+---
+
+## 테스트 전략
+
+`OrderServiceTest`에 추가할 케이스:
+
+1. **정상 케이스** — N건 orders 조회 시 `findAllByOrderInWithProduct` 1회 호출, 응답 N건 검증
+2. **빈 페이지** — 결과 0건일 때 IN 쿼리 미호출 검증
+3. **OrderItem 누락** — itemByOrderId 매핑 실패 시 `ORDER_ITEM_NOT_FOUND` 예외 검증
+
+---
+
+## ADR 준수 확인
+
+- ADR-006 (단방향 @ManyToOne만 사용): ✅ Order에 @OneToMany 추가 없음
+- ADR-002 (3-Layered + Rich Domain Model): ✅ 서비스 레이어에서 컬렉션 조회 후 도메인 메서드 인자 전달 패턴 유지

--- a/src/main/java/com/gongu/server/domain/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/gongu/server/domain/order/repository/OrderItemRepository.java
@@ -3,10 +3,15 @@ package com.gongu.server.domain.order.repository;
 import com.gongu.server.domain.order.entity.Order;
 import com.gongu.server.domain.order.entity.OrderItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
 
     List<OrderItem> findAllByOrder(Order order);
+
+    @Query("SELECT oi FROM OrderItem oi JOIN FETCH oi.product WHERE oi.order IN :orders")
+    List<OrderItem> findAllByOrderInWithProduct(@Param("orders") List<Order> orders);
 }

--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -140,12 +140,16 @@ public class OrderService {
 
     private Page<OrderSummaryResponse> toSummaryPage(Page<Order> orders) {
         if (orders.isEmpty()) {
-            return orders.map(order -> null);
+            return Page.empty(orders.getPageable());
         }
         List<OrderItem> items =
                 orderItemRepository.findAllByOrderInWithProduct(orders.getContent());
         Map<Long, OrderItem> itemByOrderId = items.stream()
-                .collect(Collectors.toMap(item -> item.getOrder().getId(), item -> item));
+                .collect(Collectors.toMap(
+                        item -> item.getOrder().getId(),
+                        item -> item,
+                        (a, b) -> a  // 주문당 OrderItem 1건 보장, 혹시 중복 시 첫 번째 사용
+                ));
         return orders.map(order -> {
             OrderItem item = itemByOrderId.get(order.getId());
             if (item == null) {

--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -28,6 +28,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -100,11 +102,7 @@ public class OrderService {
             orders = orderRepository.findAllByUserAndStatusOrderByCreatedAtDesc(user, status, pageable);
         }
 
-        return orders.map(order -> {
-            List<OrderItem> items = orderItemRepository.findAllByOrder(order);
-            return OrderSummaryResponse.of(order, items.stream().findFirst()
-                    .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_ITEM_NOT_FOUND)));
-        });
+        return toSummaryPage(orders);
     }
 
     public OrderDetailResponse getOrder(Long userId, Long orderId) {
@@ -126,11 +124,7 @@ public class OrderService {
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         Page<Order> orders = orderRepository.findAllByProduct(product, pageable);
-        return orders.map(order -> {
-            List<OrderItem> items = orderItemRepository.findAllByOrder(order);
-            return OrderSummaryResponse.of(order, items.stream().findFirst()
-                    .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_ITEM_NOT_FOUND)));
-        });
+        return toSummaryPage(orders);
     }
 
     public Page<OrderSummaryResponse> getOrdersByUser(Long storeAdminId, Long userId, Pageable pageable) {
@@ -141,10 +135,23 @@ public class OrderService {
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
         Page<Order> orders = orderRepository.findAllByUserAndStore(user, storeAdmin.getStore(), pageable);
+        return toSummaryPage(orders);
+    }
+
+    private Page<OrderSummaryResponse> toSummaryPage(Page<Order> orders) {
+        if (orders.isEmpty()) {
+            return orders.map(order -> null);
+        }
+        List<OrderItem> items =
+                orderItemRepository.findAllByOrderInWithProduct(orders.getContent());
+        Map<Long, OrderItem> itemByOrderId = items.stream()
+                .collect(Collectors.toMap(item -> item.getOrder().getId(), item -> item));
         return orders.map(order -> {
-            List<OrderItem> items = orderItemRepository.findAllByOrder(order);
-            return OrderSummaryResponse.of(order, items.stream().findFirst()
-                    .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_ITEM_NOT_FOUND)));
+            OrderItem item = itemByOrderId.get(order.getId());
+            if (item == null) {
+                throw new BusinessException(OrderErrorCode.ORDER_ITEM_NOT_FOUND);
+            }
+            return OrderSummaryResponse.of(order, item);
         });
     }
 }

--- a/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -294,7 +295,7 @@ class OrderServiceTest {
 
         given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
         given(orderRepository.findAllByUserOrderByCreatedAtDesc(user, pageable)).willReturn(orderPage);
-        given(orderItemRepository.findAllByOrder(order)).willReturn(List.of(item));
+        given(orderItemRepository.findAllByOrderInWithProduct(List.of(order))).willReturn(List.of(item));
 
         // when
         Page<OrderSummaryResponse> result = orderService.getMyOrders(1L, null, pageable);
@@ -319,7 +320,7 @@ class OrderServiceTest {
         given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
         given(orderRepository.findAllByUserAndStatusOrderByCreatedAtDesc(user, OrderStatus.RESERVED, pageable))
                 .willReturn(orderPage);
-        given(orderItemRepository.findAllByOrder(order)).willReturn(List.of(item));
+        given(orderItemRepository.findAllByOrderInWithProduct(List.of(order))).willReturn(List.of(item));
 
         // when
         Page<OrderSummaryResponse> result = orderService.getMyOrders(1L, OrderStatus.RESERVED, pageable);
@@ -345,6 +346,74 @@ class OrderServiceTest {
     }
 
     @Test
+    @DisplayName("getMyOrders_빈_페이지_IN쿼리_미호출")
+    void getMyOrders_빈_페이지_IN쿼리_미호출() {
+        // given
+        User user = user(1L);
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Order> emptyPage = Page.empty(pageable);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(orderRepository.findAllByUserOrderByCreatedAtDesc(user, pageable)).willReturn(emptyPage);
+
+        // when
+        Page<OrderSummaryResponse> result = orderService.getMyOrders(1L, null, pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(0);
+        verify(orderItemRepository, never()).findAllByOrderInWithProduct(any());
+    }
+
+    @Test
+    @DisplayName("getMyOrders_OrderItem_누락_ORDER_ITEM_NOT_FOUND_예외")
+    void getMyOrders_OrderItem_누락_ORDER_ITEM_NOT_FOUND_예외() {
+        // given
+        User user = user(1L);
+        Order order = order(1L, user, 10_000L);
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Order> orderPage = new PageImpl<>(List.of(order), pageable, 1);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(orderRepository.findAllByUserOrderByCreatedAtDesc(user, pageable)).willReturn(orderPage);
+        given(orderItemRepository.findAllByOrderInWithProduct(List.of(order))).willReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.getMyOrders(1L, null, pageable))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(OrderErrorCode.ORDER_ITEM_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("getMyOrders_복수_주문_정상_매핑")
+    void getMyOrders_복수_주문_정상_매핑() {
+        // given
+        User user = user(1L);
+        Product product1 = product(1L, 10);
+        Product product2 = product(2L, 10);
+        Order order1 = order(1L, user, 10_000L);
+        Order order2 = order(2L, user, 20_000L);
+        OrderItem item1 = orderItem(order1, product1, 1L);
+        OrderItem item2 = orderItem(order2, product2, 2L);
+        setId(item2, 2L);
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Order> orderPage = new PageImpl<>(List.of(order1, order2), pageable, 2);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(orderRepository.findAllByUserOrderByCreatedAtDesc(user, pageable)).willReturn(orderPage);
+        given(orderItemRepository.findAllByOrderInWithProduct(List.of(order1, order2)))
+                .willReturn(List.of(item1, item2));
+
+        // when
+        Page<OrderSummaryResponse> result = orderService.getMyOrders(1L, null, pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent()).extracting("productName")
+                .containsExactlyInAnyOrder("상품1", "상품2");
+    }
+
+    @Test
     @DisplayName("getOrdersByProduct_정상_상품별_주문_목록_반환")
     void getOrdersByProduct_정상_상품별_주문_목록_반환() {
         // given
@@ -360,7 +429,7 @@ class OrderServiceTest {
         given(storeAdminRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(storeAdmin));
         given(productRepository.findByIdAndStore(1L, store)).willReturn(Optional.of(product));
         given(orderRepository.findAllByProduct(product, pageable)).willReturn(orderPage);
-        given(orderItemRepository.findAllByOrder(order)).willReturn(List.of(item));
+        given(orderItemRepository.findAllByOrderInWithProduct(List.of(order))).willReturn(List.of(item));
 
         // when
         Page<OrderSummaryResponse> result = orderService.getOrdersByProduct(1L, 1L, pageable);
@@ -418,7 +487,7 @@ class OrderServiceTest {
         given(storeAdminRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(storeAdmin));
         given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
         given(orderRepository.findAllByUserAndStore(user, store, pageable)).willReturn(orderPage);
-        given(orderItemRepository.findAllByOrder(order)).willReturn(List.of(item));
+        given(orderItemRepository.findAllByOrderInWithProduct(List.of(order))).willReturn(List.of(item));
 
         // when
         Page<OrderSummaryResponse> result = orderService.getOrdersByUser(1L, 1L, pageable);

--- a/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
@@ -395,7 +395,6 @@ class OrderServiceTest {
         Order order2 = order(2L, user, 20_000L);
         OrderItem item1 = orderItem(order1, product1, 1L);
         OrderItem item2 = orderItem(order2, product2, 2L);
-        setId(item2, 2L);
         Pageable pageable = PageRequest.of(0, 20);
         Page<Order> orderPage = new PageImpl<>(List.of(order1, order2), pageable, 2);
 


### PR DESCRIPTION
## 🔷 Github Issue ID
- close #83

## 📌 작업 내용 및 특이사항
- `getMyOrders`, `getOrdersByProduct`, `getOrdersByUser` 세 메서드에서 발생하던 N+1 쿼리 제거
- **기존**: 페이지당 N건 × (OrderItem 조회 + Product lazy 로딩) → 최대 1 + 2N queries
- **변경**: Page\<Order\> 조회 후 `findAllByOrderInWithProduct`(IN절 + JOIN FETCH)로 1회 일괄 조회 → **2 queries 고정**
- ADR-006(단방향 @ManyToOne) 완전 준수 — Order에 @OneToMany 컬렉션 추가 없음
- 3개 목록 조회 메서드의 공통 로직을 `toSummaryPage()` private 헬퍼로 추출

## 📚 참고사항
- 설계 문서: `docs/superpowers/specs/2026-05-23-order-list-n-plus-one-fix-design.md`
- 논의 이슈: #83 (A안 페이지네이션 문제, B안 ADR-006 위반 검토 후 C안 선택)
- 빈 페이지 early return으로 IN절에 빈 리스트 전달 방지
- 신규 테스트 3개 추가: 빈 페이지 IN쿼리 미호출, OrderItem 누락 예외, 복수 주문 정상 매핑