### PR TITLE
[FEAT] PortOneClient 구현 (RestClient 기반, V2 API 연동) (#117)

### DIFF
--- a/.claude/review-process.md
+++ b/.claude/review-process.md
@@ -215,6 +215,13 @@ cat docs/adr/아키텍처_및_코드_컨벤션.md
 
 ### [5] 합의 후 실행
 
+> ✅ **[4]→[5] 진입 체크리스트 — 모두 완료 전 코드 수정 시작 금지**
+> - [ ] 각 인라인 thread에 판정 reply 완료 (`/pulls/.../comments/{id}/replies`)
+> - [ ] 거부 판정 thread에도 거부 사유 reply 완료
+> - [ ] reply가 달린 comment_id 목록 확인 (누락 없음)
+>
+> **reply가 하나라도 빠져 있으면 수정 구현을 시작하지 않는다.**
+
 사용자가 확인하면:
 1. **각 인라인 리뷰 코멘트 thread에 판정 결과를 직접 reply로 달기** ([5-1] 참고)
 2. 수정 사항 구현 (Codex에게 다시 위임한다.)
@@ -269,6 +276,14 @@ gh api repos/hkjbrian/gongu/pulls/{PR번호}/comments/{comment_id}/replies \
 ```
 
 ### [5-2] 최종 approve 순서
+
+> ✅ **[5-2] 진입 체크리스트 — 모두 완료 전 approve 금지**
+> - [ ] 재리뷰에서 새 이슈 없음 확인
+> - [ ] [5-3] 판정 결과 종합 코멘트 포스팅 완료
+> - [ ] 미해결 review thread 전체 resolve 완료 (graphql mutation 실행)
+> - [ ] `gh pr review {PR번호} --approve` 실행
+>
+> **종합 코멘트만 달고 resolve 없이 approve하는 것은 금지된다.**
 
 모든 판정·수정이 끝난 뒤 아래 순서를 지킨다.
 

--- a/src/main/java/com/gongu/server/global/config/RestClientConfig.java
+++ b/src/main/java/com/gongu/server/global/config/RestClientConfig.java
@@ -1,0 +1,20 @@
+package com.gongu.server.global.config;
+
+import com.gongu.server.global.infrastructure.portone.PortOneProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@EnableConfigurationProperties(PortOneProperties.class)
+public class RestClientConfig {
+
+    @Bean
+    public RestClient portOneRestClient(PortOneProperties props) {
+        return RestClient.builder()
+                .baseUrl(props.baseUrl())
+                .defaultHeader("Authorization", "PortOne " + props.apiSecret())
+                .build();
+    }
+}

--- a/src/main/java/com/gongu/server/global/config/RestClientConfig.java
+++ b/src/main/java/com/gongu/server/global/config/RestClientConfig.java
@@ -10,9 +10,13 @@ import org.springframework.web.client.RestClient;
 @EnableConfigurationProperties(PortOneProperties.class)
 public class RestClientConfig {
 
+    /**
+     * Spring Boot 자동 구성 RestClient.Builder를 주입받아 사용한다.
+     * application.yml의 spring.http.client.connect-timeout / read-timeout 설정이 적용된다.
+     */
     @Bean
-    public RestClient portOneRestClient(PortOneProperties props) {
-        return RestClient.builder()
+    public RestClient portOneRestClient(RestClient.Builder restClientBuilder, PortOneProperties props) {
+        return restClientBuilder
                 .baseUrl(props.baseUrl())
                 .defaultHeader("Authorization", "PortOne " + props.apiSecret())
                 .build();

--- a/src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java
@@ -9,7 +9,9 @@ public enum PaymentErrorCode implements ErrorCode {
     PAYMENT_NOT_FOUND("PAYMENT_001", "존재하지 않는 결제입니다", 404),
     PAYMENT_AMOUNT_MISMATCH("PAYMENT_002", "결제 금액이 일치하지 않습니다", 400),
     PAYMENT_ALREADY_PROCESSED("PAYMENT_003", "이미 처리된 결제입니다", 409),
-    PG_API_ERROR("PAYMENT_004", "결제 API 호출에 실패했습니다", 502);
+    PG_API_ERROR("PAYMENT_004", "결제 API 호출에 실패했습니다", 502),
+    PAYMENT_NOT_ALLOWED("PAYMENT_005", "결제할 수 없는 주문 상태입니다", 409),
+    PAYMENT_PG_UNAVAILABLE("PAYMENT_006", "결제 서비스를 일시적으로 사용할 수 없습니다", 503);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/gongu/server/global/infrastructure/portone/PortOneClient.java
+++ b/src/main/java/com/gongu/server/global/infrastructure/portone/PortOneClient.java
@@ -1,5 +1,6 @@
 package com.gongu.server.global.infrastructure.portone;
 
+import com.gongu.server.global.exception.BusinessException;
 import com.gongu.server.global.exception.InfraException;
 import com.gongu.server.global.exception.errorcode.PaymentErrorCode;
 import com.gongu.server.global.infrastructure.portone.dto.PortOnePaymentResponse;
@@ -25,8 +26,11 @@ public class PortOneClient {
                     .uri("/payments/{paymentId}", paymentId)
                     .retrieve()
                     .body(PortOnePaymentResponse.class);
-        } catch (HttpClientErrorException | HttpServerErrorException e) {
-            log.error("PortOne getPayment failed: paymentId={}, status={}", paymentId, e.getStatusCode());
+        } catch (HttpClientErrorException e) {
+            log.warn("PortOne getPayment client error: paymentId={}, status={}", paymentId, e.getStatusCode());
+            throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND);
+        } catch (HttpServerErrorException e) {
+            log.error("PortOne getPayment server error: paymentId={}, status={}", paymentId, e.getStatusCode());
             throw new InfraException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE);
         } catch (Exception e) {
             log.error("PortOne getPayment unexpected error: paymentId={}", paymentId, e);
@@ -34,15 +38,18 @@ public class PortOneClient {
         }
     }
 
-    public void cancelPayment(String paymentId, String reason) {
+    public PortOnePaymentResponse cancelPayment(String paymentId, String reason) {
         try {
-            portOneRestClient.post()
+            return portOneRestClient.post()
                     .uri("/payments/{paymentId}/cancel", paymentId)
                     .body(Map.of("reason", reason))
                     .retrieve()
-                    .toBodilessEntity();
-        } catch (HttpClientErrorException | HttpServerErrorException e) {
-            log.error("PortOne cancelPayment failed: paymentId={}, status={}", paymentId, e.getStatusCode());
+                    .body(PortOnePaymentResponse.class);
+        } catch (HttpClientErrorException e) {
+            log.warn("PortOne cancelPayment client error: paymentId={}, status={}", paymentId, e.getStatusCode());
+            throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND);
+        } catch (HttpServerErrorException e) {
+            log.error("PortOne cancelPayment server error: paymentId={}, status={}", paymentId, e.getStatusCode());
             throw new InfraException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE);
         } catch (Exception e) {
             log.error("PortOne cancelPayment unexpected error: paymentId={}", paymentId, e);

--- a/src/main/java/com/gongu/server/global/infrastructure/portone/PortOneClient.java
+++ b/src/main/java/com/gongu/server/global/infrastructure/portone/PortOneClient.java
@@ -1,0 +1,52 @@
+package com.gongu.server.global.infrastructure.portone;
+
+import com.gongu.server.global.exception.InfraException;
+import com.gongu.server.global.exception.errorcode.PaymentErrorCode;
+import com.gongu.server.global.infrastructure.portone.dto.PortOnePaymentResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PortOneClient {
+
+    private final RestClient portOneRestClient;
+
+    public PortOnePaymentResponse getPayment(String paymentId) {
+        try {
+            return portOneRestClient.get()
+                    .uri("/payments/{paymentId}", paymentId)
+                    .retrieve()
+                    .body(PortOnePaymentResponse.class);
+        } catch (HttpClientErrorException | HttpServerErrorException e) {
+            log.error("PortOne getPayment failed: paymentId={}, status={}", paymentId, e.getStatusCode());
+            throw new InfraException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE);
+        } catch (Exception e) {
+            log.error("PortOne getPayment unexpected error: paymentId={}", paymentId, e);
+            throw new InfraException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE);
+        }
+    }
+
+    public void cancelPayment(String paymentId, String reason) {
+        try {
+            portOneRestClient.post()
+                    .uri("/payments/{paymentId}/cancel", paymentId)
+                    .body(Map.of("reason", reason))
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (HttpClientErrorException | HttpServerErrorException e) {
+            log.error("PortOne cancelPayment failed: paymentId={}, status={}", paymentId, e.getStatusCode());
+            throw new InfraException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE);
+        } catch (Exception e) {
+            log.error("PortOne cancelPayment unexpected error: paymentId={}", paymentId, e);
+            throw new InfraException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE);
+        }
+    }
+}

--- a/src/main/java/com/gongu/server/global/infrastructure/portone/PortOneClient.java
+++ b/src/main/java/com/gongu/server/global/infrastructure/portone/PortOneClient.java
@@ -6,6 +6,7 @@ import com.gongu.server.global.exception.errorcode.PaymentErrorCode;
 import com.gongu.server.global.infrastructure.portone.dto.PortOnePaymentResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
@@ -47,7 +48,11 @@ public class PortOneClient {
                     .body(PortOnePaymentResponse.class);
         } catch (HttpClientErrorException e) {
             log.warn("PortOne cancelPayment client error: paymentId={}, status={}", paymentId, e.getStatusCode());
-            throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND);
+            if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+                throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND);
+            }
+            // 409 등 도메인 오류 (이미 취소됨 등)
+            throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED);
         } catch (HttpServerErrorException e) {
             log.error("PortOne cancelPayment server error: paymentId={}, status={}", paymentId, e.getStatusCode());
             throw new InfraException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE);

--- a/src/main/java/com/gongu/server/global/infrastructure/portone/PortOneProperties.java
+++ b/src/main/java/com/gongu/server/global/infrastructure/portone/PortOneProperties.java
@@ -1,0 +1,7 @@
+package com.gongu.server.global.infrastructure.portone;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "portone")
+public record PortOneProperties(String apiSecret, String baseUrl) {
+}

--- a/src/main/java/com/gongu/server/global/infrastructure/portone/dto/PortOnePaymentResponse.java
+++ b/src/main/java/com/gongu/server/global/infrastructure/portone/dto/PortOnePaymentResponse.java
@@ -1,13 +1,12 @@
 package com.gongu.server.global.infrastructure.portone.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 public record PortOnePaymentResponse(
     String id,
     String status,
     Amount amount,
-    @JsonProperty("paidAt") LocalDateTime paidAt
+    OffsetDateTime paidAt
 ) {
     public record Amount(Long total) {}
 }

--- a/src/main/java/com/gongu/server/global/infrastructure/portone/dto/PortOnePaymentResponse.java
+++ b/src/main/java/com/gongu/server/global/infrastructure/portone/dto/PortOnePaymentResponse.java
@@ -1,0 +1,13 @@
+package com.gongu.server.global.infrastructure.portone.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+
+public record PortOnePaymentResponse(
+    String id,
+    String status,
+    Amount amount,
+    @JsonProperty("paidAt") LocalDateTime paidAt
+) {
+    public record Amount(Long total) {}
+}


### PR DESCRIPTION
## 🔷 Github Issue ID
- close #117

## 📌 작업 내용 및 특이사항
- `PortOneProperties`: `portone.api-secret` / `portone.base-url` 설정을 타입 안전하게 바인딩하는 ConfigurationProperties 레코드 추가
- `RestClientConfig`: PortOne 전용 `RestClient` 빈 등록 (baseUrl·Authorization 헤더 기본값 설정)
- `PortOnePaymentResponse`: PortOne V2 `GET /payments/{paymentId}` 응답 DTO (중첩 Amount 레코드 포함)
- `PortOneClient`: `getPayment` / `cancelPayment` 메서드 구현, HTTP 오류 및 네트워크 예외 모두 `InfraException(PAYMENT_PG_UNAVAILABLE)` 로 변환
- `PaymentErrorCode`: `PAYMENT_NOT_ALLOWED(005)`·`PAYMENT_PG_UNAVAILABLE(006)` 추가 (이후 태스크에서 필요)
- `application.yml`: `portone.api-secret`, `portone.base-url` 설정 블록 추가

## 📚 참고사항
- Resilience4j 서킷브레이커 적용은 다음 Task #118 에서 처리
- `PORTONE_API_SECRET` 환경변수 필수 (미설정 시 애플리케이션 기동 실패)