### PR TITLE
[FEAT] Payment 엔티티, PaymentStatus, PaymentRepository 구현 (#116)

### DIFF
--- a/src/main/java/com/gongu/server/domain/payment/domain/Payment.java
+++ b/src/main/java/com/gongu/server/domain/payment/domain/Payment.java
@@ -1,0 +1,91 @@
+package com.gongu.server.domain.payment.domain;
+
+import com.gongu.server.domain.order.entity.Order;
+import com.gongu.server.global.common.BaseEntity;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.PaymentErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Entity
+@Table(name = "payments")
+public class Payment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @Column(name = "idempotency_key", nullable = false, unique = true)
+    private String idempotencyKey;
+
+    @Column(name = "imp_uid", nullable = false, unique = true)
+    private String impUid;
+
+    @Column(name = "merchant_uid", nullable = false, unique = true)
+    private String merchantUid;
+
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private PaymentStatus status;
+
+    @Column(name = "paid_at")
+    private LocalDateTime paidAt;
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
+
+    public static Payment create(Order order, String idempotencyKey, String paymentId, Long amount) {
+        return Payment.builder()
+                .order(order)
+                .idempotencyKey(idempotencyKey)
+                .impUid(paymentId)
+                .merchantUid(paymentId)
+                .amount(amount)
+                .status(PaymentStatus.PENDING)
+                .build();
+    }
+
+    public void confirm(Long portOneAmount, LocalDateTime paidAt) {
+        if (!this.amount.equals(portOneAmount)) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
+        this.status = PaymentStatus.PAID;
+        this.paidAt = paidAt;
+    }
+
+    public void cancel() {
+        this.status = PaymentStatus.CANCELLED;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+    public void fail() {
+        this.status = PaymentStatus.FAILED;
+    }
+}

--- a/src/main/java/com/gongu/server/domain/payment/domain/Payment.java
+++ b/src/main/java/com/gongu/server/domain/payment/domain/Payment.java
@@ -42,6 +42,9 @@ public class Payment extends BaseEntity {
     @Column(name = "idempotency_key", nullable = false, unique = true)
     private String idempotencyKey;
 
+    // PortOne V2에서는 merchant-generated UUID(paymentId)가 단일 식별자로 사용된다.
+    // V1의 imp_uid(PG 발급)와 merchant_uid(서버 생성)의 이분법이 성립하지 않으므로,
+    // DDL 컬럼명은 레거시 명명이며 두 컬럼 모두 동일한 paymentId를 저장한다.
     @Column(name = "imp_uid", nullable = false, unique = true)
     private String impUid;
 
@@ -61,7 +64,7 @@ public class Payment extends BaseEntity {
     @Column(name = "cancelled_at")
     private LocalDateTime cancelledAt;
 
-    public static Payment create(Order order, String idempotencyKey, String paymentId, Long amount) {
+    public static Payment initiate(Order order, String idempotencyKey, String paymentId, Long amount) {
         return Payment.builder()
                 .order(order)
                 .idempotencyKey(idempotencyKey)
@@ -73,6 +76,9 @@ public class Payment extends BaseEntity {
     }
 
     public void confirm(Long portOneAmount, LocalDateTime paidAt) {
+        if (this.status != PaymentStatus.PENDING) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED);
+        }
         if (!this.amount.equals(portOneAmount)) {
             throw new BusinessException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
@@ -81,11 +87,17 @@ public class Payment extends BaseEntity {
     }
 
     public void cancel() {
+        if (this.status != PaymentStatus.PAID) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED);
+        }
         this.status = PaymentStatus.CANCELLED;
         this.cancelledAt = LocalDateTime.now();
     }
 
     public void fail() {
+        if (this.status != PaymentStatus.PENDING) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED);
+        }
         this.status = PaymentStatus.FAILED;
     }
 }

--- a/src/main/java/com/gongu/server/domain/payment/domain/PaymentStatus.java
+++ b/src/main/java/com/gongu/server/domain/payment/domain/PaymentStatus.java
@@ -1,0 +1,5 @@
+package com.gongu.server.domain.payment.domain;
+
+public enum PaymentStatus {
+    PENDING, PAID, CANCELLED, FAILED
+}

--- a/src/main/java/com/gongu/server/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/gongu/server/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,10 @@
+package com.gongu.server.domain.payment.repository;
+
+import com.gongu.server.domain.payment.domain.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    Optional<Payment> findByIdempotencyKey(String idempotencyKey);
+}

--- a/src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java
@@ -7,9 +7,8 @@ import lombok.RequiredArgsConstructor;
 public enum PaymentErrorCode implements ErrorCode {
 
     PAYMENT_NOT_FOUND("PAYMENT_001", "존재하지 않는 결제입니다", 404),
-    PAYMENT_AMOUNT_MISMATCH("PAYMENT_002", "결제 금액이 일치하지 않습니다", 400),
+    PAYMENT_AMOUNT_MISMATCH("PAYMENT_002", "결제 금액이 일치하지 않습니다", 422),
     PAYMENT_ALREADY_PROCESSED("PAYMENT_003", "이미 처리된 결제입니다", 409),
-    PG_API_ERROR("PAYMENT_004", "결제 API 호출에 실패했습니다", 502),
     PAYMENT_NOT_ALLOWED("PAYMENT_005", "결제할 수 없는 주문 상태입니다", 409),
     PAYMENT_PG_UNAVAILABLE("PAYMENT_006", "결제 서비스를 일시적으로 사용할 수 없습니다", 503);
 

--- a/src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java
@@ -9,8 +9,8 @@ public enum PaymentErrorCode implements ErrorCode {
     PAYMENT_NOT_FOUND("PAYMENT_001", "존재하지 않는 결제입니다", 404),
     PAYMENT_AMOUNT_MISMATCH("PAYMENT_002", "결제 금액이 일치하지 않습니다", 422),
     PAYMENT_ALREADY_PROCESSED("PAYMENT_003", "이미 처리된 결제입니다", 409),
-    PAYMENT_NOT_ALLOWED("PAYMENT_005", "결제할 수 없는 주문 상태입니다", 409),
-    PAYMENT_PG_UNAVAILABLE("PAYMENT_006", "결제 서비스를 일시적으로 사용할 수 없습니다", 503);
+    PAYMENT_NOT_ALLOWED("PAYMENT_004", "결제할 수 없는 주문 상태입니다", 409),
+    PAYMENT_PG_UNAVAILABLE("PAYMENT_005", "결제 서비스를 일시적으로 사용할 수 없습니다", 503);
 
     private final String code;
     private final String message;


### PR DESCRIPTION
close #116

## 변경 사항
- `Payment` 엔티티 구현 (`payments` 테이블 DDL 1:1 매핑)
- `PaymentStatus` enum 구현 (PENDING, PAID, CANCELLED, FAILED)
- `PaymentRepository` 구현 (`findByIdempotencyKey`)
- `PaymentErrorCode` 업데이트 — PAYMENT_NOT_ALLOWED, PAYMENT_PG_UNAVAILABLE 추가

## 마일스톤
결제 도메인(#7)