### PR TITLE
[TEST] 결제 도메인 테스트 작성 (#121)

### DIFF
--- a/docs/superpowers/plans/2026-05-30-payment-domain-tests.md
+++ b/docs/superpowers/plans/2026-05-30-payment-domain-tests.md
@@ -1,0 +1,125 @@
+# Payment Domain Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Payment 엔티티 도메인 메서드 단위 테스트 작성 및 PaymentServiceTest 서킷브레이커 케이스 명칭 보완
+
+**Spec:** GitHub Issue #121
+
+**Tech Stack:** Spring Boot 3.5, Java 25, JUnit 5, Mockito, Resilience4j
+
+---
+
+## File Map
+
+| 파일 | 동작 |
+|------|------|
+| `src/test/java/com/gongu/server/domain/payment/domain/PaymentTest.java` | **Create** — Payment 엔티티 도메인 메서드 단위 테스트 |
+| `src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java` | **Modify** — 서킷브레이커 명칭 테스트 추가 |
+
+**참조 전용 (수정 금지):**
+- `src/main/java/com/gongu/server/domain/payment/domain/Payment.java` — 도메인 메서드 목록
+- `src/main/java/com/gongu/server/domain/payment/domain/PaymentStatus.java` — 상태 열거값
+- `src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java` — 에러 코드
+- `src/main/java/com/gongu/server/global/exception/InfraException.java` — InfraException 타입
+- `src/main/java/com/gongu/server/global/infrastructure/portone/PortOneClient.java` — 서킷브레이커 구조 파악
+
+---
+
+### Task 1: Payment 엔티티 도메인 메서드 단위 테스트 작성
+
+**참고 파일:**
+- `src/main/java/com/gongu/server/domain/payment/domain/Payment.java` — 테스트 대상 메서드 전체
+- `src/main/java/com/gongu/server/domain/payment/domain/PaymentStatus.java` — PENDING, PAID, FAILED, CANCELLED
+- `src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java` — 기대 예외 코드
+- `src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java` — 패키지·import 패턴 참고
+
+**수정 대상 파일:**
+- Create: `src/test/java/com/gongu/server/domain/payment/domain/PaymentTest.java`
+
+**금지 사항:**
+- `Payment.java` 프로덕션 코드 수정 금지
+
+**구현 방향:**
+
+`Payment.initiate()` 테스트:
+- 반환 객체의 `status == PENDING`, `amount`, `merchantUid`, `impUid`, `idempotencyKey` 값이 인수와 일치하는지 검증
+- `order` 필드가 전달한 Order 객체와 동일한지 검증
+
+`Payment.confirm()` 테스트:
+- PENDING 상태에서 올바른 금액 전달 → `status == PAID`, `paidAt != null`
+- PENDING 아닌 상태(PAID, FAILED, CANCELLED)에서 호출 → `BusinessException(PAYMENT_ALREADY_PROCESSED)` 발생
+- PENDING 상태에서 금액 불일치 → `BusinessException(PAYMENT_AMOUNT_MISMATCH)` 발생
+
+`Payment.cancelByMismatch()` 테스트:
+- PENDING 상태에서 호출 → `status == CANCELLED`, `cancelledAt != null`
+- PENDING 아닌 상태(PAID)에서 호출 → `BusinessException(PAYMENT_INVALID_STATE_TRANSITION)` 발생
+
+`Payment.cancel()` 테스트:
+- PAID 상태에서 호출 → `status == CANCELLED`, `cancelledAt != null`
+- PAID 아닌 상태(PENDING, FAILED)에서 호출 → `BusinessException(PAYMENT_INVALID_STATE_TRANSITION)` 발생
+
+`Payment.fail()` 테스트:
+- PENDING 상태에서 호출 → `status == FAILED`
+- PENDING 아닌 상태(PAID, CANCELLED)에서 호출 → `BusinessException(PAYMENT_INVALID_STATE_TRANSITION)` 발생
+
+**구현 시 주의:**
+- `Payment.builder()`는 `AccessLevel.PRIVATE`이므로 `Payment.initiate()` 팩토리 메서드로만 생성
+- 상태를 PAID/CANCELLED로 만들기 위해서는 `initiate()` 후 `confirm()` / `cancel()` 순서로 호출
+- Order 인수는 `Mockito.mock(Order.class)`로 처리
+
+**검증:**
+```bash
+./gradlew test --tests "com.gongu.server.domain.payment.domain.*" -x jacocoTestCoverageVerification
+```
+Expected: BUILD SUCCESSFUL, PaymentTest 전체 통과
+
+**커밋:**
+```bash
+git add src/test/java/com/gongu/server/domain/payment/domain/PaymentTest.java
+git commit -m "test: Payment 엔티티 도메인 메서드 단위 테스트 추가 (#121)"
+```
+
+---
+
+### Task 2: PaymentServiceTest 서킷브레이커 명칭 케이스 추가
+
+**참고 파일:**
+- `src/main/java/com/gongu/server/global/infrastructure/portone/PortOneClient.java` — `getPaymentFallback`이 `InfraException(PAYMENT_PG_UNAVAILABLE)` 던지는 구조 확인
+- `src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java` — 기존 `completePayment_PortOne_InfraException` 테스트 위치 확인
+- `src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java` — `PAYMENT_PG_UNAVAILABLE` (503)
+
+**수정 대상 파일:**
+- Modify: `src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java`
+
+**금지 사항:**
+- 기존 테스트 메서드 수정·삭제 금지 (기존 `completePayment_PortOne_InfraException` 유지)
+- PaymentService.java 프로덕션 코드 수정 금지
+
+**구현 방향:**
+
+기존 `completePayment_PortOne_InfraException` 아래에 서킷브레이커 전용 명칭 테스트 추가:
+
+`completePayment_서킷브레이커_오픈_503` 테스트:
+- `portOneClient.getPayment(PAYMENT_ID)` → `InfraException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE)` throw
+- 서비스가 `InfraException`을 전파하는지 (`assertThatThrownBy → isInstanceOf(InfraException.class)`)
+- `payment.fail()` 호출 여부 검증 (`verify(payment).fail()`)
+- DisplayName: `"completePayment_서킷브레이커_오픈_503 — InfraException 전파 + payment.fail() 호출"`
+
+**검증:**
+```bash
+./gradlew test --tests "com.gongu.server.domain.payment.service.*" -x jacocoTestCoverageVerification
+```
+Expected: BUILD SUCCESSFUL, 신규 테스트 포함 전체 통과
+
+**커밋:**
+```bash
+git add src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
+git commit -m "test: PaymentServiceTest 서킷브레이커 명칭 케이스 추가 (#121)"
+```
+
+---
+
+## 완료 후
+
+PR 생성 후 CLAUDE.md 9~11단계(Codex 리뷰 위임 → 판정 → 반영) 따름.

--- a/src/test/java/com/gongu/server/domain/payment/domain/PaymentTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/domain/PaymentTest.java
@@ -1,0 +1,218 @@
+package com.gongu.server.domain.payment.domain;
+
+import com.gongu.server.domain.order.entity.Order;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.PaymentErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PaymentTest {
+
+    private Order order;
+
+    private static final Long AMOUNT = 10_000L;
+    private static final String PAYMENT_ID = "pay-uuid-001";
+    private static final String IDEMPOTENCY_KEY = "idp-key-001";
+
+    @BeforeEach
+    void setUp() {
+        order = Mockito.mock(Order.class);
+    }
+
+    // ── 헬퍼 ──────────────────────────────────────────────────────────
+
+    private Payment pendingPayment() {
+        return Payment.initiate(order, IDEMPOTENCY_KEY, PAYMENT_ID, AMOUNT);
+    }
+
+    private Payment paidPayment() {
+        Payment p = pendingPayment();
+        p.confirm(AMOUNT, LocalDateTime.now());
+        return p;
+    }
+
+    private Payment cancelledPayment() {
+        Payment p = pendingPayment();
+        p.cancelByMismatch();
+        return p;
+    }
+
+    private Payment failedPayment() {
+        Payment p = pendingPayment();
+        p.fail();
+        return p;
+    }
+
+    // ── initiate() ────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("initiate() — PENDING 상태, 필드 값 검증")
+    void initiate_성공() {
+        Payment payment = pendingPayment();
+
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PENDING);
+        assertThat(payment.getAmount()).isEqualTo(AMOUNT);
+        assertThat(payment.getMerchantUid()).isEqualTo(PAYMENT_ID);
+        assertThat(payment.getImpUid()).isEqualTo(PAYMENT_ID);
+        assertThat(payment.getIdempotencyKey()).isEqualTo(IDEMPOTENCY_KEY);
+        assertThat(payment.getOrder()).isSameAs(order);
+    }
+
+    // ── confirm() ─────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("confirm() — PENDING + 올바른 금액 → PAID, paidAt 설정")
+    void confirm_성공() {
+        Payment payment = pendingPayment();
+        LocalDateTime paidAt = LocalDateTime.now();
+
+        payment.confirm(AMOUNT, paidAt);
+
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID);
+        assertThat(payment.getPaidAt()).isEqualTo(paidAt);
+    }
+
+    @Test
+    @DisplayName("confirm() — PAID 상태에서 호출 → PAYMENT_ALREADY_PROCESSED")
+    void confirm_PAID상태_예외() {
+        Payment payment = paidPayment();
+
+        assertThatThrownBy(() -> payment.confirm(AMOUNT, LocalDateTime.now()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED));
+    }
+
+    @Test
+    @DisplayName("confirm() — FAILED 상태에서 호출 → PAYMENT_ALREADY_PROCESSED")
+    void confirm_FAILED상태_예외() {
+        Payment payment = failedPayment();
+
+        assertThatThrownBy(() -> payment.confirm(AMOUNT, LocalDateTime.now()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED));
+    }
+
+    @Test
+    @DisplayName("confirm() — CANCELLED 상태에서 호출 → PAYMENT_ALREADY_PROCESSED")
+    void confirm_CANCELLED상태_예외() {
+        Payment payment = cancelledPayment();
+
+        assertThatThrownBy(() -> payment.confirm(AMOUNT, LocalDateTime.now()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED));
+    }
+
+    @Test
+    @DisplayName("confirm() — PENDING + 금액 불일치 → PAYMENT_AMOUNT_MISMATCH")
+    void confirm_금액불일치_예외() {
+        Payment payment = pendingPayment();
+
+        assertThatThrownBy(() -> payment.confirm(AMOUNT + 1, LocalDateTime.now()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH));
+    }
+
+    // ── cancelByMismatch() ────────────────────────────────────────────
+
+    @Test
+    @DisplayName("cancelByMismatch() — PENDING → CANCELLED, cancelledAt 설정")
+    void cancelByMismatch_성공() {
+        Payment payment = pendingPayment();
+
+        payment.cancelByMismatch();
+
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
+        assertThat(payment.getCancelledAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("cancelByMismatch() — PAID 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
+    void cancelByMismatch_PAID상태_예외() {
+        Payment payment = paidPayment();
+
+        assertThatThrownBy(payment::cancelByMismatch)
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION));
+    }
+
+    // ── cancel() ──────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("cancel() — PAID → CANCELLED, cancelledAt 설정")
+    void cancel_성공() {
+        Payment payment = paidPayment();
+
+        payment.cancel();
+
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
+        assertThat(payment.getCancelledAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("cancel() — PENDING 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
+    void cancel_PENDING상태_예외() {
+        Payment payment = pendingPayment();
+
+        assertThatThrownBy(payment::cancel)
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION));
+    }
+
+    @Test
+    @DisplayName("cancel() — FAILED 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
+    void cancel_FAILED상태_예외() {
+        Payment payment = failedPayment();
+
+        assertThatThrownBy(payment::cancel)
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION));
+    }
+
+    // ── fail() ────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("fail() — PENDING → FAILED")
+    void fail_성공() {
+        Payment payment = pendingPayment();
+
+        payment.fail();
+
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.FAILED);
+    }
+
+    @Test
+    @DisplayName("fail() — PAID 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
+    void fail_PAID상태_예외() {
+        Payment payment = paidPayment();
+
+        assertThatThrownBy(payment::fail)
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION));
+    }
+
+    @Test
+    @DisplayName("fail() — CANCELLED 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
+    void fail_CANCELLED상태_예외() {
+        Payment payment = cancelledPayment();
+
+        assertThatThrownBy(payment::fail)
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION));
+    }
+}

--- a/src/test/java/com/gongu/server/domain/payment/domain/PaymentTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/domain/PaymentTest.java
@@ -63,6 +63,8 @@ class PaymentTest {
         assertThat(payment.getImpUid()).isEqualTo(PAYMENT_ID);
         assertThat(payment.getIdempotencyKey()).isEqualTo(IDEMPOTENCY_KEY);
         assertThat(payment.getOrder()).isSameAs(order);
+        assertThat(payment.getPaidAt()).isNull();
+        assertThat(payment.getCancelledAt()).isNull();
     }
 
     // ── confirm() ─────────────────────────────────────────────────────
@@ -80,7 +82,7 @@ class PaymentTest {
     }
 
     @Test
-    @DisplayName("confirm() — PAID 상태에서 호출 → PAYMENT_ALREADY_PROCESSED")
+    @DisplayName("confirm() — PAID 상태에서 호출 → PAYMENT_ALREADY_PROCESSED, 상태 불변")
     void confirm_PAID상태_예외() {
         Payment payment = paidPayment();
 
@@ -88,10 +90,11 @@ class PaymentTest {
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED));
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID);
     }
 
     @Test
-    @DisplayName("confirm() — FAILED 상태에서 호출 → PAYMENT_ALREADY_PROCESSED")
+    @DisplayName("confirm() — FAILED 상태에서 호출 → PAYMENT_ALREADY_PROCESSED, 상태 불변")
     void confirm_FAILED상태_예외() {
         Payment payment = failedPayment();
 
@@ -99,10 +102,11 @@ class PaymentTest {
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED));
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.FAILED);
     }
 
     @Test
-    @DisplayName("confirm() — CANCELLED 상태에서 호출 → PAYMENT_ALREADY_PROCESSED")
+    @DisplayName("confirm() — CANCELLED 상태에서 호출 → PAYMENT_ALREADY_PROCESSED, 상태 불변")
     void confirm_CANCELLED상태_예외() {
         Payment payment = cancelledPayment();
 
@@ -110,10 +114,11 @@ class PaymentTest {
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED));
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
     }
 
     @Test
-    @DisplayName("confirm() — PENDING + 금액 불일치 → PAYMENT_AMOUNT_MISMATCH")
+    @DisplayName("confirm() — PENDING + 금액 불일치 → PAYMENT_AMOUNT_MISMATCH, 상태 불변")
     void confirm_금액불일치_예외() {
         Payment payment = pendingPayment();
 
@@ -121,6 +126,8 @@ class PaymentTest {
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH));
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PENDING);
+        assertThat(payment.getPaidAt()).isNull();
     }
 
     // ── cancelByMismatch() ────────────────────────────────────────────
@@ -140,6 +147,28 @@ class PaymentTest {
     @DisplayName("cancelByMismatch() — PAID 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
     void cancelByMismatch_PAID상태_예외() {
         Payment payment = paidPayment();
+
+        assertThatThrownBy(payment::cancelByMismatch)
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION));
+    }
+
+    @Test
+    @DisplayName("cancelByMismatch() — FAILED 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
+    void cancelByMismatch_FAILED상태_예외() {
+        Payment payment = failedPayment();
+
+        assertThatThrownBy(payment::cancelByMismatch)
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION));
+    }
+
+    @Test
+    @DisplayName("cancelByMismatch() — CANCELLED 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
+    void cancelByMismatch_CANCELLED상태_예외() {
+        Payment payment = cancelledPayment();
 
         assertThatThrownBy(payment::cancelByMismatch)
                 .isInstanceOf(BusinessException.class)
@@ -182,6 +211,17 @@ class PaymentTest {
                         .isEqualTo(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION));
     }
 
+    @Test
+    @DisplayName("cancel() — CANCELLED 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
+    void cancel_CANCELLED상태_예외() {
+        Payment payment = cancelledPayment();
+
+        assertThatThrownBy(payment::cancel)
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION));
+    }
+
     // ── fail() ────────────────────────────────────────────────────────
 
     @Test
@@ -209,6 +249,17 @@ class PaymentTest {
     @DisplayName("fail() — CANCELLED 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
     void fail_CANCELLED상태_예외() {
         Payment payment = cancelledPayment();
+
+        assertThatThrownBy(payment::fail)
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION));
+    }
+
+    @Test
+    @DisplayName("fail() — FAILED 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
+    void fail_FAILED상태_예외() {
+        Payment payment = failedPayment();
 
         assertThatThrownBy(payment::fail)
                 .isInstanceOf(BusinessException.class)

--- a/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
@@ -283,7 +283,7 @@ class PaymentServiceTest {
     }
 
     @Test
-    @DisplayName("completePayment_PortOne_InfraException")
+    @DisplayName("completePayment_서킷브레이커_오픈_503 — PortOne InfraException 전파 + payment.fail() 호출")
     void completePayment_PortOne_InfraException() {
         // given
         Payment payment = Mockito.mock(Payment.class);


### PR DESCRIPTION
## Issue ID

close #121

## 작업 내용

### 1. Payment 엔티티 도메인 메서드 단위 테스트 추가
**파일**: `src/test/java/com/gongu/server/domain/payment/domain/PaymentTest.java` (신규)

테스트 케이스 (총 14개):
- `initiate()` — PENDING 상태·필드 값 검증
- `confirm()` — PENDING+올바른 금액 → PAID / PAID·FAILED·CANCELLED 상태 → PAYMENT_ALREADY_PROCESSED / 금액 불일치 → PAYMENT_AMOUNT_MISMATCH
- `cancelByMismatch()` — PENDING → CANCELLED / PAID 상태 → PAYMENT_INVALID_STATE_TRANSITION
- `cancel()` — PAID → CANCELLED / PENDING·FAILED 상태 → PAYMENT_INVALID_STATE_TRANSITION
- `fail()` — PENDING → FAILED / PAID·CANCELLED 상태 → PAYMENT_INVALID_STATE_TRANSITION

### 2. PaymentServiceTest 서킷브레이커 명칭 보완
**파일**: `src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java`

기존 `completePayment_PortOne_InfraException` 테스트의 `@DisplayName`을 서킷브레이커 컨텍스트가 명시되도록 변경.

## 참고사항

- PR #129에서 이미 작성된 PaymentServiceTest(preparePayment·validateOwnership·completePayment 전 케이스)·PaymentControllerTest는 이번 PR에 미포함
- 서킷브레이커 InfraException 케이스는 기존 테스트 구조와 동일하여 DisplayName 보완으로 처리