### PR TITLE
[FIX] 미사용 Idempotency-Key 헤더 파라미터 제거 (#130)

### DIFF
--- a/src/main/java/com/gongu/server/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/gongu/server/domain/payment/controller/PaymentController.java
@@ -16,7 +16,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -40,7 +39,6 @@ public class PaymentController {
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ApiResponse<VerifyPaymentResponse>> verifyPayment(
             @Valid @RequestBody VerifyPaymentRequest request,
-            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
         paymentService.validateOwnership(userPrincipal.id(), request.paymentId());
         VerifyPaymentResponse result = paymentService.completePayment(request.paymentId());


### PR DESCRIPTION
## Issue ID
close #130

## 작업 내용

- `POST /payments/verify`의 `@RequestHeader Idempotency-Key` 파라미터 제거
- 서비스에 전달되지 않아 완전히 미사용 상태였음
- 함께 불필요해진 `RequestHeader` import 제거

## 참고사항

이슈 #130 논의 결과, 현 `completePayment`는 비관적 락(`findByMerchantUidWithLock`) + `PAID` 상태 체크 조합으로 race condition 및 중복 처리가 이미 방지되어 있어 별도 Idempotency-Key 캐싱이 불필요하다고 결론.
헤더 추출 코드만 코드 노이즈로 남아 있어 제거.