### PR TITLE
[FEAT] PortOneClient에 Resilience4j CircuitBreaker, Retry 적용 (#118)

### DIFF
--- a/src/main/java/com/gongu/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gongu/server/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.gongu.server.global.exception;
 
 import com.gongu.server.global.common.ErrorResponse;
 import com.gongu.server.global.exception.errorcode.CommonErrorCode;
+import com.gongu.server.global.exception.errorcode.PaymentErrorCode;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +28,15 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleInfraException(InfraException e) {
         log.error("External system failure: {}", e.getMessage(), e);
         return handleGonguException(e);
+    }
+
+    @ExceptionHandler(CallNotPermittedException.class)
+    public ResponseEntity<ErrorResponse> handleCallNotPermittedException(CallNotPermittedException e) {
+        log.error("Circuit breaker open: {}", e.getMessage());
+        ErrorCode errorCode = PaymentErrorCode.PAYMENT_PG_UNAVAILABLE;
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(errorCode));
     }
 
     @ExceptionHandler(GonguException.class)

--- a/src/main/java/com/gongu/server/global/infrastructure/portone/PortOneClient.java
+++ b/src/main/java/com/gongu/server/global/infrastructure/portone/PortOneClient.java
@@ -4,12 +4,13 @@ import com.gongu.server.global.exception.BusinessException;
 import com.gongu.server.global.exception.InfraException;
 import com.gongu.server.global.exception.errorcode.PaymentErrorCode;
 import com.gongu.server.global.infrastructure.portone.dto.PortOnePaymentResponse;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClient;
 
 import java.util.Map;
@@ -21,6 +22,12 @@ public class PortOneClient {
 
     private final RestClient portOneRestClient;
 
+    /**
+     * 4xx → BusinessException 즉시 전파 (CB/Retry ignore-exceptions 설정으로 장애 집계 제외)
+     * 5xx·네트워크 오류 → @Retry 재시도 → 소진 시 CB fallback → InfraException
+     */
+    @CircuitBreaker(name = "portone", fallbackMethod = "getPaymentFallback")
+    @Retry(name = "portone")
     public PortOnePaymentResponse getPayment(String paymentId) {
         try {
             return portOneRestClient.get()
@@ -30,15 +37,17 @@ public class PortOneClient {
         } catch (HttpClientErrorException e) {
             log.warn("PortOne getPayment client error: paymentId={}, status={}", paymentId, e.getStatusCode());
             throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND);
-        } catch (HttpServerErrorException e) {
-            log.error("PortOne getPayment server error: paymentId={}, status={}", paymentId, e.getStatusCode());
-            throw new InfraException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE);
-        } catch (Exception e) {
-            log.error("PortOne getPayment unexpected error: paymentId={}", paymentId, e);
-            throw new InfraException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE);
         }
+        // HttpServerErrorException, ResourceAccessException 등은 자연 전파 → @Retry 동작
     }
 
+    private PortOnePaymentResponse getPaymentFallback(String paymentId, Exception e) {
+        log.error("PortOne circuit open or retry exhausted for getPayment: paymentId={}", paymentId, e);
+        throw new InfraException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE);
+    }
+
+    @CircuitBreaker(name = "portone", fallbackMethod = "cancelPaymentFallback")
+    @Retry(name = "portone")
     public PortOnePaymentResponse cancelPayment(String paymentId, String reason) {
         try {
             return portOneRestClient.post()
@@ -53,12 +62,13 @@ public class PortOneClient {
             }
             // 409 등 도메인 오류 (이미 취소됨 등)
             throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED);
-        } catch (HttpServerErrorException e) {
-            log.error("PortOne cancelPayment server error: paymentId={}, status={}", paymentId, e.getStatusCode());
-            throw new InfraException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE);
-        } catch (Exception e) {
-            log.error("PortOne cancelPayment unexpected error: paymentId={}", paymentId, e);
-            throw new InfraException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE);
         }
+        // HttpServerErrorException, ResourceAccessException 등은 자연 전파 → @Retry 동작
+    }
+
+    private PortOnePaymentResponse cancelPaymentFallback(String paymentId, String reason, Exception e) {
+        log.warn("PortOne cancelPayment circuit open or retry exhausted: paymentId={}", paymentId, e);
+        // 보상 취소 실패는 상위로 전파하지 않음 — DB는 이미 CANCELLED 상태
+        return null;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,8 @@ resilience4j:
         wait-duration-in-open-state: 30s
         permitted-number-of-calls-in-half-open-state: 3
         register-health-indicator: true
+        ignore-exceptions:
+          - com.gongu.server.global.exception.BusinessException
   retry:
     instances:
       portone:
@@ -53,3 +55,4 @@ resilience4j:
         retry-exceptions:
           - java.io.IOException
           - org.springframework.web.client.ResourceAccessException
+          - org.springframework.web.client.HttpServerErrorException


### PR DESCRIPTION
## 🔷 Github Issue ID
- close #118

## 📌 작업 내용 및 특이사항
- `PortOneClient.getPayment()`에 `@CircuitBreaker(name="portone")`, `@Retry(name="portone")` 적용
- `PortOneClient.cancelPayment()`에 동일한 어노테이션 적용
- `getPaymentFallback()`: circuit open / retry 소진 시 `InfraException(PAYMENT_PG_UNAVAILABLE)` throw
- `cancelPaymentFallback()`: 보상 취소 실패는 상위로 전파하지 않음 (DB는 이미 CANCELLED 상태이므로)
- `GlobalExceptionHandler`에 `CallNotPermittedException` 핸들러 추가 → HTTP 503 반환
- 선행 브랜치 (#115 yml 설정, #117 PortOneClient 기반 구현) 병합 포함

## 📚 참고사항
- resilience4j 인스턴스 설정은 `application.yml`의 `resilience4j.circuitbreaker.instances.portone` 블록 참조
- `cancelPaymentFallback`이 예외를 전파하지 않는 이유: 결제 취소는 이미 DB에 CANCELLED로 기록된 상태이므로 PG 통신 실패가 치명적이지 않음. 추후 별도 보상 로직(배치/이벤트)으로 처리 예정