### PR TITLE
[FIX] 스케줄러 트랜잭션 경계 — 상품별 REQUIRES_NEW 개별 트랜잭션 분리 (#98)

### DIFF
--- a/docs/superpowers/plans/2026-05-25-scheduler-individual-transaction.md
+++ b/docs/superpowers/plans/2026-05-25-scheduler-individual-transaction.md
@@ -1,0 +1,160 @@
+# 스케줄러 트랜잭션 경계 개선 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `ProductStatusScheduler.activateUpcomingProducts()`의 단일 트랜잭션을 개별 `REQUIRES_NEW` 트랜잭션으로 분리하여 단일 상품 실패가 다른 상품 전이에 영향을 주지 않도록 한다.
+
+**Issue:** #98
+
+**Tech Stack:** Spring Boot 3.5, Java 25, JUnit 5 + Mockito
+
+---
+
+## 설계 결정 (논의 완료)
+
+- **채택: 개별 트랜잭션 (`REQUIRES_NEW`)**
+- Self-invocation 방지를 위해 별도 Helper 빈 도입
+- `activateUpcomingProducts()`에서 `@Transactional` 제거 → Connection 이중 점유 방지
+- 실패 상품은 `log.error`로 ID와 예외를 로깅하고 계속 진행
+- 최대 처리 수 ~50개 이하 / 1분 주기 → N 트랜잭션 성능 부담 없음
+
+---
+
+## File Map
+
+| 상태 | 파일 경로 |
+|------|----------|
+| **Create** | `src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusTransactionHelper.java` |
+| **Modify** | `src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusScheduler.java` |
+| **Modify** | `src/test/java/com/gongu/server/domain/product/scheduler/ProductStatusSchedulerTest.java` |
+| **Reference** | `src/main/java/com/gongu/server/domain/product/entity/Product.java` — `activate()` 메서드 시그니처 확인 |
+| **Reference** | `src/main/java/com/gongu/server/global/exception/BusinessException.java` — 예외 타입 확인 |
+| **Reference** | `src/main/java/com/gongu/server/global/exception/errorcode/ProductErrorCode.java` — 에러코드 확인 |
+
+---
+
+## Task 1: `ProductStatusTransactionHelper` 생성
+
+**참고 문서/파일:**
+- `src/main/java/com/gongu/server/domain/product/entity/Product.java` — `activate()` 시그니처
+- `src/main/java/com/gongu/server/global/exception/BusinessException.java` — catch 대상 타입
+
+**수정 대상 파일:**
+- Create: `src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusTransactionHelper.java`
+
+**금지 사항:**
+- `ProductStatusScheduler.java` 수정 금지 (Task 2에서 처리)
+- 기존 파일 일체 수정 금지
+
+**구현 방향:**
+- 패키지: `com.gongu.server.domain.product.scheduler`
+- 클래스 어노테이션: `@Component`, `@RequiredArgsConstructor`
+- 메서드 하나: `activateOne(Product product)`
+  - `@Transactional(propagation = Propagation.REQUIRES_NEW)` 적용
+  - 내부에서 `product.activate()` 호출
+  - 예외를 catch하지 않는다 — 예외 전파를 스케줄러에서 처리
+
+**검증:**
+```bash
+./gradlew compileJava
+```
+Expected: BUILD SUCCESSFUL
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusTransactionHelper.java
+git commit -m "feat: ProductStatusTransactionHelper REQUIRES_NEW 트랜잭션 헬퍼 추가 (#98)"
+```
+
+---
+
+## Task 2: `ProductStatusScheduler` 수정
+
+**참고 문서/파일:**
+- `src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusScheduler.java` — 현재 구조
+- `src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusTransactionHelper.java` — Task 1 결과물
+
+**수정 대상 파일:**
+- Modify: `src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusScheduler.java`
+
+**금지 사항:**
+- `findActivatableUpcomingProducts()` 쿼리 로직 변경 금지
+- `@Scheduled` cron 식 변경 금지
+
+**구현 방향:**
+- `ProductStatusTransactionHelper` 필드 주입 추가 (`@RequiredArgsConstructor` 활용)
+- `activateUpcomingProducts()` 메서드에서 `@Transactional` 제거
+- `forEach(Product::activate)` → 아래 루프로 교체:
+  ```
+  for (Product product : products) {
+      try {
+          helper.activateOne(product);
+      } catch (Exception e) {
+          log.error("상품 활성화 실패: id={}", product.getId(), e);
+      }
+  }
+  ```
+- 클래스에 `@Slf4j` (Lombok) 어노테이션 추가
+
+**검증:**
+```bash
+./gradlew compileJava
+```
+Expected: BUILD SUCCESSFUL
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusScheduler.java
+git commit -m "fix: 스케줄러 단일 트랜잭션 → 상품별 REQUIRES_NEW 개별 트랜잭션 분리 (#98)"
+```
+
+---
+
+## Task 3: `ProductStatusSchedulerTest` 수정
+
+**참고 문서/파일:**
+- `src/test/java/com/gongu/server/domain/product/scheduler/ProductStatusSchedulerTest.java` — 기존 테스트 패턴
+- `src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusScheduler.java` — 수정된 구조
+- `src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusTransactionHelper.java` — Mock 대상
+
+**수정 대상 파일:**
+- Modify: `src/test/java/com/gongu/server/domain/product/scheduler/ProductStatusSchedulerTest.java`
+
+**금지 사항:**
+- 기존 테스트 케이스 삭제 금지 (수정은 가능 — 스케줄러 의존성이 바뀌었으므로)
+
+**구현 방향:**
+- `@Mock ProductStatusTransactionHelper helper` 추가
+- 기존 `@InjectMocks ProductStatusScheduler scheduler` 유지 — Helper도 자동 주입됨
+- 기존 테스트 케이스 수정:
+  - `forEach(Product::activate)` 대신 `helper.activateOne(product)`가 호출되므로, `helper.activateOne()` 호출 여부를 단언하거나 `doAnswer`로 실제 `product.activate()`를 실행하도록 stub 처리
+  - 상태 단언(`product.getStatus() == ACTIVE`)은 유지하기 위해 stub에서 `product.activate()`를 직접 호출하는 방식 사용:
+    ```
+    doAnswer(inv -> { ((Product) inv.getArgument(0)).activate(); return null; })
+        .when(helper).activateOne(any(Product.class));
+    ```
+- 신규 테스트 케이스 추가:
+  - `activateUpcomingProducts_1개_실패_시_나머지_성공`: 3개 상품 중 두 번째 상품이 `activateOne()` 호출 시 `BusinessException` throw → 나머지 2개는 정상 전이 단언
+
+**검증:**
+```bash
+./gradlew test --tests "com.gongu.server.domain.product.scheduler.*"
+```
+Expected: 모든 테스트 통과
+
+```bash
+./gradlew test
+```
+Expected: BUILD SUCCESSFUL (전체 테스트 통과)
+
+**커밋:**
+```bash
+git add src/test/java/com/gongu/server/domain/product/scheduler/ProductStatusSchedulerTest.java
+git commit -m "test: 스케줄러 개별 트랜잭션 단위 테스트 추가 (#98)"
+```
+
+---
+
+## PR 생성 후
+
+PR 생성 후 CLAUDE.md 9~11단계(Codex 리뷰 위임 → 판정 → 반영) 따름.

--- a/src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusScheduler.java
+++ b/src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusScheduler.java
@@ -4,23 +4,31 @@ import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.entity.ProductStatus;
 import com.gongu.server.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ProductStatusScheduler {
 
     private final ProductRepository productRepository;
+    private final ProductStatusTransactionHelper productStatusTransactionHelper;
 
     @Scheduled(cron = "0 * * * * *")
-    @Transactional
     public void activateUpcomingProducts() {
-        productRepository
-                .findActivatableUpcomingProducts(ProductStatus.UPCOMING, LocalDateTime.now())
-                .forEach(Product::activate);
+        List<Product> products = productRepository.findActivatableUpcomingProducts(ProductStatus.UPCOMING, LocalDateTime.now());
+
+        for (Product product : products) {
+            try {
+                productStatusTransactionHelper.activateOne(product);
+            } catch (Exception e) {
+                log.error("상품 활성화 실패: id={}", product.getId(), e);
+            }
+        }
     }
 }

--- a/src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusScheduler.java
+++ b/src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusScheduler.java
@@ -25,7 +25,7 @@ public class ProductStatusScheduler {
 
         for (Product product : products) {
             try {
-                productStatusTransactionHelper.activateOne(product);
+                productStatusTransactionHelper.activateOne(product.getId());
             } catch (Exception e) {
                 log.error("상품 활성화 실패: id={}", product.getId(), e);
             }

--- a/src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusTransactionHelper.java
+++ b/src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusTransactionHelper.java
@@ -1,0 +1,17 @@
+package com.gongu.server.domain.product.scheduler;
+
+import com.gongu.server.domain.product.entity.Product;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ProductStatusTransactionHelper {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void activateOne(Product product) {
+        product.activate();
+    }
+}

--- a/src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusTransactionHelper.java
+++ b/src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusTransactionHelper.java
@@ -1,6 +1,9 @@
 package com.gongu.server.domain.product.scheduler;
 
 import com.gongu.server.domain.product.entity.Product;
+import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.ProductErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -10,8 +13,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ProductStatusTransactionHelper {
 
+    private final ProductRepository productRepository;
+
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void activateOne(Product product) {
+    public void activateOne(Long productId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
         product.activate();
     }
 }

--- a/src/test/java/com/gongu/server/domain/product/scheduler/ProductStatusSchedulerTest.java
+++ b/src/test/java/com/gongu/server/domain/product/scheduler/ProductStatusSchedulerTest.java
@@ -4,6 +4,8 @@ import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.entity.ProductStatus;
 import com.gongu.server.domain.product.repository.ProductRepository;
 import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.ProductErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,12 +20,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
 
 @ExtendWith(MockitoExtension.class)
 class ProductStatusSchedulerTest {
 
     @Mock
     private ProductRepository productRepository;
+
+    @Mock
+    private ProductStatusTransactionHelper productStatusTransactionHelper;
 
     @InjectMocks
     private ProductStatusScheduler scheduler;
@@ -42,6 +48,10 @@ class ProductStatusSchedulerTest {
         given(productRepository.findActivatableUpcomingProducts(
                 eq(ProductStatus.UPCOMING), any(LocalDateTime.class)))
                 .willReturn(List.of(product1, product2));
+        doAnswer(invocation -> {
+            ((Product) invocation.getArgument(0)).activate();
+            return null;
+        }).when(productStatusTransactionHelper).activateOne(any(Product.class));
 
         // when
         scheduler.activateUpcomingProducts();
@@ -61,6 +71,37 @@ class ProductStatusSchedulerTest {
 
         // when & then (예외 없이 정상 종료)
         scheduler.activateUpcomingProducts();
+    }
+
+    @Test
+    @DisplayName("activateUpcomingProducts_1개_실패_시_나머지_성공")
+    void activateUpcomingProducts_1개_실패_시_나머지_성공() {
+        // given
+        Store store = createStore("테스트매장");
+        Product product1 = createProduct(store, "상품1", ProductStatus.UPCOMING);
+        Product product2 = createProduct(store, "상품2", ProductStatus.UPCOMING);
+        Product product3 = createProduct(store, "상품3", ProductStatus.UPCOMING);
+
+        given(productRepository.findActivatableUpcomingProducts(
+                eq(ProductStatus.UPCOMING), any(LocalDateTime.class)))
+                .willReturn(List.of(product1, product2, product3));
+        doAnswer(invocation -> {
+            Product product = invocation.getArgument(0);
+            if (product == product2) {
+                throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_STATUS);
+            }
+
+            product.activate();
+            return null;
+        }).when(productStatusTransactionHelper).activateOne(any(Product.class));
+
+        // when
+        scheduler.activateUpcomingProducts();
+
+        // then
+        assertThat(product1.getStatus()).isEqualTo(ProductStatus.ACTIVE);
+        assertThat(product2.getStatus()).isEqualTo(ProductStatus.UPCOMING);
+        assertThat(product3.getStatus()).isEqualTo(ProductStatus.ACTIVE);
     }
 
     private Store createStore(String name) {

--- a/src/test/java/com/gongu/server/domain/product/scheduler/ProductStatusSchedulerTest.java
+++ b/src/test/java/com/gongu/server/domain/product/scheduler/ProductStatusSchedulerTest.java
@@ -12,9 +12,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,14 +46,21 @@ class ProductStatusSchedulerTest {
         Store store = createStore("테스트매장");
         Product product1 = createProduct(store, "상품1", ProductStatus.UPCOMING);
         Product product2 = createProduct(store, "상품2", ProductStatus.UPCOMING);
+        setProductId(product1, 1L);
+        setProductId(product2, 2L);
+        Map<Long, Product> productsById = Map.of(
+                product1.getId(), product1,
+                product2.getId(), product2
+        );
 
         given(productRepository.findActivatableUpcomingProducts(
                 eq(ProductStatus.UPCOMING), any(LocalDateTime.class)))
                 .willReturn(List.of(product1, product2));
         doAnswer(invocation -> {
-            ((Product) invocation.getArgument(0)).activate();
+            Long productId = invocation.getArgument(0);
+            productsById.get(productId).activate();
             return null;
-        }).when(productStatusTransactionHelper).activateOne(any(Product.class));
+        }).when(productStatusTransactionHelper).activateOne(any(Long.class));
 
         // when
         scheduler.activateUpcomingProducts();
@@ -81,19 +90,28 @@ class ProductStatusSchedulerTest {
         Product product1 = createProduct(store, "상품1", ProductStatus.UPCOMING);
         Product product2 = createProduct(store, "상품2", ProductStatus.UPCOMING);
         Product product3 = createProduct(store, "상품3", ProductStatus.UPCOMING);
+        setProductId(product1, 1L);
+        setProductId(product2, 2L);
+        setProductId(product3, 3L);
+        Map<Long, Product> productsById = Map.of(
+                product1.getId(), product1,
+                product2.getId(), product2,
+                product3.getId(), product3
+        );
 
         given(productRepository.findActivatableUpcomingProducts(
                 eq(ProductStatus.UPCOMING), any(LocalDateTime.class)))
                 .willReturn(List.of(product1, product2, product3));
         doAnswer(invocation -> {
-            Product product = invocation.getArgument(0);
+            Long productId = invocation.getArgument(0);
+            Product product = productsById.get(productId);
             if (product == product2) {
                 throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_STATUS);
             }
 
             product.activate();
             return null;
-        }).when(productStatusTransactionHelper).activateOne(any(Product.class));
+        }).when(productStatusTransactionHelper).activateOne(any(Long.class));
 
         // when
         scheduler.activateUpcomingProducts();
@@ -110,5 +128,9 @@ class ProductStatusSchedulerTest {
 
     private Product createProduct(Store store, String name, ProductStatus status) {
         return Product.create(store, name, "상품 설명", 10_000L, 100, status, startAt, endAt);
+    }
+
+    private void setProductId(Product product, Long id) {
+        ReflectionTestUtils.setField(product, "id", id);
     }
 }


### PR DESCRIPTION
## Issue ID
close #98

## 작업 내용

### 문제
`ProductStatusScheduler.activateUpcomingProducts()`가 단일 `@Transactional`로 전체 배치를 묶고 있어, 1개 상품이 `activate()` 실패 시 전체가 롤백되는 문제.

### 해결 방식: 개별 트랜잭션 (REQUIRES_NEW)
Self-invocation 우회를 위해 `ProductStatusTransactionHelper` 빈을 별도 도입.

- **ProductStatusTransactionHelper** (신규): `@Transactional(propagation = REQUIRES_NEW)`로 상품 1개씩 처리
- **ProductStatusScheduler** 수정:
  - `@Transactional` 제거 (Connection 이중 점유 방지)
  - `forEach` → for 루프 + try-catch 교체
  - 실패 상품은 `log.error("상품 활성화 실패: id={}", ...)` 로깅 후 계속 진행

### 테스트
- 기존 테스트 Helper Mock 방식으로 수정
- 신규: 3개 상품 중 1개 실패 시 나머지 2개 정상 전이 케이스 추가

## 참고사항
- REQUIRES_NEW는 매 iteration마다 Connection을 획득·반납하며, 단일 스레드에서 물리 Connection 재사용 가능
- 최대 ~50개 / 1분 주기 → N 트랜잭션 성능 부담 없음
- 스케줄러 `@Transactional` 제거로 외부·내부 트랜잭션 간 Connection 이중 점유 방지