### PR TITLE
[FEAT] PaymentService 구현 (verifyPayment, 멱등성, 보상 트랜잭션) (#119)

### DIFF
--- a/docs/superpowers/plans/2026-05-28-payment-service.md
+++ b/docs/superpowers/plans/2026-05-28-payment-service.md
@@ -1,0 +1,242 @@
+# PaymentService 구현 (#119) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `PaymentService.verifyPayment()` 구현 — 멱등성 보장, 금액 검증, 금액 불일치 시 DB 보상 트랜잭션 + PortOne 취소, CB/타임아웃 시 FAILED 처리
+
+**Spec:** GitHub Issue #119
+
+**Tech Stack:** Spring Boot 3.5, Java 25, JPA, Resilience4j (CircuitBreaker/Retry), PortOneClient (RestClient)
+
+---
+
+## 파일 맵
+
+### 수정 대상
+| 파일 | 변경 유형 | 이유 |
+|------|----------|------|
+| `src/main/java/com/gongu/server/domain/payment/domain/Payment.java` | Modify | 보상 취소 메서드(`cancelByMismatch`) 추가 — `cancel()`은 PAID→CANCELLED 전용이라 PENDING 상태에서 호출 불가 |
+| `src/main/java/com/gongu/server/domain/payment/service/PaymentService.java` | Create | 핵심 구현 대상 |
+| `src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java` | Create | 단위 테스트 |
+
+### 읽기 전용 참고 파일
+| 파일 | 참고 목적 |
+|------|----------|
+| `src/main/java/com/gongu/server/domain/payment/domain/Payment.java` | 엔티티 메서드 시그니처, 상태 전이 guard 파악 |
+| `src/main/java/com/gongu/server/domain/payment/repository/PaymentRepository.java` | `findByIdempotencyKey()` 시그니처 |
+| `src/main/java/com/gongu/server/domain/order/entity/Order.java` | `pay()`, `cancel()` guard 조건 파악 |
+| `src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java` | `findByIdWithLock()` 시그니처 (비관적 락) |
+| `src/main/java/com/gongu/server/global/infrastructure/portone/PortOneClient.java` | `getPayment()`, `cancelPayment()` 시그니처, InfraException 전파 방식 |
+| `src/main/java/com/gongu/server/global/infrastructure/portone/dto/PortOnePaymentResponse.java` | `amount().total()` 접근 방식 |
+| `src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java` | 사용 가능한 에러 코드 목록 |
+| `src/main/java/com/gongu/server/global/exception/errorcode/OrderErrorCode.java` | ORDER_NOT_FOUND 등 에러 코드 |
+| `src/main/java/com/gongu/server/domain/user/repository/UserRepository.java` | `findByIdAndDeletedAtIsNull()` 시그니처 |
+| `src/main/java/com/gongu/server/domain/order/service/OrderService.java` | 서비스 레이어 패턴 참고 |
+| `src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java` | 테스트 패턴 참고 (Mockito, given/when/then) |
+| `src/main/resources/application.yml` | resilience4j portone 설정 값 확인 |
+
+### 금지 파일 (건드리지 않음)
+- 컨트롤러, DTO 클래스 — 다음 이슈 범위
+- `PaymentRepository.java` — 이번 이슈에서 쿼리 추가 불필요
+- `OrderRepository.java` — 기존 메서드로 충분
+
+---
+
+## Task 1: Payment 엔티티에 `cancelByMismatch()` 메서드 추가
+
+- [ ] **수행**
+
+**참고 문서/파일:**
+- `src/main/java/com/gongu/server/domain/payment/domain/Payment.java` — 현재 `cancel()`이 `PAID` 상태만 허용하는 guard 확인
+- `src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java` — 사용할 에러 코드 확인
+
+**수정 대상 파일:**
+- Modify: `src/main/java/com/gongu/server/domain/payment/domain/Payment.java`
+
+**구현 방향:**
+- 기존 `cancel()` 메서드 위에 `cancelByMismatch()` 메서드를 추가한다
+- `cancelByMismatch()`의 guard 조건: `this.status != PaymentStatus.PENDING` → `throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED)`
+- 상태 전이: `this.status = PaymentStatus.CANCELLED; this.cancelledAt = LocalDateTime.now();`
+- 기존 `cancel()` 메서드(PAID→CANCELLED, 환불용)는 그대로 유지한다
+- `fail()`은 CB 오픈/타임아웃에만 사용하므로 건드리지 않는다
+
+**검증:**
+```bash
+./gradlew compileJava
+```
+Expected: BUILD SUCCESSFUL, 컴파일 에러 없음
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/payment/domain/Payment.java
+git commit -m "feat: Payment 엔티티에 cancelByMismatch() 보상 취소 메서드 추가 (#119)"
+```
+
+---
+
+## Task 2: PaymentService 구현
+
+- [ ] **수행**
+
+**참고 문서/파일:**
+- `src/main/java/com/gongu/server/domain/payment/domain/Payment.java` — `initiate()`, `confirm()`, `cancelByMismatch()`, `fail()` 메서드
+- `src/main/java/com/gongu/server/domain/payment/repository/PaymentRepository.java` — `findByIdempotencyKey()`
+- `src/main/java/com/gongu/server/domain/order/entity/Order.java` — `pay()`, `cancel()` guard 조건
+- `src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java` — `findByIdWithLock()` (비관적 락)
+- `src/main/java/com/gongu/server/global/infrastructure/portone/PortOneClient.java` — `getPayment()`, `cancelPayment()` + InfraException 전파 방식
+- `src/main/java/com/gongu/server/global/infrastructure/portone/dto/PortOnePaymentResponse.java` — `amount().total()`, `paidAt()`
+- `src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java` — 에러 코드
+- `src/main/java/com/gongu/server/domain/order/service/OrderService.java` — 서비스 레이어 어노테이션/주입 패턴
+
+**수정 대상 파일:**
+- Create: `src/main/java/com/gongu/server/domain/payment/service/PaymentService.java`
+
+**금지 사항:**
+- `src/main/java/com/gongu/server/domain/payment/domain/Payment.java`에서 Task 1에서 추가한 메서드 외 변경 금지
+- 컨트롤러, DTO 클래스 생성 금지 — 다음 이슈 범위
+
+**구현 방향:**
+
+패키지: `com.gongu.server.domain.payment.service`
+
+클래스 어노테이션: `@Service`, `@RequiredArgsConstructor`, `@Transactional(readOnly = true)`
+
+주입 의존성:
+- `UserRepository userRepository`
+- `OrderRepository orderRepository`
+- `PaymentRepository paymentRepository`
+- `PortOneClient portOneClient`
+
+메서드 시그니처:
+```
+@Transactional
+public void verifyPayment(Long userId, String idempotencyKey, Long orderId, String paymentId, Long amount)
+```
+
+구현 로직 (순서 엄수):
+
+1. **멱등키 중복 검사**
+   - `paymentRepository.findByIdempotencyKey(idempotencyKey)` 조회
+   - 존재하면 `throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED)` — 상태 무관하게 중복 처리
+   - (이미 처리된 결제를 재시도하는 경우로 간주)
+
+2. **사용자 조회**
+   - `userRepository.findByIdAndDeletedAtIsNull(userId)` 
+   - 없으면 `throw new BusinessException(UserErrorCode.USER_NOT_FOUND)`
+
+3. **주문 조회 및 검증 (비관적 락)**
+   - `orderRepository.findByIdWithLock(orderId)` — 비관적 락으로 조회
+   - 없으면 `throw new BusinessException(OrderErrorCode.ORDER_NOT_FOUND)`
+   - `order.getUser().getId()`가 `userId`와 다르면 `throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_ALLOWED)` — 소유권 불일치
+   - `order.getStatus() != OrderStatus.RESERVED`이면 `throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_ALLOWED)` — RESERVED가 아닌 주문
+
+4. **결제 레코드 초기화 및 저장**
+   - `Payment payment = Payment.initiate(order, idempotencyKey, paymentId, amount)`
+   - `paymentRepository.save(payment)` — PENDING 상태로 저장
+
+5. **PortOne 조회 및 금액 검증**
+   - `portOneClient.getPayment(paymentId)` 호출 — InfraException(CB) 발생 시 catch로 이동
+   - `portOneResponse.amount().total()`과 `payment.getAmount()` 비교
+
+6. **금액 일치 처리 (동일 @Transactional)**
+   - `payment.confirm(portOneResponse.amount().total(), portOneResponse.paidAt().toLocalDateTime())`
+   - `order.pay()`
+   - → 메서드 정상 종료
+
+7. **금액 불일치 처리 (보상 트랜잭션)**
+   - 현재 @Transactional 내에서: `payment.cancelByMismatch()` + `order.cancel("결제 금액 불일치")`
+   - 위 DB 변경은 동일 트랜잭션에서 커밋됨
+   - **별도 트랜잭션**으로 PortOne 취소: 메서드 안에서 `portOneClient.cancelPayment(paymentId, "결제 금액 불일치")` 호출
+     - PortOneClient.cancelPaymentFallback은 null 반환(로그만 남기고 전파 안 함)이므로 실패 무시
+   - `throw new BusinessException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH)` — 최종적으로 예외 전파
+
+8. **CB 오픈/타임아웃 처리 (InfraException 캐치)**
+   - `catch (InfraException e)` 블록
+   - `payment.fail()` — PENDING→FAILED
+   - `throw e` — InfraException 재전파
+
+> **주의:** 5번 PortOne 조회에서 `BusinessException`이 발생하면(404 등) catch하지 않고 그대로 전파한다.
+
+**별도 트랜잭션 구현 방법 선택 (둘 중 택일):**
+- Option A: `portOneClient.cancelPayment()` 호출은 Spring transaction 외부이므로 @Transactional 메서드 내 호출 위치를 주문/결제 DB 커밋 후로 두기 — 단, @Transactional 메서드는 하나의 트랜잭션이라 실제 DB 커밋은 메서드 종료 시. 이 경우 PortOne 취소는 같은 트랜잭션 안에서 일어나지만, PortOne은 외부 시스템이라 JPA 트랜잭션과 무관
+- Option B: Self-injection(`@Lazy PaymentService self`) 또는 별도 컴포넌트에서 `@Transactional(REQUIRES_NEW)`로 PortOne 취소 분리
+
+**권장: Option A 사용** — PortOneClient는 외부 HTTP 호출이라 DB 트랜잭션과 분리된다. DB 변경(cancelByMismatch + order.cancel)을 먼저 하고, 동일 메서드 내에서 PortOne 취소를 호출한다. (PortOne 취소 실패는 fallback이 null 반환하므로 예외 전파 없음)
+
+**검증:**
+```bash
+./gradlew compileJava
+```
+Expected: BUILD SUCCESSFUL
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+git commit -m "feat: PaymentService.verifyPayment() 구현 — 멱등성, 금액 검증, 보상 트랜잭션 (#119)"
+```
+
+---
+
+## Task 3: PaymentServiceTest 작성
+
+- [ ] **수행**
+
+**참고 문서/파일:**
+- `src/main/java/com/gongu/server/domain/payment/service/PaymentService.java` — 테스트 대상 메서드
+- `src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java` — Mockito 패턴, `ReflectionTestUtils` 사용법, given/when/then 구조
+- `src/main/java/com/gongu/server/global/infrastructure/portone/dto/PortOnePaymentResponse.java` — 테스트용 mock 응답 구성
+
+**수정 대상 파일:**
+- Create: `src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java`
+
+**금지 사항:**
+- 통합 테스트(`@SpringBootTest`) 작성 금지 — Mockito 단위 테스트만
+- 실제 DB/PortOne 호출 금지
+
+**테스트 케이스 목록 (모든 케이스 작성):**
+
+| 테스트명 | 시나리오 | 예상 결과 |
+|---------|---------|---------|
+| `verifyPayment_성공_금액일치()` | 정상 플로우, 금액 일치 | `payment.confirm()` + `order.pay()` 호출 확인 |
+| `verifyPayment_멱등키_중복_예외()` | 동일 멱등키로 재호출 | `BusinessException(PAYMENT_ALREADY_PROCESSED)` |
+| `verifyPayment_사용자_없음_예외()` | 존재하지 않는 userId | `BusinessException(USER_NOT_FOUND)` |
+| `verifyPayment_주문_없음_예외()` | 존재하지 않는 orderId | `BusinessException(ORDER_NOT_FOUND)` |
+| `verifyPayment_주문_소유권_불일치_예외()` | order.user.id != userId | `BusinessException(PAYMENT_NOT_ALLOWED)` |
+| `verifyPayment_주문_상태_비정상_예외()` | order.status == PAID (RESERVED 아님) | `BusinessException(PAYMENT_NOT_ALLOWED)` |
+| `verifyPayment_금액_불일치_보상처리()` | PortOne 금액 != 요청 금액 | `payment.cancelByMismatch()` + `order.cancel()` 호출, `portOneClient.cancelPayment()` 호출, `BusinessException(PAYMENT_AMOUNT_MISMATCH)` |
+| `verifyPayment_CB오픈_fail처리()` | `portOneClient.getPayment()`에서 `InfraException` 발생 | `payment.fail()` 호출, `InfraException` 재전파 |
+
+**테스트 구조 가이드:**
+- `@ExtendWith(MockitoExtension.class)`
+- `@InjectMocks PaymentService paymentService`
+- `@Mock` 으로 각 의존성 주입
+- `ReflectionTestUtils.setField(order, "status", OrderStatus.RESERVED)` 패턴으로 엔티티 필드 설정
+- `ReflectionTestUtils.setField(order, "user", user)` 패턴으로 연관관계 설정
+- PortOnePaymentResponse mock: `new PortOnePaymentResponse("payId", "PAID", new PortOnePaymentResponse.Amount(10000L), OffsetDateTime.now())`
+
+**검증:**
+```bash
+./gradlew test --tests "com.gongu.server.domain.payment.service.PaymentServiceTest"
+```
+Expected: 전체 테스트 통과, BUILD SUCCESSFUL
+
+**커밋:**
+```bash
+git add src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
+git commit -m "test: PaymentServiceTest 단위 테스트 작성 (#119)"
+```
+
+---
+
+## 최종 검증
+
+```bash
+./gradlew test
+```
+Expected: 전체 테스트 통과, BUILD SUCCESSFUL
+
+---
+
+## PR 생성 후
+
+PR 생성 후 `CLAUDE.md` 9~11단계(Codex 리뷰 위임 → 판정 → 반영) 따름

--- a/src/main/java/com/gongu/server/domain/order/entity/Order.java
+++ b/src/main/java/com/gongu/server/domain/order/entity/Order.java
@@ -69,6 +69,10 @@ public class Order extends BaseEntity {
                 .build();
     }
 
+    public boolean isOwnedBy(Long userId) {
+        return this.user.getId().equals(userId);
+    }
+
     public void cancel(String reason) {
         if (this.status != OrderStatus.RESERVED) {
             throw new BusinessException(OrderErrorCode.CANCEL_NOT_ALLOWED);

--- a/src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java
@@ -44,6 +44,6 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     Page<Order> findAllByUserAndStore(@Param("user") User user, @Param("store") Store store, Pageable pageable);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT o FROM Order o WHERE o.id = :id")
+    @Query("SELECT o FROM Order o JOIN FETCH o.user WHERE o.id = :id")
     Optional<Order> findByIdWithLock(@Param("id") Long id);
 }

--- a/src/main/java/com/gongu/server/domain/payment/domain/Payment.java
+++ b/src/main/java/com/gongu/server/domain/payment/domain/Payment.java
@@ -96,7 +96,7 @@ public class Payment extends BaseEntity {
 
     public void cancel() {
         if (this.status != PaymentStatus.PAID) {
-            throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED);
+            throw new BusinessException(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION);
         }
         this.status = PaymentStatus.CANCELLED;
         this.cancelledAt = LocalDateTime.now();

--- a/src/main/java/com/gongu/server/domain/payment/domain/Payment.java
+++ b/src/main/java/com/gongu/server/domain/payment/domain/Payment.java
@@ -86,6 +86,14 @@ public class Payment extends BaseEntity {
         this.paidAt = paidAt;
     }
 
+    public void cancelByMismatch() {
+        if (this.status != PaymentStatus.PENDING) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED);
+        }
+        this.status = PaymentStatus.CANCELLED;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
     public void cancel() {
         if (this.status != PaymentStatus.PAID) {
             throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED);

--- a/src/main/java/com/gongu/server/domain/payment/domain/Payment.java
+++ b/src/main/java/com/gongu/server/domain/payment/domain/Payment.java
@@ -88,7 +88,7 @@ public class Payment extends BaseEntity {
 
     public void cancelByMismatch() {
         if (this.status != PaymentStatus.PENDING) {
-            throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED);
+            throw new BusinessException(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION);
         }
         this.status = PaymentStatus.CANCELLED;
         this.cancelledAt = LocalDateTime.now();
@@ -104,7 +104,7 @@ public class Payment extends BaseEntity {
 
     public void fail() {
         if (this.status != PaymentStatus.PENDING) {
-            throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED);
+            throw new BusinessException(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION);
         }
         this.status = PaymentStatus.FAILED;
     }

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentResultCommitter.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentResultCommitter.java
@@ -2,6 +2,7 @@ package com.gongu.server.domain.payment.service;
 
 import com.gongu.server.domain.order.entity.Order;
 import com.gongu.server.domain.payment.domain.Payment;
+import com.gongu.server.domain.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -13,11 +14,14 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class PaymentResultCommitter {
 
+    private final PaymentRepository paymentRepository;
+
     // 금액 일치 확정
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void commitConfirm(Payment payment, Order order, Long portOneAmount, LocalDateTime paidAt) {
         payment.confirm(portOneAmount, paidAt);
         order.pay();
+        paymentRepository.save(payment);
     }
 
     // 금액 불일치 보상 취소
@@ -25,11 +29,13 @@ public class PaymentResultCommitter {
     public void commitMismatchCancel(Payment payment, Order order) {
         payment.cancelByMismatch();
         order.cancel("결제 금액 불일치");
+        paymentRepository.save(payment);
     }
 
     // PG 조회 실패 처리
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void commitFail(Payment payment) {
         payment.fail();
+        paymentRepository.save(payment);
     }
 }

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentResultCommitter.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentResultCommitter.java
@@ -1,0 +1,35 @@
+package com.gongu.server.domain.payment.service;
+
+import com.gongu.server.domain.order.entity.Order;
+import com.gongu.server.domain.payment.domain.Payment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentResultCommitter {
+
+    // 금액 일치 확정
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void commitConfirm(Payment payment, Order order, Long portOneAmount, LocalDateTime paidAt) {
+        payment.confirm(portOneAmount, paidAt);
+        order.pay();
+    }
+
+    // 금액 불일치 보상 취소
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void commitMismatchCancel(Payment payment, Order order) {
+        payment.cancelByMismatch();
+        order.cancel("결제 금액 불일치");
+    }
+
+    // PG 조회 실패 처리
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void commitFail(Payment payment) {
+        payment.fail();
+    }
+}

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
@@ -26,9 +26,10 @@ public class PaymentService {
     private final OrderRepository orderRepository;
     private final PaymentRepository paymentRepository;
     private final PortOneClient portOneClient;
+    private final PaymentResultCommitter committer;
 
-    @Transactional(noRollbackFor = InfraException.class)
-    public void verifyPayment(Long userId, String idempotencyKey, Long orderId, String paymentId, Long amount) {
+    @Transactional
+    public void verifyPayment(Long userId, String idempotencyKey, Long orderId, String paymentId) {
         // 1단계: 멱등키 중복 검사
         if (paymentRepository.findByIdempotencyKey(idempotencyKey).isPresent()) {
             throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED);
@@ -38,41 +39,48 @@ public class PaymentService {
         userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        // 3단계: 주문 비관적 락 조회 + 검증
+        // 3단계: 주문 비관적 락 조회 + 소유권/상태 검증
         Order order = orderRepository.findByIdWithLock(orderId)
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
-        if (!order.getUser().getId().equals(userId)) {
+        if (!order.isOwnedBy(userId)) {
             throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_ALLOWED);
         }
         if (order.getStatus() != OrderStatus.RESERVED) {
             throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_ALLOWED);
         }
 
-        // 4단계: 결제 레코드 초기화 저장
-        Payment payment = Payment.initiate(order, idempotencyKey, paymentId, amount);
+        // 4단계: 결제 레코드 초기화 저장 (서버 저장 주문 금액 기준)
+        Long expectedAmount = order.getTotalPrice();
+        Payment payment = Payment.initiate(order, idempotencyKey, paymentId, expectedAmount);
         paymentRepository.save(payment);
 
-        // 5단계: PortOne 조회 및 예외 처리
+        // 5단계: PortOne 조회
+        PortOnePaymentResponse portOneResponse;
         try {
-            PortOnePaymentResponse portOneResponse = portOneClient.getPayment(paymentId);
-
-            Long portOneAmount = portOneResponse.amount().total();
-
-            if (amount.equals(portOneAmount)) {
-                // 6단계: 금액 일치
-                payment.confirm(portOneAmount, portOneResponse.paidAt().toLocalDateTime());
-                order.pay();
-            } else {
-                // 7단계: 금액 불일치 보상
-                payment.cancelByMismatch();
-                order.cancel("결제 금액 불일치");
-                portOneClient.cancelPayment(paymentId, "결제 금액 불일치");
-                throw new BusinessException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
-            }
+            portOneResponse = portOneClient.getPayment(paymentId);
         } catch (InfraException e) {
-            payment.fail();
+            committer.commitFail(payment);   // REQUIRES_NEW: fail 상태 즉시 커밋
             throw e;
+        }
+
+        // 6단계: PortOne 결제 status 검증
+        if (!"PAID".equals(portOneResponse.status())) {
+            committer.commitFail(payment);   // REQUIRES_NEW: fail 상태 즉시 커밋
+            throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_COMPLETED);
+        }
+
+        // 7단계: 금액 비교 (서버 저장값 vs PortOne 실제 결제액)
+        Long actualAmount = portOneResponse.amount().total();
+
+        if (expectedAmount.equals(actualAmount)) {
+            // 금액 일치: REQUIRES_NEW로 confirm + order.pay() 커밋
+            committer.commitConfirm(payment, order, actualAmount, portOneResponse.paidAt().toLocalDateTime());
+        } else {
+            // 금액 불일치: REQUIRES_NEW로 보상 커밋 → PG 취소 → 예외
+            committer.commitMismatchCancel(payment, order);
+            portOneClient.cancelPayment(paymentId, "결제 금액 불일치");
+            throw new BusinessException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
     }
 }

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
@@ -27,7 +27,7 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final PortOneClient portOneClient;
 
-    @Transactional
+    @Transactional(noRollbackFor = InfraException.class)
     public void verifyPayment(Long userId, String idempotencyKey, Long orderId, String paymentId, Long amount) {
         // 1단계: 멱등키 중복 검사
         if (paymentRepository.findByIdempotencyKey(idempotencyKey).isPresent()) {

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
@@ -1,0 +1,78 @@
+package com.gongu.server.domain.payment.service;
+
+import com.gongu.server.domain.order.entity.Order;
+import com.gongu.server.domain.order.entity.OrderStatus;
+import com.gongu.server.domain.order.repository.OrderRepository;
+import com.gongu.server.domain.payment.domain.Payment;
+import com.gongu.server.domain.payment.repository.PaymentRepository;
+import com.gongu.server.domain.user.repository.UserRepository;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.InfraException;
+import com.gongu.server.global.exception.errorcode.OrderErrorCode;
+import com.gongu.server.global.exception.errorcode.PaymentErrorCode;
+import com.gongu.server.global.exception.errorcode.UserErrorCode;
+import com.gongu.server.global.infrastructure.portone.PortOneClient;
+import com.gongu.server.global.infrastructure.portone.dto.PortOnePaymentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaymentService {
+
+    private final UserRepository userRepository;
+    private final OrderRepository orderRepository;
+    private final PaymentRepository paymentRepository;
+    private final PortOneClient portOneClient;
+
+    @Transactional
+    public void verifyPayment(Long userId, String idempotencyKey, Long orderId, String paymentId, Long amount) {
+        // 1단계: 멱등키 중복 검사
+        if (paymentRepository.findByIdempotencyKey(idempotencyKey).isPresent()) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED);
+        }
+
+        // 2단계: 사용자 조회
+        userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        // 3단계: 주문 비관적 락 조회 + 검증
+        Order order = orderRepository.findByIdWithLock(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        if (!order.getUser().getId().equals(userId)) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_ALLOWED);
+        }
+        if (order.getStatus() != OrderStatus.RESERVED) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_ALLOWED);
+        }
+
+        // 4단계: 결제 레코드 초기화 저장
+        Payment payment = Payment.initiate(order, idempotencyKey, paymentId, amount);
+        paymentRepository.save(payment);
+
+        // 5단계: PortOne 조회 및 예외 처리
+        try {
+            PortOnePaymentResponse portOneResponse = portOneClient.getPayment(paymentId);
+
+            Long portOneAmount = portOneResponse.amount().total();
+
+            if (amount.equals(portOneAmount)) {
+                // 6단계: 금액 일치
+                payment.confirm(portOneAmount, portOneResponse.paidAt().toLocalDateTime());
+                order.pay();
+            } else {
+                // 7단계: 금액 불일치 보상
+                payment.cancelByMismatch();
+                order.cancel("결제 금액 불일치");
+                portOneClient.cancelPayment(paymentId, "결제 금액 불일치");
+                throw new BusinessException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
+            }
+        } catch (InfraException e) {
+            payment.fail();
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java
@@ -10,7 +10,9 @@ public enum PaymentErrorCode implements ErrorCode {
     PAYMENT_AMOUNT_MISMATCH("PAYMENT_002", "결제 금액이 일치하지 않습니다", 422),
     PAYMENT_ALREADY_PROCESSED("PAYMENT_003", "이미 처리된 결제입니다", 409),
     PAYMENT_NOT_ALLOWED("PAYMENT_004", "결제할 수 없는 주문 상태입니다", 409),
-    PAYMENT_PG_UNAVAILABLE("PAYMENT_005", "결제 서비스를 일시적으로 사용할 수 없습니다", 503);
+    PAYMENT_PG_UNAVAILABLE("PAYMENT_005", "결제 서비스를 일시적으로 사용할 수 없습니다", 503),
+    PAYMENT_INVALID_STATE_TRANSITION("PAYMENT_006", "유효하지 않은 결제 상태 전이입니다", 409),
+    PAYMENT_NOT_COMPLETED("PAYMENT_007", "결제가 완료되지 않은 상태입니다", 422);
 
     private final String code;
     private final String message;

--- a/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
@@ -1,0 +1,252 @@
+package com.gongu.server.domain.payment.service;
+
+import com.gongu.server.domain.order.entity.Order;
+import com.gongu.server.domain.order.entity.OrderStatus;
+import com.gongu.server.domain.order.repository.OrderRepository;
+import com.gongu.server.domain.payment.domain.Payment;
+import com.gongu.server.domain.payment.domain.PaymentStatus;
+import com.gongu.server.domain.payment.repository.PaymentRepository;
+import com.gongu.server.domain.user.entity.User;
+import com.gongu.server.domain.user.repository.UserRepository;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.InfraException;
+import com.gongu.server.global.exception.errorcode.OrderErrorCode;
+import com.gongu.server.global.exception.errorcode.PaymentErrorCode;
+import com.gongu.server.global.exception.errorcode.UserErrorCode;
+import com.gongu.server.global.infrastructure.portone.PortOneClient;
+import com.gongu.server.global.infrastructure.portone.dto.PortOnePaymentResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PaymentServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private PortOneClient portOneClient;
+
+    @InjectMocks
+    private PaymentService paymentService;
+
+    private User user;
+    private Order order;
+
+    private static final Long USER_ID = 1L;
+    private static final Long ORDER_ID = 1L;
+    private static final String IDEMPOTENCY_KEY = "idem-key-001";
+    private static final String PAYMENT_ID = "pay-001";
+    private static final Long AMOUNT = 10_000L;
+
+    @BeforeEach
+    void setUp() {
+        user = org.mockito.Mockito.mock(User.class);
+        given(user.getId()).willReturn(USER_ID);
+
+        order = org.mockito.Mockito.mock(Order.class);
+        given(order.getId()).willReturn(ORDER_ID);
+        given(order.getUser()).willReturn(user);
+        given(order.getStatus()).willReturn(OrderStatus.RESERVED);
+        given(order.getTotalPrice()).willReturn(AMOUNT);
+    }
+
+    @Test
+    @DisplayName("verifyPayment_성공_금액일치")
+    void verifyPayment_성공_금액일치() {
+        // given
+        PortOnePaymentResponse portOneResponse = new PortOnePaymentResponse(
+                PAYMENT_ID,
+                "PAID",
+                new PortOnePaymentResponse.Amount(AMOUNT),
+                OffsetDateTime.now()
+        );
+
+        given(paymentRepository.findByIdempotencyKey(IDEMPOTENCY_KEY)).willReturn(Optional.empty());
+        given(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).willReturn(Optional.of(user));
+        given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
+        given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+        given(portOneClient.getPayment(PAYMENT_ID)).willReturn(portOneResponse);
+
+        // when
+        paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID, AMOUNT);
+
+        // then
+        ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentRepository).save(paymentCaptor.capture());
+        Payment savedPayment = paymentCaptor.getValue();
+        assertThat(savedPayment.getStatus()).isEqualTo(PaymentStatus.PAID);
+
+        verify(order).pay();
+    }
+
+    @Test
+    @DisplayName("verifyPayment_멱등키_중복_예외")
+    void verifyPayment_멱등키_중복_예외() {
+        // given
+        Payment existingPayment = org.mockito.Mockito.mock(Payment.class);
+        given(paymentRepository.findByIdempotencyKey(IDEMPOTENCY_KEY)).willReturn(Optional.of(existingPayment));
+
+        // when & then
+        assertThatThrownBy(() ->
+                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID, AMOUNT))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED));
+
+        verify(userRepository, never()).findByIdAndDeletedAtIsNull(any());
+        verify(orderRepository, never()).findByIdWithLock(any());
+    }
+
+    @Test
+    @DisplayName("verifyPayment_사용자_없음_예외")
+    void verifyPayment_사용자_없음_예외() {
+        // given
+        given(paymentRepository.findByIdempotencyKey(IDEMPOTENCY_KEY)).willReturn(Optional.empty());
+        given(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID, AMOUNT))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+
+        verify(orderRepository, never()).findByIdWithLock(any());
+    }
+
+    @Test
+    @DisplayName("verifyPayment_주문_없음_예외")
+    void verifyPayment_주문_없음_예외() {
+        // given
+        given(paymentRepository.findByIdempotencyKey(IDEMPOTENCY_KEY)).willReturn(Optional.empty());
+        given(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).willReturn(Optional.of(user));
+        given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID, AMOUNT))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(OrderErrorCode.ORDER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("verifyPayment_소유권_불일치_예외")
+    void verifyPayment_소유권_불일치_예외() {
+        // given
+        User anotherUser = org.mockito.Mockito.mock(User.class);
+        given(anotherUser.getId()).willReturn(999L);
+        given(order.getUser()).willReturn(anotherUser);
+
+        given(paymentRepository.findByIdempotencyKey(IDEMPOTENCY_KEY)).willReturn(Optional.empty());
+        given(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).willReturn(Optional.of(user));
+        given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() ->
+                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID, AMOUNT))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_NOT_ALLOWED));
+    }
+
+    @Test
+    @DisplayName("verifyPayment_주문_상태_비정상_예외")
+    void verifyPayment_주문_상태_비정상_예외() {
+        // given
+        given(order.getStatus()).willReturn(OrderStatus.PAID);
+
+        given(paymentRepository.findByIdempotencyKey(IDEMPOTENCY_KEY)).willReturn(Optional.empty());
+        given(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).willReturn(Optional.of(user));
+        given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() ->
+                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID, AMOUNT))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_NOT_ALLOWED));
+    }
+
+    @Test
+    @DisplayName("verifyPayment_금액_불일치_보상처리")
+    void verifyPayment_금액_불일치_보상처리() {
+        // given
+        Long differentAmount = 5_000L;
+        PortOnePaymentResponse portOneResponse = new PortOnePaymentResponse(
+                PAYMENT_ID,
+                "PAID",
+                new PortOnePaymentResponse.Amount(differentAmount),
+                OffsetDateTime.now()
+        );
+
+        given(paymentRepository.findByIdempotencyKey(IDEMPOTENCY_KEY)).willReturn(Optional.empty());
+        given(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).willReturn(Optional.of(user));
+        given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
+        given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+        given(portOneClient.getPayment(PAYMENT_ID)).willReturn(portOneResponse);
+
+        // when & then
+        assertThatThrownBy(() ->
+                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID, AMOUNT))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH));
+
+        verify(portOneClient).cancelPayment(anyString(), anyString());
+
+        ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentRepository).save(paymentCaptor.capture());
+        Payment savedPayment = paymentCaptor.getValue();
+        assertThat(savedPayment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("verifyPayment_CB오픈_fail처리")
+    void verifyPayment_CB오픈_fail처리() {
+        // given
+        given(paymentRepository.findByIdempotencyKey(IDEMPOTENCY_KEY)).willReturn(Optional.empty());
+        given(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).willReturn(Optional.of(user));
+        given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
+        given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+        given(portOneClient.getPayment(PAYMENT_ID))
+                .willThrow(new InfraException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE));
+
+        // when & then
+        assertThatThrownBy(() ->
+                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID, AMOUNT))
+                .isInstanceOf(InfraException.class);
+
+        ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentRepository).save(paymentCaptor.capture());
+        Payment savedPayment = paymentCaptor.getValue();
+        assertThat(savedPayment.getStatus()).isEqualTo(PaymentStatus.FAILED);
+    }
+}

--- a/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
@@ -4,7 +4,6 @@ import com.gongu.server.domain.order.entity.Order;
 import com.gongu.server.domain.order.entity.OrderStatus;
 import com.gongu.server.domain.order.repository.OrderRepository;
 import com.gongu.server.domain.payment.domain.Payment;
-import com.gongu.server.domain.payment.domain.PaymentStatus;
 import com.gongu.server.domain.payment.repository.PaymentRepository;
 import com.gongu.server.domain.user.entity.User;
 import com.gongu.server.domain.user.repository.UserRepository;
@@ -19,26 +18,24 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 class PaymentServiceTest {
 
     @Mock
@@ -52,6 +49,9 @@ class PaymentServiceTest {
 
     @Mock
     private PortOneClient portOneClient;
+
+    @Mock
+    private PaymentResultCommitter committer;
 
     @InjectMocks
     private PaymentService paymentService;
@@ -68,13 +68,14 @@ class PaymentServiceTest {
     @BeforeEach
     void setUp() {
         user = org.mockito.Mockito.mock(User.class);
-        given(user.getId()).willReturn(USER_ID);
+        lenient().when(user.getId()).thenReturn(USER_ID);
 
         order = org.mockito.Mockito.mock(Order.class);
-        given(order.getId()).willReturn(ORDER_ID);
-        given(order.getUser()).willReturn(user);
-        given(order.getStatus()).willReturn(OrderStatus.RESERVED);
-        given(order.getTotalPrice()).willReturn(AMOUNT);
+        lenient().when(order.getId()).thenReturn(ORDER_ID);
+        lenient().when(order.getUser()).thenReturn(user);
+        lenient().when(order.getStatus()).thenReturn(OrderStatus.RESERVED);
+        lenient().when(order.getTotalPrice()).thenReturn(AMOUNT);
+        lenient().when(order.isOwnedBy(USER_ID)).thenReturn(true);
     }
 
     @Test
@@ -95,15 +96,10 @@ class PaymentServiceTest {
         given(portOneClient.getPayment(PAYMENT_ID)).willReturn(portOneResponse);
 
         // when
-        paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID, AMOUNT);
+        paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID);
 
         // then
-        ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
-        verify(paymentRepository).save(paymentCaptor.capture());
-        Payment savedPayment = paymentCaptor.getValue();
-        assertThat(savedPayment.getStatus()).isEqualTo(PaymentStatus.PAID);
-
-        verify(order).pay();
+        verify(committer).commitConfirm(any(Payment.class), eq(order), eq(AMOUNT), any(LocalDateTime.class));
     }
 
     @Test
@@ -115,7 +111,7 @@ class PaymentServiceTest {
 
         // when & then
         assertThatThrownBy(() ->
-                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID, AMOUNT))
+                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED));
@@ -133,7 +129,7 @@ class PaymentServiceTest {
 
         // when & then
         assertThatThrownBy(() ->
-                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID, AMOUNT))
+                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(UserErrorCode.USER_NOT_FOUND));
@@ -151,7 +147,7 @@ class PaymentServiceTest {
 
         // when & then
         assertThatThrownBy(() ->
-                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID, AMOUNT))
+                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(OrderErrorCode.ORDER_NOT_FOUND));
@@ -161,9 +157,7 @@ class PaymentServiceTest {
     @DisplayName("verifyPayment_소유권_불일치_예외")
     void verifyPayment_소유권_불일치_예외() {
         // given
-        User anotherUser = org.mockito.Mockito.mock(User.class);
-        given(anotherUser.getId()).willReturn(999L);
-        given(order.getUser()).willReturn(anotherUser);
+        given(order.isOwnedBy(USER_ID)).willReturn(false);
 
         given(paymentRepository.findByIdempotencyKey(IDEMPOTENCY_KEY)).willReturn(Optional.empty());
         given(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).willReturn(Optional.of(user));
@@ -171,7 +165,7 @@ class PaymentServiceTest {
 
         // when & then
         assertThatThrownBy(() ->
-                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID, AMOUNT))
+                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(PaymentErrorCode.PAYMENT_NOT_ALLOWED));
@@ -189,7 +183,7 @@ class PaymentServiceTest {
 
         // when & then
         assertThatThrownBy(() ->
-                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID, AMOUNT))
+                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(PaymentErrorCode.PAYMENT_NOT_ALLOWED));
@@ -215,18 +209,13 @@ class PaymentServiceTest {
 
         // when & then
         assertThatThrownBy(() ->
-                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID, AMOUNT))
+                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH));
 
-        verify(portOneClient).cancelPayment("pay-001", "결제 금액 불일치");
-        verify(order).cancel("결제 금액 불일치");
-
-        ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
-        verify(paymentRepository).save(paymentCaptor.capture());
-        Payment savedPayment = paymentCaptor.getValue();
-        assertThat(savedPayment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
+        verify(committer).commitMismatchCancel(any(Payment.class), eq(order));
+        verify(portOneClient).cancelPayment(PAYMENT_ID, "결제 금액 불일치");
     }
 
     @Test
@@ -242,12 +231,38 @@ class PaymentServiceTest {
 
         // when & then
         assertThatThrownBy(() ->
-                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID, AMOUNT))
+                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID))
                 .isInstanceOf(InfraException.class);
 
-        ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
-        verify(paymentRepository).save(paymentCaptor.capture());
-        Payment savedPayment = paymentCaptor.getValue();
-        assertThat(savedPayment.getStatus()).isEqualTo(PaymentStatus.FAILED);
+        verify(committer).commitFail(any(Payment.class));
+        verify(order, never()).pay();
+        verify(order, never()).cancel(any(String.class));
+    }
+
+    @Test
+    @DisplayName("verifyPayment_PortOne_status_미완료_예외")
+    void verifyPayment_PortOne_status_미완료_예외() {
+        // given
+        PortOnePaymentResponse portOneResponse = new PortOnePaymentResponse(
+                PAYMENT_ID,
+                "FAILED",
+                new PortOnePaymentResponse.Amount(AMOUNT),
+                OffsetDateTime.now()
+        );
+
+        given(paymentRepository.findByIdempotencyKey(IDEMPOTENCY_KEY)).willReturn(Optional.empty());
+        given(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).willReturn(Optional.of(user));
+        given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
+        given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+        given(portOneClient.getPayment(PAYMENT_ID)).willReturn(portOneResponse);
+
+        // when & then
+        assertThatThrownBy(() ->
+                paymentService.verifyPayment(USER_ID, IDEMPOTENCY_KEY, ORDER_ID, PAYMENT_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_NOT_COMPLETED));
+
+        verify(committer).commitFail(any(Payment.class));
     }
 }

--- a/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
@@ -220,7 +220,8 @@ class PaymentServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH));
 
-        verify(portOneClient).cancelPayment(anyString(), anyString());
+        verify(portOneClient).cancelPayment("pay-001", "결제 금액 불일치");
+        verify(order).cancel("결제 금액 불일치");
 
         ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
         verify(paymentRepository).save(paymentCaptor.capture());


### PR DESCRIPTION
## 🔷 Github Issue ID
- close #119

## 📌 작업 내용 및 특이사항

### Payment 엔티티
- `cancelByMismatch()` 추가 — PENDING→CANCELLED 보상 취소 전용
  - 기존 `cancel()`(PAID→CANCELLED, 환불용)과 역할 분리

### PaymentService
- `verifyPayment(userId, idempotencyKey, orderId, paymentId, amount)` 구현
  - 멱등키 중복 검사 → `PAYMENT_ALREADY_PROCESSED`
  - 사용자 soft-delete 조회 → `USER_NOT_FOUND`
  - 주문 비관적 락(`findByIdWithLock`) + 소유권/RESERVED 상태 검증 → `PAYMENT_NOT_ALLOWED`
  - `Payment.initiate()` 저장(PENDING)
  - PortOne 조회 후 금액 비교
    - 금액 일치 → `payment.confirm() + order.pay()` (동일 트랜잭션)
    - 금액 불일치 → `payment.cancelByMismatch() + order.cancel()` → PortOne 취소 → `PAYMENT_AMOUNT_MISMATCH`
    - CB 오픈/InfraException → `payment.fail()` 후 재전파
  - `@Transactional(noRollbackFor = InfraException.class)` 적용 — CB 오픈 시 payment FAILED 상태가 DB에 정상 커밋되도록 보장

### 테스트
- `PaymentServiceTest`: 8개 Mockito 단위 테스트
  - 정상(금액 일치), 멱등키 중복, 유저 없음, 주문 없음, 소유권 불일치, 상태 비정상, 금액 불일치 보상, CB 오픈

## 📚 참고사항
- `cancel()`과 `cancelByMismatch()` 분리 이유: `cancel()`은 환불(PAID→CANCELLED), `cancelByMismatch()`는 미확정 결제 보상(PENDING→CANCELLED). 상태 guard 조건이 다르므로 메서드를 분리함
- CB 오픈 시 Order는 RESERVED 유지 — PortOne 장애 상황이므로 사용자 재시도 가능하게 설계