### PR TITLE
[CHORE] Resilience4j·AOP 의존성 및 PortOne 설정 추가 (#115)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 
+	// Actuator (CircuitBreaker health indicator)
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ dependencies {
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// Resilience4j
+	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,3 +31,25 @@ cors:
 
 app:
   timezone: Asia/Seoul
+
+portone:
+  api-secret: ${PORTONE_API_SECRET}
+  base-url: https://api.portone.io
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      portone:
+        sliding-window-size: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+        permitted-number-of-calls-in-half-open-state: 3
+        register-health-indicator: true
+  retry:
+    instances:
+      portone:
+        max-attempts: 3
+        wait-duration: 500ms
+        retry-exceptions:
+          - java.io.IOException
+          - org.springframework.web.client.ResourceAccessException


### PR DESCRIPTION
## 🔷 Github Issue ID
- close #115

## 📌 작업 내용 및 특이사항
- `build.gradle`에 Resilience4j(`resilience4j-spring-boot3:2.2.0`) 및 Spring AOP 의존성 추가
- `application.yml`에 PortOne API 설정 블록 추가 (`portone.api-secret`, `portone.base-url`)
- `application.yml`에 Resilience4j 서킷브레이커·리트라이 설정 블록 추가 (인스턴스명: `portone`)
  - CircuitBreaker: sliding-window-size=10, failure-rate-threshold=50%, wait-duration=30s
  - Retry: max-attempts=3, wait-duration=500ms

## 📚 참고사항
- PORTONE_API_SECRET 환경변수는 배포 환경에 별도 등록 필요
- 이후 이슈(#117, #118)에서 PortOneClient 및 서킷브레이커 AOP 적용 예정