### PR TITLE
[FEAT] Payment/Order 만료 취소 연동 및 보상 처리 구현 (#139)

### DIFF
--- a/docs/adr/payment_만료_취소_설계.md
+++ b/docs/adr/payment_만료_취소_설계.md
@@ -63,7 +63,7 @@ Issue #136에서 RESERVED Order TTL 만료 스케줄러를 구현하면서 두 �
 
 **문제 시나리오**
 
-```
+```text
 T=19:59  사용자가 PG에 결제 정보 제출 → PortOne 내부 결제 처리 완료 (돈 빠져나감)
 T=20:00  Payment 취소 스케줄러 실행 → Payment: CANCELLED, Order: CANCELLED, 재고 복구
 T=20:01  PortOne webhook / client verify 도착 → Order가 이미 CANCELLED
@@ -72,7 +72,7 @@ T=20:01  PortOne webhook / client verify 도착 → Order가 이미 CANCELLED
 
 **보상 트랜잭션 흐름**
 
-```
+```text
 Order CANCELLED 감지
   → PortOne 취소 API 호출 (환불)
   → payment.refund()  (Payment: REFUNDED)

--- a/docs/adr/payment_만료_취소_설계.md
+++ b/docs/adr/payment_만료_취소_설계.md
@@ -1,0 +1,113 @@
+# ADR-007: Payment 만료 취소 설계
+
+- **날짜**: 2026-06-03
+- **상태**: 승인됨
+
+---
+
+## 배경
+
+Issue #136에서 RESERVED Order TTL 만료 스케줄러를 구현하면서 두 가지 미해결 설계 문제가 도출되었다.
+
+1. `preparePayment()` 호출 후 PENDING 상태인 Payment가 존재할 때, Order 만료 스케줄러가 Order만 CANCELLED 처리하면 Payment가 PENDING orphan으로 남는다.
+2. PortOne 내부에서 결제가 완료된 직후, 스케줄러가 Order를 CANCELLED 처리하면 PG 상태(결제 완료)와 DB 상태(CANCELLED) 간 불일치가 발생한다.
+
+---
+
+## 결정 1: PaymentStatus에 REFUNDED 추가
+
+**기준: 돈의 이동 여부**
+
+| 상태 | 의미 |
+|------|------|
+| `CANCELLED` | 돈 이동 없이 만료된 경우 (스케줄러 만료 처리) |
+| `REFUNDED` | 돈이 이동했다가 반환된 경우 (금액 불일치, race condition 보상) |
+
+**선택하지 않은 대안**: CANCELLED로 모든 경우를 통합 처리  
+**선택하지 않은 근거**: 취소와 환불은 회계·감사 이력 관점에서 명확히 구분해야 하며, 실제 돈의 흐름이 다른 두 케이스를 동일 상태로 관리하면 정산 오류 가능성이 생긴다.
+
+---
+
+## 결정 2: 스케줄러 분리 (Payment 취소 스케줄러 + Order 취소 스케줄러)
+
+**Payment 취소 스케줄러**
+- 대상: PENDING Payment가 있는 만료 Order
+- 처리: Payment(CANCELLED) + Order(CANCELLED) 함께 처리
+- 락 순서: Payment → Order (`completePayment()`와 동일 순서, 데드락 방지)
+
+**Order 취소 스케줄러**
+- 대상: PENDING Payment가 없는 만료 RESERVED Order
+- 처리: Order(CANCELLED)만 처리
+- 락 순서: Order만
+
+**TTL 설정**
+
+| 항목 | 값 | 설정 키 |
+|------|-----|---------|
+| PortOne 결제 세션 만료 | 15분 | — (PortOne 정책) |
+| Order/Payment 만료 임계값 | 20분 | `order.reservation-ttl-minutes` |
+
+두 스케줄러 모두 동일한 20분 임계값을 사용하며, PortOne TTL(15분)보다 길게 설정해 PG 세션이 먼저 만료된 뒤 스케줄러가 정리하는 순서를 보장한다.
+
+**선택하지 않은 대안 1**: 단일 스케줄러에서 PENDING Payment 존재 시 skip  
+**선택하지 않은 근거**: 사용자가 `preparePayment()`만 하고 이탈하면 Order가 영구 RESERVED 상태로 남아 재고가 묶인다.
+
+**선택하지 않은 대안 2**: 단일 스케줄러에서 PENDING Payment 존재 시 조건 분기  
+**선택하지 않은 근거**: 단일 스케줄러 내에서 두 락 경로(Payment → Order, Order만)가 혼재하면 락 순서 추론이 복잡해진다. 스케줄러를 분리하면 각 스케줄러의 락 순서가 단순 명확해진다.
+
+**핵심 근거**: `completePayment()`는 Payment 락 → Order 락 순서로 동작한다. Payment 취소 스케줄러가 동일한 순서를 유지함으로써 데드락을 원천 차단한다.
+
+---
+
+## 결정 3: completePayment() race condition 보상 트랜잭션
+
+**문제 시나리오**
+
+```
+T=19:59  사용자가 PG에 결제 정보 제출 → PortOne 내부 결제 처리 완료 (돈 빠져나감)
+T=20:00  Payment 취소 스케줄러 실행 → Payment: CANCELLED, Order: CANCELLED, 재고 복구
+T=20:01  PortOne webhook / client verify 도착 → Order가 이미 CANCELLED
+           → completePayment() 진입 → Order CANCELLED 감지 → 보상 트랜잭션 실행
+```
+
+**보상 트랜잭션 흐름**
+
+```
+Order CANCELLED 감지
+  → PortOne 취소 API 호출 (환불)
+  → payment.refund()  (Payment: REFUNDED)
+  → ORDER_EXPIRED_REFUNDED 예외 발생
+  → 사용자에게 "주문 만료로 자동 환불" 알림
+```
+
+**선택하지 않은 대안**: TTL 마진만으로 race condition 방지 (PortOne TTL < 우리 TTL)  
+**선택하지 않은 근거**: PortOne TTL이 우리 TTL보다 짧더라도 webhook 지연 케이스를 100% 차단할 수 없다. PortOne이 세션을 만료시킨 뒤에도 이미 처리된 결제의 webhook은 늦게 도착할 수 있다. TTL 설정은 1차 방어선이고, 보상 트랜잭션은 그 뒤를 막는 안전망이다.
+
+---
+
+## 최종 비교
+
+| 항목 | 채택안 | 선택하지 않은 대안 |
+|------|--------|-------------------|
+| Payment 상태 구분 | CANCELLED / REFUNDED 분리 | CANCELLED 단일 상태로 통합 |
+| PENDING Payment 만료 처리 | 스케줄러 분리 (Payment 취소 + Order 취소) | 단일 스케줄러 skip 또는 분기 |
+| Race condition 처리 | 보상 트랜잭션 (PortOne 환불 + REFUNDED) | TTL 마진만으로 방지 |
+
+---
+
+## 결과
+
+**긍정적 영향**
+- PENDING Payment orphan 발생 원천 차단
+- `completePayment()`와 동일한 락 순서 유지 → 데드락 위험 없음
+- PG 결제 완료 후 Order 만료 케이스에서 사용자 환불 자동 처리
+- CANCELLED/REFUNDED 구분으로 정산·감사 이력 명확
+
+**부정적 영향 및 제약**
+- 스케줄러 2개 유지 필요 (운영 관리 포인트 증가)
+- PortOne 환불 API 연동 필요
+- `completePayment()` 내에 보상 트랜잭션 분기 추가로 복잡도 소폭 증가
+
+**향후 고려 사항**
+- PortOne webhook 재시도 정책과 우리 시스템의 멱등성 처리 연계 강화
+- Payment 상태 전이를 State Machine 패턴으로 명시화하는 방향 검토 (현재 규모에서는 오버엔지니어링)

--- a/docs/superpowers/plans/2026-06-03-payment-order-expiry-integration.md
+++ b/docs/superpowers/plans/2026-06-03-payment-order-expiry-integration.md
@@ -1,0 +1,387 @@
+# Payment/Order 만료 취소 연동 및 보상 처리 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** PENDING Payment가 있는 Order의 만료 처리 연동 및 결제 완료 후 스케줄러 race condition 보상 트랜잭션 구현
+
+**Spec:** `docs/superpowers/specs/2026-06-03-payment-order-expiry-design.md`
+
+**Tech Stack:** Spring Boot 3.5, Java 25, JPA (Pessimistic Lock), PortOne V2
+
+---
+
+## 브랜치
+
+`feat/#139-payment-order-expiry-integration` (main에서 분기)
+
+---
+
+## 파일 맵
+
+### 신규 생성
+- `src/main/java/com/gongu/server/domain/payment/service/PaymentExpireService.java`
+- `src/main/java/com/gongu/server/domain/order/scheduler/PaymentExpiryScheduler.java`
+- `src/test/java/com/gongu/server/domain/payment/service/PaymentExpireServiceTest.java`
+
+### 수정
+- `src/main/java/com/gongu/server/domain/payment/domain/PaymentStatus.java`
+- `src/main/java/com/gongu/server/domain/payment/domain/Payment.java`
+- `src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java`
+- `src/main/java/com/gongu/server/domain/payment/repository/PaymentRepository.java`
+- `src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java`
+- `src/main/java/com/gongu/server/domain/order/service/OrderExpireService.java` (NOT EXISTS 조건 대응 확인)
+- `src/main/java/com/gongu/server/domain/payment/service/PaymentService.java`
+- `src/test/java/com/gongu/server/domain/order/service/OrderExpireServiceTest.java`
+
+### 참고 전용 (수정 금지)
+- `src/main/java/com/gongu/server/domain/order/scheduler/OrderExpiryScheduler.java` — Task 4에서만 수정
+- `src/main/java/com/gongu/server/domain/order/entity/Order.java` — cancel() 시그니처 확인용
+- `docs/adr/예외_처리_전략.md` — BusinessException 컨벤션 확인용
+
+---
+
+## Task 1: Payment 도메인 모델 변경
+
+- [ ] PaymentStatus, Payment 메서드, PaymentErrorCode 변경
+
+**참고 문서/파일:**
+- Spec: `docs/superpowers/specs/2026-06-03-payment-order-expiry-design.md` — "Payment 상태 머신 변경" 섹션
+- `src/main/java/com/gongu/server/domain/payment/domain/Payment.java` — 현재 메서드 시그니처 확인
+- `docs/adr/예외_처리_전략.md` — BusinessException 사용 컨벤션
+
+**수정 대상 파일:**
+- Modify: `src/main/java/com/gongu/server/domain/payment/domain/PaymentStatus.java`
+- Modify: `src/main/java/com/gongu/server/domain/payment/domain/Payment.java`
+- Modify: `src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java`
+
+**구현 방향:**
+
+`PaymentStatus.java`:
+- `REFUNDED` 값 추가 → `PENDING, PAID, CANCELLED, FAILED, REFUNDED`
+
+`Payment.java`:
+- `cancelByMismatch()` 메서드 삭제. 대신 `refund()` 메서드 추가.
+  - `refund()`: status가 PENDING 또는 PAID가 아니면 `PAYMENT_INVALID_STATE_TRANSITION` 예외. 조건 통과 시 `this.status = PaymentStatus.REFUNDED`, `this.cancelledAt = LocalDateTime.now()`
+- `cancel()` 메서드 삭제. `refund()` 가 PAID 상태도 처리하므로 통합.
+- `expire()` 메서드 추가.
+  - `expire()`: status가 PENDING이 아니면 `PAYMENT_INVALID_STATE_TRANSITION` 예외. `this.status = PaymentStatus.CANCELLED`, `this.cancelledAt = LocalDateTime.now()`
+
+`PaymentErrorCode.java`:
+- `ORDER_EXPIRED_REFUNDED("PAYMENT_008", "주문 만료로 결제가 자동 환불되었습니다", 409)` 추가
+
+**검증:**
+```bash
+./gradlew compileJava
+```
+Expected: BUILD SUCCESSFUL
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/payment/domain/PaymentStatus.java \
+        src/main/java/com/gongu/server/domain/payment/domain/Payment.java \
+        src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java
+git commit -m "feat: PaymentStatus REFUNDED 추가 및 Payment 상태 전이 메서드 변경 (#139)"
+```
+
+---
+
+## Task 2: Repository 쿼리 추가 및 수정
+
+- [ ] PaymentRepository에 만료 Payment 조회 쿼리 추가, OrderRepository의 만료 Order 조회 쿼리에 NOT EXISTS 조건 추가
+
+**참고 문서/파일:**
+- Spec: `docs/superpowers/specs/2026-06-03-payment-order-expiry-design.md` — "스케줄러 분리" 섹션
+- `src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java` — `findExpiredReservedOrderIds` 기존 쿼리 참고
+- `src/main/java/com/gongu/server/domain/payment/repository/PaymentRepository.java` — `findByMerchantUidWithLock` Lock 패턴 참고
+
+**수정 대상 파일:**
+- Modify: `src/main/java/com/gongu/server/domain/payment/repository/PaymentRepository.java`
+- Modify: `src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java`
+
+**구현 방향:**
+
+`PaymentRepository.java`에 두 메서드 추가:
+
+1. 만료 대상 PENDING Payment ID 목록 조회 (락 없음):
+```java
+@Query("SELECT p.id FROM Payment p WHERE p.status = :status AND p.order.status = :orderStatus AND p.order.createdAt < :threshold ORDER BY p.id")
+List<Long> findExpiredPendingPaymentIds(@Param("status") PaymentStatus status, @Param("orderStatus") OrderStatus orderStatus, @Param("threshold") LocalDateTime threshold, Pageable pageable);
+```
+
+2. ID로 Payment 비관적 락 조회 추가:
+```java
+@Lock(LockModeType.PESSIMISTIC_WRITE)
+@Query("SELECT p FROM Payment p JOIN FETCH p.order WHERE p.id = :id")
+Optional<Payment> findByIdWithLock(@Param("id") Long id);
+```
+
+`OrderRepository.java`에서 `findExpiredReservedOrderIds` 쿼리를 아래로 교체:
+```java
+@Query("SELECT o.id FROM Order o WHERE o.status = :status AND o.createdAt < :threshold AND NOT EXISTS (SELECT 1 FROM Payment p WHERE p.order = o AND p.status = 'PENDING') ORDER BY o.id")
+List<Long> findExpiredReservedOrderIds(@Param("status") OrderStatus status, @Param("threshold") LocalDateTime threshold, Pageable pageable);
+```
+- 기존 쿼리 파라미터에서 `:status`는 그대로 유지. `PageRequest.of(0, 100)` 호출부(`OrderExpiryScheduler.java`)는 변경 불필요.
+
+**검증:**
+```bash
+./gradlew compileJava
+```
+Expected: BUILD SUCCESSFUL
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/payment/repository/PaymentRepository.java \
+        src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java
+git commit -m "feat: Payment 만료 조회 쿼리 추가 및 Order 만료 조회에 NOT EXISTS 조건 적용 (#139)"
+```
+
+---
+
+## Task 3: PaymentExpireService 신규 구현
+
+- [ ] PENDING Payment + Order 함께 만료 취소하는 서비스 구현
+
+**참고 문서/파일:**
+- Spec: `docs/superpowers/specs/2026-06-03-payment-order-expiry-design.md` — "Payment 취소 스케줄러", "락 순서 정합성" 섹션
+- `src/main/java/com/gongu/server/domain/order/service/OrderExpireService.java` — REQUIRES_NEW 트랜잭션 + double-check 패턴 참고
+- `src/main/java/com/gongu/server/domain/order/entity/Order.java` — `cancel(String reason)` 시그니처 확인
+- `src/main/java/com/gongu/server/domain/product/repository/ProductRepository.java` — `findByIdWithLock` 사용 여부 확인
+
+**수정 대상 파일:**
+- Create: `src/main/java/com/gongu/server/domain/payment/service/PaymentExpireService.java`
+
+**구현 방향:**
+
+패키지: `com.gongu.server.domain.payment.service`
+
+`cancelExpiredPayment(Long paymentId, LocalDateTime threshold)` 메서드:
+- `@Transactional(propagation = Propagation.REQUIRES_NEW)`
+- `paymentRepository.findByIdWithLock(paymentId)` — Payment 먼저 락 (completePayment와 동일 순서)
+- double-check 1: payment가 없으면 return
+- double-check 2: `payment.getStatus() != PaymentStatus.PENDING`이면 return
+- `orderRepository.findByIdWithLock(payment.getOrder().getId())` — Order 락
+- double-check 3: `order.getStatus() != OrderStatus.RESERVED`이면 return
+- double-check 4: `!order.getCreatedAt().isBefore(threshold)`이면 return
+- 재고 복구: `OrderItem` 목록 조회 → Product ID 오름차순 정렬 → 각 Product 비관적 락 획득 → `product.restoreStock()` (OrderExpireService의 기존 재고 복구 로직과 동일)
+- `payment.expire()` 호출
+- `order.cancel("결제 시간 초과")` 호출
+
+**검증:**
+```bash
+./gradlew compileJava
+```
+Expected: BUILD SUCCESSFUL
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/payment/service/PaymentExpireService.java
+git commit -m "feat: PaymentExpireService 구현 (만료 PENDING Payment + Order 함께 취소) (#139)"
+```
+
+---
+
+## Task 4: 스케줄러 분리 — PaymentExpiryScheduler 추가 및 OrderExpiryScheduler 쿼리 반영
+
+- [ ] PaymentExpiryScheduler 신규 추가, OrderExpiryScheduler 쿼리 변경 반영
+
+**참고 문서/파일:**
+- Spec: `docs/superpowers/specs/2026-06-03-payment-order-expiry-design.md` — "스케줄러 분리", "TTL 설정" 섹션
+- `src/main/java/com/gongu/server/domain/order/scheduler/OrderExpiryScheduler.java` — 기존 패턴 참고 (fixedDelay, @Value, 예외 로깅)
+
+**수정 대상 파일:**
+- Create: `src/main/java/com/gongu/server/domain/order/scheduler/PaymentExpiryScheduler.java`
+- Modify: `src/main/java/com/gongu/server/domain/order/scheduler/OrderExpiryScheduler.java`
+
+**구현 방향:**
+
+`PaymentExpiryScheduler.java`:
+- 패키지: `com.gongu.server.domain.order.scheduler`
+- `@Scheduled(fixedDelay = 60_000)`
+- `@Value("${order.reservation-ttl-minutes}")` 로 TTL 주입 (Order 스케줄러와 동일한 프로퍼티 사용)
+- `paymentRepository.findExpiredPendingPaymentIds(PaymentStatus.PENDING, OrderStatus.RESERVED, threshold, PageRequest.of(0, 100))`로 대상 조회
+- 각 paymentId에 대해 `paymentExpireService.cancelExpiredPayment(id, threshold)` 호출
+- 예외 발생 시 `log.warn("만료 Payment 취소 실패: paymentId={}", id, e)`로 개별 실패 처리 (OrderExpiryScheduler와 동일한 패턴)
+
+`OrderExpiryScheduler.java`:
+- Task 2에서 수정된 `findExpiredReservedOrderIds` 쿼리가 이미 NOT EXISTS 조건을 포함하므로 코드 변경 없음. 컴파일 확인만.
+
+**검증:**
+```bash
+./gradlew compileJava
+```
+Expected: BUILD SUCCESSFUL
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/order/scheduler/PaymentExpiryScheduler.java \
+        src/main/java/com/gongu/server/domain/order/scheduler/OrderExpiryScheduler.java
+git commit -m "feat: PaymentExpiryScheduler 추가 (60초 주기 만료 Payment 자동 취소) (#139)"
+```
+
+---
+
+## Task 5: completePayment() race condition 보상 처리
+
+- [ ] Order CANCELLED 감지 → PortOne 환불 → Payment REFUNDED 처리
+
+**참고 문서/파일:**
+- Spec: `docs/superpowers/specs/2026-06-03-payment-order-expiry-design.md` — "문제 2: completePayment() race condition 보상 처리" 섹션
+- `src/main/java/com/gongu/server/domain/payment/service/PaymentService.java` — `completePayment()` 전체 흐름, `noRollbackFor` 설정 확인
+- `src/main/java/com/gongu/server/global/infrastructure/portone/PortOneClient.java` — `cancelPayment()` 시그니처 확인
+
+**수정 대상 파일:**
+- Modify: `src/main/java/com/gongu/server/domain/payment/service/PaymentService.java`
+
+**구현 방향:**
+
+`completePayment()` 내 Order 락 획득 직후, PortOne 조회 이전에 아래 블록 삽입:
+
+```
+Order order = orderRepository.findByIdWithLock(...)  // 기존 코드
+
+// [추가] race condition 보상 처리
+if (order.getStatus() == OrderStatus.CANCELLED) {
+    portOneClient.cancelPayment(paymentId, "주문 만료로 인한 자동 환불");
+    payment.refund();
+    throw new BusinessException(PaymentErrorCode.ORDER_EXPIRED_REFUNDED);
+    // noRollbackFor 설정으로 REFUNDED 상태가 커밋됨
+}
+
+PortOnePaymentResponse portOneResponse = ...  // 기존 코드
+```
+
+기존 `payment.cancelByMismatch()` 호출부를 `payment.refund()`로 교체 (Task 1에서 메서드 삭제됨).
+
+**금지 사항:**
+- `noRollbackFor` 설정 변경 금지 — 기존 설정이 보상 처리 커밋을 보장함
+- PortOne 조회(`getPayment`) 로직 순서 변경 금지
+
+**검증:**
+```bash
+./gradlew compileJava
+```
+Expected: BUILD SUCCESSFUL
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+git commit -m "feat: completePayment race condition 보상 처리 구현 (Order CANCELLED 감지 → 자동 환불) (#139)"
+```
+
+---
+
+## Task 6: 단위 테스트 작성
+
+- [ ] PaymentExpireService, Payment 상태 전이, completePayment 보상 처리 테스트
+
+**참고 문서/파일:**
+- `src/test/java/com/gongu/server/domain/order/service/OrderExpireServiceTest.java` — Mockito 패턴, fixture helper 스타일 참고
+- `src/main/java/com/gongu/server/domain/payment/service/PaymentExpireService.java` — 테스트 대상
+- `src/main/java/com/gongu/server/domain/payment/service/PaymentService.java` — completePayment 테스트 대상
+
+**수정 대상 파일:**
+- Create: `src/test/java/com/gongu/server/domain/payment/service/PaymentExpireServiceTest.java`
+- Modify: `src/test/java/com/gongu/server/domain/order/service/OrderExpireServiceTest.java`
+- Modify: (기존 PaymentServiceTest가 있다면 보상 처리 케이스 추가, 없다면 생략)
+
+**구현 방향:**
+
+`PaymentExpireServiceTest.java` — `@ExtendWith(MockitoExtension.class)`:
+
+| 테스트명 | 시나리오 |
+|---------|---------|
+| `만료된_PENDING_Payment_취소_및_Order_취소_재고_복구` | 정상 만료 처리 |
+| `이미_PAID된_Payment_skip` | double-check: payment.status == PAID → return |
+| `Order가_이미_PAID_상태_skip` | double-check: order.status == PAID → return |
+| `아직_유효한_Payment_skip` | double-check: threshold 이전 생성 → return |
+| `존재하지_않는_Payment_예외_없음` | Optional.empty() → return |
+
+`OrderExpireServiceTest.java`:
+- 기존 테스트는 변경 없음. `cancelExpiredOrder`는 서명 변화 없으므로 기존 테스트 그대로 유지.
+- PENDING Payment 있는 Order가 Order 스케줄러에서 skip되는 것은 Repository 쿼리 레벨에서 처리되므로 서비스 단위 테스트 추가 불필요.
+
+**검증:**
+```bash
+./gradlew test --tests "com.gongu.server.domain.payment.service.PaymentExpireServiceTest"
+./gradlew test --tests "com.gongu.server.domain.order.service.OrderExpireServiceTest"
+```
+Expected: 모든 테스트 PASSED
+
+**커밋:**
+```bash
+git add src/test/java/com/gongu/server/domain/payment/service/PaymentExpireServiceTest.java \
+        src/test/java/com/gongu/server/domain/order/service/OrderExpireServiceTest.java
+git commit -m "test: PaymentExpireService 단위 테스트 추가 (#139)"
+```
+
+---
+
+## Task 7: ADR 작성 및 GitHub Issue #139 결론 업데이트
+
+- [ ] ADR 작성, Issue 결론 섹션 업데이트
+
+**수정 대상 파일:**
+- Create: `docs/adr/payment_만료_취소_설계.md`
+
+**구현 방향:**
+
+ADR 작성 (`docs/adr/` 내 기존 ADR 파일 형식 참고):
+- 결정 사항: Payment 상태 머신에 REFUNDED 추가, 스케줄러 분리 (Payment + Order 독립), completePayment 보상 트랜잭션
+- 선택하지 않은 대안: PENDING Payment skip (A안), 단일 스케줄러, TTL만으로 race condition 처리
+- 근거: 돈 흐름 기준 상태 구분, 락 순서 통일로 데드락 방지, webhook 지연 대비 안전망
+
+GitHub Issue #139 결론 섹션 업데이트:
+```bash
+gh issue edit 139 --repo hkjbrian/gongu --body "$(cat <<'EOF'
+[기존 이슈 본문 유지]
+
+## 결론
+
+### 문제 1: PENDING Payment 만료 처리
+**B안 변형 채택** — 스케줄러를 두 개로 분리
+- Payment 취소 스케줄러: PENDING Payment가 있는 만료 Order → Payment(CANCELLED) + Order(CANCELLED) 함께 처리. 락 순서: Payment → Order (completePayment와 동일, 데드락 방지)
+- Order 취소 스케줄러: PENDING Payment 없는 만료 Order → Order(CANCELLED)만 처리
+- TTL: 두 스케줄러 모두 PortOne TTL(15분)보다 긴 20분 사용
+
+### 문제 2: Race condition 보상 처리
+**A안 채택** — completePayment()에서 Order CANCELLED 감지 → PortOne 환불 → Payment REFUNDED
+- TTL 마진만으로는 webhook 지연 케이스를 100% 보장할 수 없어 보상 트랜잭션을 안전망으로 추가
+
+### 추가 결정
+- PaymentStatus에 REFUNDED 추가: 돈이 이동했다가 반환된 모든 케이스를 CANCELLED와 구분
+- cancelByMismatch() → refund()로 통합: PAID 여부와 무관하게 동일한 메서드로 처리
+EOF
+)"
+```
+(실제 커맨드 실행 시 기존 이슈 본문을 gh issue view로 먼저 읽어 유지)
+
+**검증:**
+```bash
+./gradlew test
+```
+Expected: BUILD SUCCESSFUL, 전체 테스트 PASSED
+
+**커밋:**
+```bash
+git add docs/adr/payment_만료_취소_설계.md
+git commit -m "docs: #139 Payment 만료 취소 설계 ADR 추가"
+```
+
+---
+
+## 전체 검증 후 PR
+
+```bash
+./gradlew test
+```
+Expected: BUILD SUCCESSFUL, 전체 테스트 PASSED
+
+```bash
+git push origin feat/#139-payment-order-expiry-integration
+gh pr create \
+  --title "[FEAT] Payment/Order 만료 취소 연동 및 race condition 보상 처리 (#139)" \
+  --body "..." \
+  --milestone "결제 도메인"
+```
+
+PR 생성 후 CLAUDE.md 9~11단계(Codex 리뷰 위임 → 판정 → 반영) 진행.

--- a/docs/superpowers/specs/2026-06-03-payment-order-expiry-design.md
+++ b/docs/superpowers/specs/2026-06-03-payment-order-expiry-design.md
@@ -1,0 +1,182 @@
+# Payment / Order 만료 취소 연동 및 결제 완료 후 보상 처리 설계
+
+**이슈**: #139  
+**작성일**: 2026-06-03
+
+---
+
+## 배경
+
+Issue #136에서 구현한 Order 만료 스케줄러에서 두 가지 미해결 설계 문제가 도출되었다.
+
+1. PENDING Payment가 있는 Order가 만료될 때 Payment가 orphan으로 남음
+2. PortOne 결제 완료 직후 스케줄러가 Order를 취소하는 순차적 race condition
+
+---
+
+## Payment 상태 머신 변경
+
+### 현재
+
+```
+PENDING → PAID
+        → CANCELLED  (금액 불일치 cancelByMismatch, 미래 사용자 취소)
+        → FAILED     (PG 오류)
+```
+
+### 변경 후
+
+```
+PENDING → PAID
+        → CANCELLED  (스케줄러 만료 처리 — 돈 이동 없음)
+        → REFUNDED   (금액 불일치, race condition 보상 — 돈 이동 후 반환)
+        → FAILED     (PG 오류)
+
+PAID    → REFUNDED   (사용자 취소 등)
+```
+
+**구분 기준: 돈의 이동 여부**
+
+| 상태 | 의미 | 돈 이동 |
+|------|------|---------|
+| CANCELLED | PENDING 단계에서 정리됨 | 없음 |
+| FAILED | PG 처리 실패 | 없음 |
+| REFUNDED | 결제 완료 후 역방향 이동 (이유 무관) | 수취 후 반환 |
+
+### Payment 메서드 변경
+
+| 기존 | 변경 | 전이 | 비고 |
+|------|------|------|------|
+| `cancelByMismatch()` | `refund()` | PENDING → REFUNDED | 금액 불일치 시 PortOne 환불 후 호출 |
+| `cancel()` | `refund()` | PAID → REFUNDED | 사용자 취소 등 미래 사용 |
+| (없음) | `expire()` | PENDING → CANCELLED | 스케줄러 만료 전용 |
+
+`refund()`는 PENDING, PAID 두 상태를 모두 허용하도록 내부에서 분기한다.
+
+---
+
+## 문제 1: PENDING Payment 만료 처리 — 스케줄러 분리
+
+### 설계
+
+기존 단일 스케줄러를 두 개로 분리한다.
+
+#### Payment 취소 스케줄러 (신규: PaymentExpireService)
+
+- **조건**: PENDING payment가 존재하는 RESERVED order, `createdAt < threshold`
+- **락 순서**: Payment 먼저 → Order (`completePayment()`와 동일 → 데드락 없음)
+- **처리**: `payment.expire()` + `order.cancel("결제 시간 초과")`
+
+```java
+// 락 획득 후 double-check 필수
+Payment payment = paymentRepository.findByIdWithLock(paymentId);
+if (payment.getStatus() != PaymentStatus.PENDING) return;
+
+Order order = orderRepository.findByIdWithLock(payment.getOrder().getId());
+if (order.getStatus() != OrderStatus.RESERVED) return;
+if (!order.getCreatedAt().isBefore(threshold)) return;
+
+payment.expire();
+order.cancel("결제 시간 초과");
+```
+
+#### Order 취소 스케줄러 (기존: OrderExpireService)
+
+- **조건**: RESERVED order, `createdAt < threshold`, PENDING payment 없음 (NOT EXISTS)
+- **락 순서**: Order만 (Payment 없으므로 충돌 불가)
+- **처리**: `order.cancel("결제 시간 초과")`
+
+```sql
+SELECT o FROM orders o
+WHERE o.status = 'RESERVED'
+  AND o.created_at < :threshold
+  AND NOT EXISTS (
+    SELECT 1 FROM payments p
+    WHERE p.order_id = o.id AND p.status = 'PENDING'
+  )
+```
+
+### TTL 설정
+
+두 스케줄러 모두 동일한 임계값 사용: **PortOne TTL(15분)보다 긴 20분**
+
+| 설정 | 값 |
+|------|-----|
+| PortOne 결제 세션 만료 | 15분 |
+| Order / Payment 만료 임계값 | 20분 |
+
+Order TTL과 Payment TTL을 다르게 설정하면 Payment는 취소됐는데 Order가 RESERVED인 limbo 상태가 발생하므로 동일하게 유지한다.
+
+### 락 순서 정합성
+
+| 경로 | 락 순서 |
+|------|---------|
+| `completePayment()` | Payment → Order |
+| Payment 취소 스케줄러 | Payment → Order |
+| Order 취소 스케줄러 | Order만 |
+
+Payment 취소 스케줄러와 `completePayment()`의 락 순서가 동일하므로 데드락이 발생하지 않는다. 락 획득 이후 반드시 double-check를 수행하여 이미 처리된 케이스를 안전하게 skip한다.
+
+---
+
+## 문제 2: completePayment() race condition 보상 처리
+
+### 시나리오
+
+```
+T=19:59  사용자가 PortOne에 결제 정보 제출 → PortOne 처리 완료 (돈 빠져나감)
+T=20:00  스케줄러 실행 → Payment: CANCELLED, Order: CANCELLED
+T=20:05  PortOne webhook / client verify 도착
+          → completePayment(): Order가 이미 CANCELLED
+          → 돈은 빠져나갔지만 아무 처리도 안 된 상태
+```
+
+### 보상 트랜잭션
+
+`completePayment()`에서 Order 락 획득 후 CANCELLED 상태를 감지하면 즉시 PortOne 환불을 호출한다.
+
+```java
+Order order = orderRepository.findByIdWithLock(payment.getOrder().getId());
+
+if (order.getStatus() == OrderStatus.CANCELLED) {
+    portOneClient.cancelPayment(paymentId, "주문 만료로 인한 자동 환불");
+    payment.refund();  // PENDING → REFUNDED
+    throw new BusinessException(PaymentErrorCode.ORDER_EXPIRED_REFUNDED);
+    // noRollbackFor → REFUNDED 상태 커밋 보장
+}
+```
+
+기존 `noRollbackFor = {BusinessException.class, InfraException.class}` 설정이 그대로 적용되어 REFUNDED 상태가 커밋된다.
+
+### 두 보상 경로 비교
+
+| 경로 | 트리거 | Payment 전이 |
+|------|--------|-------------|
+| 금액 불일치 | `completePayment()` 내 금액 검증 실패 | PENDING → REFUNDED |
+| Race condition | Order CANCELLED 감지 | PENDING → REFUNDED |
+| 스케줄러 만료 | 스케줄러 정상 실행 | PENDING → CANCELLED |
+
+---
+
+## 에러 코드 추가
+
+| 코드 | 설명 |
+|------|------|
+| `ORDER_EXPIRED_REFUNDED` | 주문 만료로 인해 결제가 자동 환불됨 |
+
+---
+
+## 테스트 시나리오
+
+### Payment 취소 스케줄러
+- PENDING payment가 있는 만료 Order → Payment CANCELLED, Order CANCELLED, 재고 복구
+- completePayment()가 먼저 실행 후 스케줄러 실행 → double-check로 skip, 상태 유지
+- PENDING payment 없는 만료 Order → Order 취소 스케줄러가 처리, Payment 스케줄러는 무시
+
+### Order 취소 스케줄러
+- PENDING payment 없는 만료 Order → Order CANCELLED, 재고 복구
+- PENDING payment 있는 만료 Order → NOT EXISTS 조건으로 skip
+
+### completePayment() 보상
+- Order가 CANCELLED인 상태에서 PortOne PAID 응답 → PortOne 환불 호출, Payment REFUNDED
+- 정상 흐름 (Order RESERVED) → 기존과 동일하게 PAID 처리

--- a/src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java
@@ -48,6 +48,6 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     @Query("SELECT o FROM Order o JOIN FETCH o.user WHERE o.id = :id")
     Optional<Order> findByIdWithLock(@Param("id") Long id);
 
-    @Query("SELECT o.id FROM Order o WHERE o.status = :status AND o.createdAt < :threshold AND NOT EXISTS (SELECT 1 FROM Payment p WHERE p.order = o AND p.status = 'PENDING') ORDER BY o.id")
+    @Query("SELECT o.id FROM Order o WHERE o.status = :status AND o.createdAt < :threshold AND NOT EXISTS (SELECT 1 FROM Payment p WHERE p.order = o AND p.status = com.gongu.server.domain.payment.domain.PaymentStatus.PENDING) ORDER BY o.id")
     List<Long> findExpiredReservedOrderIds(@Param("status") OrderStatus status, @Param("threshold") LocalDateTime threshold, Pageable pageable);
 }

--- a/src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/gongu/server/domain/order/repository/OrderRepository.java
@@ -48,6 +48,6 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     @Query("SELECT o FROM Order o JOIN FETCH o.user WHERE o.id = :id")
     Optional<Order> findByIdWithLock(@Param("id") Long id);
 
-    @Query("SELECT o.id FROM Order o WHERE o.status = :status AND o.createdAt < :threshold ORDER BY o.id")
+    @Query("SELECT o.id FROM Order o WHERE o.status = :status AND o.createdAt < :threshold AND NOT EXISTS (SELECT 1 FROM Payment p WHERE p.order = o AND p.status = 'PENDING') ORDER BY o.id")
     List<Long> findExpiredReservedOrderIds(@Param("status") OrderStatus status, @Param("threshold") LocalDateTime threshold, Pageable pageable);
 }

--- a/src/main/java/com/gongu/server/domain/order/scheduler/PaymentExpiryScheduler.java
+++ b/src/main/java/com/gongu/server/domain/order/scheduler/PaymentExpiryScheduler.java
@@ -1,0 +1,45 @@
+package com.gongu.server.domain.order.scheduler;
+
+import com.gongu.server.domain.order.entity.OrderStatus;
+import com.gongu.server.domain.payment.domain.PaymentStatus;
+import com.gongu.server.domain.payment.repository.PaymentRepository;
+import com.gongu.server.domain.payment.service.PaymentExpireService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentExpiryScheduler {
+
+    private final PaymentExpireService paymentExpireService;
+    private final PaymentRepository paymentRepository;
+
+    @Value("${order.reservation-ttl-minutes}")
+    private long reservationTtlMinutes;
+
+    @Scheduled(fixedDelay = 60_000)
+    public void expireReservedPayments() {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(reservationTtlMinutes);
+        List<Long> expiredIds = paymentRepository.findExpiredPendingPaymentIds(
+                PaymentStatus.PENDING, OrderStatus.RESERVED, threshold, PageRequest.of(0, 100));
+
+        int count = 0;
+        for (Long id : expiredIds) {
+            try {
+                paymentExpireService.cancelExpiredPayment(id, threshold);
+                count++;
+            } catch (Exception e) {
+                log.warn("만료 Payment 취소 실패: paymentId={}", id, e);
+            }
+        }
+        log.info("만료 Payment 처리 완료: {}건", count);
+    }
+}

--- a/src/main/java/com/gongu/server/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/gongu/server/domain/payment/controller/PaymentController.java
@@ -53,7 +53,8 @@ public class PaymentController {
             try {
                 paymentService.completePayment(payload.data().paymentId());
             } catch (BusinessException e) {
-                if (e.getErrorCode() == PaymentErrorCode.ORDER_EXPIRED_REFUNDED) {
+                if (e.getErrorCode() == PaymentErrorCode.ORDER_EXPIRED_REFUNDED
+                        || e.getErrorCode() == PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION) {
                     // 이미 환불 처리 완료 — PortOne에 200 반환하여 webhook 재시도 방지
                     return ResponseEntity.ok().build();
                 }

--- a/src/main/java/com/gongu/server/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/gongu/server/domain/payment/controller/PaymentController.java
@@ -8,6 +8,8 @@ import com.gongu.server.domain.payment.dto.response.PreparePaymentResponse;
 import com.gongu.server.domain.payment.dto.response.VerifyPaymentResponse;
 import com.gongu.server.domain.payment.service.PaymentService;
 import com.gongu.server.global.common.ApiResponse;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.PaymentErrorCode;
 import com.gongu.server.global.security.UserPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -48,7 +50,15 @@ public class PaymentController {
     @PostMapping("/webhook")
     public ResponseEntity<Void> receiveWebhook(@Valid @RequestBody PortOneWebhookPayload payload) {
         if ("Transaction.Paid".equals(payload.type())) {
-            paymentService.completePayment(payload.data().paymentId());
+            try {
+                paymentService.completePayment(payload.data().paymentId());
+            } catch (BusinessException e) {
+                if (e.getErrorCode() == PaymentErrorCode.ORDER_EXPIRED_REFUNDED) {
+                    // 이미 환불 처리 완료 — PortOne에 200 반환하여 webhook 재시도 방지
+                    return ResponseEntity.ok().build();
+                }
+                throw e;
+            }
         }
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/gongu/server/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/gongu/server/domain/payment/controller/PaymentController.java
@@ -53,8 +53,7 @@ public class PaymentController {
             try {
                 paymentService.completePayment(payload.data().paymentId());
             } catch (BusinessException e) {
-                if (e.getErrorCode() == PaymentErrorCode.ORDER_EXPIRED_REFUNDED
-                        || e.getErrorCode() == PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION) {
+                if (e.getErrorCode() == PaymentErrorCode.ORDER_EXPIRED_REFUNDED) {
                     // 이미 환불 처리 완료 — PortOne에 200 반환하여 webhook 재시도 방지
                     return ResponseEntity.ok().build();
                 }

--- a/src/main/java/com/gongu/server/domain/payment/domain/Payment.java
+++ b/src/main/java/com/gongu/server/domain/payment/domain/Payment.java
@@ -86,16 +86,16 @@ public class Payment extends BaseEntity {
         this.paidAt = paidAt;
     }
 
-    public void cancelByMismatch() {
-        if (this.status != PaymentStatus.PENDING) {
+    public void refund() {
+        if (this.status != PaymentStatus.PENDING && this.status != PaymentStatus.PAID) {
             throw new BusinessException(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION);
         }
-        this.status = PaymentStatus.CANCELLED;
+        this.status = PaymentStatus.REFUNDED;
         this.cancelledAt = LocalDateTime.now();
     }
 
-    public void cancel() {
-        if (this.status != PaymentStatus.PAID) {
+    public void expire() {
+        if (this.status != PaymentStatus.PENDING) {
             throw new BusinessException(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION);
         }
         this.status = PaymentStatus.CANCELLED;

--- a/src/main/java/com/gongu/server/domain/payment/domain/Payment.java
+++ b/src/main/java/com/gongu/server/domain/payment/domain/Payment.java
@@ -87,7 +87,8 @@ public class Payment extends BaseEntity {
     }
 
     public void refund() {
-        if (this.status != PaymentStatus.PENDING && this.status != PaymentStatus.PAID) {
+        if (this.status != PaymentStatus.PENDING && this.status != PaymentStatus.PAID
+                && this.status != PaymentStatus.CANCELLED) {
             throw new BusinessException(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION);
         }
         this.status = PaymentStatus.REFUNDED;

--- a/src/main/java/com/gongu/server/domain/payment/domain/PaymentStatus.java
+++ b/src/main/java/com/gongu/server/domain/payment/domain/PaymentStatus.java
@@ -1,5 +1,5 @@
 package com.gongu.server.domain.payment.domain;
 
 public enum PaymentStatus {
-    PENDING, PAID, CANCELLED, FAILED
+    PENDING, PAID, CANCELLED, FAILED, REFUNDED
 }

--- a/src/main/java/com/gongu/server/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/gongu/server/domain/payment/repository/PaymentRepository.java
@@ -1,12 +1,17 @@
 package com.gongu.server.domain.payment.repository;
 
+import com.gongu.server.domain.order.entity.OrderStatus;
 import com.gongu.server.domain.payment.domain.Payment;
+import com.gongu.server.domain.payment.domain.PaymentStatus;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
@@ -17,4 +22,11 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM Payment p WHERE p.merchantUid = :merchantUid")
     Optional<Payment> findByMerchantUidWithLock(@Param("merchantUid") String merchantUid);
+
+    @Query("SELECT p.id FROM Payment p WHERE p.status = :status AND p.order.status = :orderStatus AND p.order.createdAt < :threshold ORDER BY p.id")
+    List<Long> findExpiredPendingPaymentIds(@Param("status") PaymentStatus status, @Param("orderStatus") OrderStatus orderStatus, @Param("threshold") LocalDateTime threshold, Pageable pageable);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Payment p JOIN FETCH p.order WHERE p.id = :id")
+    Optional<Payment> findByIdWithLock(@Param("id") Long id);
 }

--- a/src/main/java/com/gongu/server/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/gongu/server/domain/payment/repository/PaymentRepository.java
@@ -29,4 +29,6 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM Payment p JOIN FETCH p.order WHERE p.id = :id")
     Optional<Payment> findByIdWithLock(@Param("id") Long id);
+
+    boolean existsByOrderIdAndStatusIn(Long orderId, List<PaymentStatus> statuses);
 }

--- a/src/main/java/com/gongu/server/domain/payment/scheduler/PaymentExpiryScheduler.java
+++ b/src/main/java/com/gongu/server/domain/payment/scheduler/PaymentExpiryScheduler.java
@@ -1,4 +1,4 @@
-package com.gongu.server.domain.order.scheduler;
+package com.gongu.server.domain.payment.scheduler;
 
 import com.gongu.server.domain.order.entity.OrderStatus;
 import com.gongu.server.domain.payment.domain.PaymentStatus;

--- a/src/main/java/com/gongu/server/domain/payment/scheduler/PaymentExpiryScheduler.java
+++ b/src/main/java/com/gongu/server/domain/payment/scheduler/PaymentExpiryScheduler.java
@@ -25,11 +25,14 @@ public class PaymentExpiryScheduler {
     @Value("${order.reservation-ttl-minutes}")
     private long reservationTtlMinutes;
 
-    @Scheduled(fixedDelay = 60_000)
+    @Value("${payment.expiry.batch-size:100}")
+    private int paymentExpiryBatchSize;
+
+    @Scheduled(fixedDelayString = "${payment.expiry.fixed-delay-ms:60000}")
     public void expireReservedPayments() {
         LocalDateTime threshold = LocalDateTime.now().minusMinutes(reservationTtlMinutes);
         List<Long> expiredIds = paymentRepository.findExpiredPendingPaymentIds(
-                PaymentStatus.PENDING, OrderStatus.RESERVED, threshold, PageRequest.of(0, 100));
+                PaymentStatus.PENDING, OrderStatus.RESERVED, threshold, PageRequest.of(0, paymentExpiryBatchSize));
 
         int count = 0;
         for (Long id : expiredIds) {

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentExpireService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentExpireService.java
@@ -1,0 +1,74 @@
+package com.gongu.server.domain.payment.service;
+
+import com.gongu.server.domain.order.entity.Order;
+import com.gongu.server.domain.order.entity.OrderItem;
+import com.gongu.server.domain.order.entity.OrderStatus;
+import com.gongu.server.domain.order.repository.OrderItemRepository;
+import com.gongu.server.domain.order.repository.OrderRepository;
+import com.gongu.server.domain.payment.domain.Payment;
+import com.gongu.server.domain.payment.domain.PaymentStatus;
+import com.gongu.server.domain.payment.repository.PaymentRepository;
+import com.gongu.server.domain.product.entity.Product;
+import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.ProductErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentExpireService {
+
+    private final PaymentRepository paymentRepository;
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final ProductRepository productRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void cancelExpiredPayment(Long paymentId, LocalDateTime threshold) {
+        Optional<Payment> optionalPayment = paymentRepository.findByIdWithLock(paymentId);
+        if (optionalPayment.isEmpty()) {
+            return;
+        }
+
+        Payment payment = optionalPayment.get();
+
+        if (payment.getStatus() != PaymentStatus.PENDING) {
+            return;
+        }
+
+        Optional<Order> optionalOrder = orderRepository.findByIdWithLock(payment.getOrder().getId());
+        if (optionalOrder.isEmpty()) {
+            return;
+        }
+
+        Order order = optionalOrder.get();
+
+        if (order.getStatus() != OrderStatus.RESERVED) {
+            return;
+        }
+
+        if (!order.getCreatedAt().isBefore(threshold)) {
+            return;
+        }
+
+        List<OrderItem> items = orderItemRepository.findAllByOrder(order);
+        items.stream()
+                .sorted(Comparator.comparingLong(item -> item.getProduct().getId()))
+                .forEach(item -> {
+                    Product product = productRepository.findByIdWithLock(item.getProduct().getId())
+                            .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+                    product.restoreStock(Math.toIntExact(item.getQuantity()));
+                });
+
+        payment.expire();
+        order.cancel("결제 시간 초과");
+    }
+}

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
@@ -78,6 +78,13 @@ public class PaymentService {
         Order order = orderRepository.findByIdWithLock(payment.getOrder().getId())
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
+        if (order.getStatus() == OrderStatus.CANCELLED) {
+            portOneClient.cancelPayment(paymentId, "주문 만료로 인한 자동 환불");
+            payment.refund();
+            throw new BusinessException(PaymentErrorCode.ORDER_EXPIRED_REFUNDED);
+            // noRollbackFor 설정으로 REFUNDED 상태가 커밋됨
+        }
+
         PortOnePaymentResponse portOneResponse;
         try {
             portOneResponse = portOneClient.getPayment(paymentId);

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
@@ -89,8 +89,10 @@ public class PaymentService {
                     && payment.getStatus() != PaymentStatus.CANCELLED) {
                 throw new BusinessException(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION);
             }
-            executePGCancel(paymentId, "주문 만료로 인한 자동 환불");
-            payment.refund();
+            boolean pgCancelled = executePGCancel(paymentId, "주문 만료로 인한 자동 환불");
+            if (pgCancelled) {
+                payment.refund();
+            }
             throw new BusinessException(PaymentErrorCode.ORDER_EXPIRED_REFUNDED);
         }
 
@@ -133,17 +135,21 @@ public class PaymentService {
 
     /**
      * PortOne 결제 취소 실행.
-     * - PAYMENT_ALREADY_PROCESSED: 멱등 성공으로 처리
-     * - PAYMENT_NOT_FOUND: 계속 진행 (PG에 결제 없음 = 취소 불필요)
-     * - 기타 BusinessException: 상위로 전파
+     *
+     * @return true: 실제 PG 취소 발생 (또는 PAYMENT_ALREADY_PROCESSED)
+     *         false: PAYMENT_NOT_FOUND (PG에 결제 없음 - 환불 불필요)
      */
-    private void executePGCancel(String paymentId, String reason) {
+    private boolean executePGCancel(String paymentId, String reason) {
         try {
             portOneClient.cancelPayment(paymentId, reason);
+            return true;
         } catch (BusinessException e) {
-            if (e.getErrorCode() == PaymentErrorCode.PAYMENT_ALREADY_PROCESSED
-                    || e.getErrorCode() == PaymentErrorCode.PAYMENT_NOT_FOUND) {
+            if (e.getErrorCode() == PaymentErrorCode.PAYMENT_ALREADY_PROCESSED) {
                 log.info("PortOne cancel idempotent: paymentId={}, reason={}", paymentId, e.getErrorCode().getCode());
+                return true;
+            } else if (e.getErrorCode() == PaymentErrorCode.PAYMENT_NOT_FOUND) {
+                log.info("PortOne cancel skipped - payment not found in PG: paymentId={}", paymentId);
+                return false;
             } else {
                 throw e;
             }

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
@@ -85,6 +85,10 @@ public class PaymentService {
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
         if (order.getStatus() == OrderStatus.CANCELLED) {
+            if (payment.getStatus() == PaymentStatus.REFUNDED) {
+                // 이미 환불 완료 — 멱등 처리
+                throw new BusinessException(PaymentErrorCode.ORDER_EXPIRED_REFUNDED);
+            }
             if (payment.getStatus() != PaymentStatus.PENDING
                     && payment.getStatus() != PaymentStatus.CANCELLED) {
                 throw new BusinessException(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION);

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
@@ -43,17 +43,17 @@ public class PaymentService {
         Order order = orderRepository.findByIdWithLock(orderId)
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
-        boolean hasActivePayment = paymentRepository.existsByOrderIdAndStatusIn(
-                orderId, List.of(PaymentStatus.PENDING, PaymentStatus.PAID));
-        if (hasActivePayment) {
-            throw new BusinessException(PaymentErrorCode.PAYMENT_ACTIVE_EXISTS);
-        }
-
         if (!order.isOwnedBy(userId)) {
             throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_ALLOWED);
         }
         if (order.getStatus() != OrderStatus.RESERVED) {
             throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_ALLOWED);
+        }
+
+        boolean hasActivePayment = paymentRepository.existsByOrderIdAndStatusIn(
+                orderId, List.of(PaymentStatus.PENDING, PaymentStatus.PAID));
+        if (hasActivePayment) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_ACTIVE_EXISTS);
         }
 
         String paymentId = UUID.randomUUID().toString();
@@ -80,17 +80,22 @@ public class PaymentService {
         if (payment.getStatus() == PaymentStatus.PAID) {
             return VerifyPaymentResponse.of(payment.getOrder(), payment);
         }
-        if (payment.getStatus() != PaymentStatus.PENDING) {
-            throw new BusinessException(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION);
-        }
 
         Order order = orderRepository.findByIdWithLock(payment.getOrder().getId())
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
         if (order.getStatus() == OrderStatus.CANCELLED) {
+            if (payment.getStatus() != PaymentStatus.PENDING
+                    && payment.getStatus() != PaymentStatus.CANCELLED) {
+                throw new BusinessException(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION);
+            }
             executePGCancel(paymentId, "주문 만료로 인한 자동 환불");
             payment.refund();
             throw new BusinessException(PaymentErrorCode.ORDER_EXPIRED_REFUNDED);
+        }
+
+        if (payment.getStatus() != PaymentStatus.PENDING) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION);
         }
 
         PortOnePaymentResponse portOneResponse;

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
@@ -17,11 +17,14 @@ import com.gongu.server.global.exception.errorcode.UserErrorCode;
 import com.gongu.server.global.infrastructure.portone.PortOneClient;
 import com.gongu.server.global.infrastructure.portone.dto.PortOnePaymentResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -36,6 +39,12 @@ public class PaymentService {
     public PaymentPrepareResult preparePayment(Long userId, Long orderId) {
         userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        boolean hasActivePayment = paymentRepository.existsByOrderIdAndStatusIn(
+                orderId, List.of(PaymentStatus.PENDING, PaymentStatus.PAID));
+        if (hasActivePayment) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_ACTIVE_EXISTS);
+        }
 
         Order order = orderRepository.findByIdWithLock(orderId)
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
@@ -79,13 +88,7 @@ public class PaymentService {
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
         if (order.getStatus() == OrderStatus.CANCELLED) {
-            try {
-                portOneClient.cancelPayment(paymentId, "주문 만료로 인한 자동 환불");
-            } catch (InfraException e) {
-                // PortOne 취소 실패 — 환불 미완료이므로 REFUNDED로 커밋하지 않고 재시도 가능 상태 유지
-                payment.fail();
-                throw e;
-            }
+            executePGCancel(paymentId, "주문 만료로 인한 자동 환불");
             payment.refund();
             throw new BusinessException(PaymentErrorCode.ORDER_EXPIRED_REFUNDED);
         }
@@ -116,10 +119,33 @@ public class PaymentService {
             payment.confirm(actualAmount, portOneResponse.paidAt().toLocalDateTime());
             return VerifyPaymentResponse.of(order, payment);
         } else {
-            portOneClient.cancelPayment(paymentId, "결제 금액 불일치");
+            executePGCancel(paymentId, "결제 금액 불일치");
             payment.refund();
             order.cancel("결제 금액 불일치");
             throw new BusinessException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
+    }
+
+    /**
+     * PortOne 결제 취소 실행.
+     * - null 반환 (circuit open): 경고 로그 후 계속 진행
+     * - PAYMENT_ALREADY_PROCESSED: 멱등 성공으로 처리
+     * - PAYMENT_NOT_FOUND: 계속 진행 (PG에 결제 없음 = 취소 불필요)
+     * - 기타 BusinessException: 상위로 전파
+     */
+    private void executePGCancel(String paymentId, String reason) {
+        try {
+            PortOnePaymentResponse response = portOneClient.cancelPayment(paymentId, reason);
+            if (response == null) {
+                log.warn("PortOne cancelPayment returned null (circuit open): paymentId={}", paymentId);
+            }
+        } catch (BusinessException e) {
+            if (e.getErrorCode() == PaymentErrorCode.PAYMENT_ALREADY_PROCESSED
+                    || e.getErrorCode() == PaymentErrorCode.PAYMENT_NOT_FOUND) {
+                log.info("PortOne cancel idempotent: paymentId={}, reason={}", paymentId, e.getErrorCode().getCode());
+            } else {
+                throw e;
+            }
         }
     }
 }

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
@@ -40,14 +40,14 @@ public class PaymentService {
         userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
+        Order order = orderRepository.findByIdWithLock(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
         boolean hasActivePayment = paymentRepository.existsByOrderIdAndStatusIn(
                 orderId, List.of(PaymentStatus.PENDING, PaymentStatus.PAID));
         if (hasActivePayment) {
             throw new BusinessException(PaymentErrorCode.PAYMENT_ACTIVE_EXISTS);
         }
-
-        Order order = orderRepository.findByIdWithLock(orderId)
-                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
         if (!order.isOwnedBy(userId)) {
             throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_ALLOWED);
@@ -128,17 +128,13 @@ public class PaymentService {
 
     /**
      * PortOne 결제 취소 실행.
-     * - null 반환 (circuit open): 경고 로그 후 계속 진행
      * - PAYMENT_ALREADY_PROCESSED: 멱등 성공으로 처리
      * - PAYMENT_NOT_FOUND: 계속 진행 (PG에 결제 없음 = 취소 불필요)
      * - 기타 BusinessException: 상위로 전파
      */
     private void executePGCancel(String paymentId, String reason) {
         try {
-            PortOnePaymentResponse response = portOneClient.cancelPayment(paymentId, reason);
-            if (response == null) {
-                log.warn("PortOne cancelPayment returned null (circuit open): paymentId={}", paymentId);
-            }
+            portOneClient.cancelPayment(paymentId, reason);
         } catch (BusinessException e) {
             if (e.getErrorCode() == PaymentErrorCode.PAYMENT_ALREADY_PROCESSED
                     || e.getErrorCode() == PaymentErrorCode.PAYMENT_NOT_FOUND) {

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
@@ -104,7 +104,7 @@ public class PaymentService {
             payment.confirm(actualAmount, portOneResponse.paidAt().toLocalDateTime());
             return VerifyPaymentResponse.of(order, payment);
         } else {
-            payment.cancelByMismatch();
+            payment.refund();
             order.cancel("결제 금액 불일치");
             portOneClient.cancelPayment(paymentId, "결제 금액 불일치");
             throw new BusinessException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
@@ -79,10 +79,15 @@ public class PaymentService {
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
         if (order.getStatus() == OrderStatus.CANCELLED) {
-            portOneClient.cancelPayment(paymentId, "주문 만료로 인한 자동 환불");
+            try {
+                portOneClient.cancelPayment(paymentId, "주문 만료로 인한 자동 환불");
+            } catch (InfraException e) {
+                // PortOne 취소 실패 — 환불 미완료이므로 REFUNDED로 커밋하지 않고 재시도 가능 상태 유지
+                payment.fail();
+                throw e;
+            }
             payment.refund();
             throw new BusinessException(PaymentErrorCode.ORDER_EXPIRED_REFUNDED);
-            // noRollbackFor 설정으로 REFUNDED 상태가 커밋됨
         }
 
         PortOnePaymentResponse portOneResponse;
@@ -111,11 +116,10 @@ public class PaymentService {
             payment.confirm(actualAmount, portOneResponse.paidAt().toLocalDateTime());
             return VerifyPaymentResponse.of(order, payment);
         } else {
+            portOneClient.cancelPayment(paymentId, "결제 금액 불일치");
             payment.refund();
             order.cancel("결제 금액 불일치");
-            portOneClient.cancelPayment(paymentId, "결제 금액 불일치");
             throw new BusinessException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
-            // noRollbackFor → transaction commits with cancelled state persisted
         }
     }
 }

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
@@ -96,6 +96,8 @@ public class PaymentService {
             boolean pgCancelled = executePGCancel(paymentId, "주문 만료로 인한 자동 환불");
             if (pgCancelled) {
                 payment.refund();
+            } else if (payment.getStatus() == PaymentStatus.PENDING) {
+                payment.expire();
             }
             throw new BusinessException(PaymentErrorCode.ORDER_EXPIRED_REFUNDED);
         }

--- a/src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java
@@ -12,7 +12,8 @@ public enum PaymentErrorCode implements ErrorCode {
     PAYMENT_NOT_ALLOWED("PAYMENT_004", "결제할 수 없는 주문 상태입니다", 409),
     PAYMENT_PG_UNAVAILABLE("PAYMENT_005", "결제 서비스를 일시적으로 사용할 수 없습니다", 503),
     PAYMENT_INVALID_STATE_TRANSITION("PAYMENT_006", "유효하지 않은 결제 상태 전이입니다", 409),
-    PAYMENT_NOT_COMPLETED("PAYMENT_007", "결제가 완료되지 않은 상태입니다", 422);
+    PAYMENT_NOT_COMPLETED("PAYMENT_007", "결제가 완료되지 않은 상태입니다", 422),
+    ORDER_EXPIRED_REFUNDED("PAYMENT_008", "주문 만료로 결제가 자동 환불되었습니다", 409);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java
+++ b/src/main/java/com/gongu/server/global/exception/errorcode/PaymentErrorCode.java
@@ -13,7 +13,8 @@ public enum PaymentErrorCode implements ErrorCode {
     PAYMENT_PG_UNAVAILABLE("PAYMENT_005", "결제 서비스를 일시적으로 사용할 수 없습니다", 503),
     PAYMENT_INVALID_STATE_TRANSITION("PAYMENT_006", "유효하지 않은 결제 상태 전이입니다", 409),
     PAYMENT_NOT_COMPLETED("PAYMENT_007", "결제가 완료되지 않은 상태입니다", 422),
-    ORDER_EXPIRED_REFUNDED("PAYMENT_008", "주문 만료로 결제가 자동 환불되었습니다", 409);
+    ORDER_EXPIRED_REFUNDED("PAYMENT_008", "주문 만료로 결제가 자동 환불되었습니다", 409),
+    PAYMENT_ACTIVE_EXISTS("PAYMENT_009", "이미 활성 결제가 존재합니다", 409);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/gongu/server/global/infrastructure/portone/PortOneClient.java
+++ b/src/main/java/com/gongu/server/global/infrastructure/portone/PortOneClient.java
@@ -68,7 +68,6 @@ public class PortOneClient {
 
     private PortOnePaymentResponse cancelPaymentFallback(String paymentId, String reason, Exception e) {
         log.warn("PortOne cancelPayment circuit open or retry exhausted: paymentId={}", paymentId, e);
-        // 보상 취소 실패는 상위로 전파하지 않음 — DB는 이미 CANCELLED 상태
-        return null;
+        throw new InfraException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE);
     }
 }

--- a/src/test/java/com/gongu/server/domain/payment/domain/PaymentTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/domain/PaymentTest.java
@@ -216,7 +216,8 @@ class PaymentTest {
     @Test
     @DisplayName("fail() — CANCELLED 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
     void fail_CANCELLED상태_예외() {
-        Payment payment = refundedPayment();
+        Payment payment = pendingPayment();
+        payment.expire();
 
         assertThatThrownBy(payment::fail)
                 .isInstanceOf(BusinessException.class)

--- a/src/test/java/com/gongu/server/domain/payment/domain/PaymentTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/domain/PaymentTest.java
@@ -38,9 +38,9 @@ class PaymentTest {
         return p;
     }
 
-    private Payment cancelledPayment() {
+    private Payment refundedPayment() {
         Payment p = pendingPayment();
-        p.cancelByMismatch();
+        p.refund();
         return p;
     }
 
@@ -106,15 +106,15 @@ class PaymentTest {
     }
 
     @Test
-    @DisplayName("confirm() — CANCELLED 상태에서 호출 → PAYMENT_ALREADY_PROCESSED, 상태 불변")
-    void confirm_CANCELLED상태_예외() {
-        Payment payment = cancelledPayment();
+    @DisplayName("confirm() — REFUNDED 상태에서 호출 → PAYMENT_ALREADY_PROCESSED, 상태 불변")
+    void confirm_REFUNDED상태_예외() {
+        Payment payment = refundedPayment();
 
         assertThatThrownBy(() -> payment.confirm(AMOUNT, LocalDateTime.now()))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED));
-        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
     }
 
     @Test
@@ -130,93 +130,61 @@ class PaymentTest {
         assertThat(payment.getPaidAt()).isNull();
     }
 
-    // ── cancelByMismatch() ────────────────────────────────────────────
+    // ── refund() (PENDING) ────────────────────────────────────────────
 
     @Test
-    @DisplayName("cancelByMismatch() — PENDING → CANCELLED, cancelledAt 설정")
-    void cancelByMismatch_성공() {
+    @DisplayName("refund() — PENDING → REFUNDED, cancelledAt 설정")
+    void refund_PENDING_성공() {
         Payment payment = pendingPayment();
 
-        payment.cancelByMismatch();
+        payment.refund();
 
-        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
         assertThat(payment.getCancelledAt()).isNotNull();
     }
 
     @Test
-    @DisplayName("cancelByMismatch() — PAID 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
-    void cancelByMismatch_PAID상태_예외() {
-        Payment payment = paidPayment();
-
-        assertThatThrownBy(payment::cancelByMismatch)
-                .isInstanceOf(BusinessException.class)
-                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
-                        .isEqualTo(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION));
-    }
-
-    @Test
-    @DisplayName("cancelByMismatch() — FAILED 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
-    void cancelByMismatch_FAILED상태_예외() {
+    @DisplayName("refund() — FAILED 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
+    void refund_FAILED상태_예외() {
         Payment payment = failedPayment();
 
-        assertThatThrownBy(payment::cancelByMismatch)
+        assertThatThrownBy(payment::refund)
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION));
     }
 
     @Test
-    @DisplayName("cancelByMismatch() — CANCELLED 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
-    void cancelByMismatch_CANCELLED상태_예외() {
-        Payment payment = cancelledPayment();
+    @DisplayName("refund() — REFUNDED 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
+    void refund_REFUNDED상태_예외() {
+        Payment payment = refundedPayment();
 
-        assertThatThrownBy(payment::cancelByMismatch)
+        assertThatThrownBy(payment::refund)
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION));
     }
 
-    // ── cancel() ──────────────────────────────────────────────────────
+    // ── refund() (PAID) ───────────────────────────────────────────────
 
     @Test
-    @DisplayName("cancel() — PAID → CANCELLED, cancelledAt 설정")
-    void cancel_성공() {
+    @DisplayName("refund() — PAID → REFUNDED, cancelledAt 설정")
+    void refund_PAID_성공() {
         Payment payment = paidPayment();
 
-        payment.cancel();
+        payment.refund();
 
-        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
         assertThat(payment.getCancelledAt()).isNotNull();
     }
 
     @Test
-    @DisplayName("cancel() — PENDING 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
-    void cancel_PENDING상태_예외() {
+    @DisplayName("refund() — CANCELLED 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
+    void refund_CANCELLED상태_예외() {
         Payment payment = pendingPayment();
+        payment.expire();
 
-        assertThatThrownBy(payment::cancel)
-                .isInstanceOf(BusinessException.class)
-                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
-                        .isEqualTo(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION));
-    }
-
-    @Test
-    @DisplayName("cancel() — FAILED 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
-    void cancel_FAILED상태_예외() {
-        Payment payment = failedPayment();
-
-        assertThatThrownBy(payment::cancel)
-                .isInstanceOf(BusinessException.class)
-                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
-                        .isEqualTo(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION));
-    }
-
-    @Test
-    @DisplayName("cancel() — CANCELLED 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
-    void cancel_CANCELLED상태_예외() {
-        Payment payment = cancelledPayment();
-
-        assertThatThrownBy(payment::cancel)
+        assertThatThrownBy(payment::refund)
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION));
@@ -248,7 +216,7 @@ class PaymentTest {
     @Test
     @DisplayName("fail() — CANCELLED 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
     void fail_CANCELLED상태_예외() {
-        Payment payment = cancelledPayment();
+        Payment payment = refundedPayment();
 
         assertThatThrownBy(payment::fail)
                 .isInstanceOf(BusinessException.class)

--- a/src/test/java/com/gongu/server/domain/payment/domain/PaymentTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/domain/PaymentTest.java
@@ -179,15 +179,14 @@ class PaymentTest {
     }
 
     @Test
-    @DisplayName("refund() — CANCELLED 상태에서 호출 → PAYMENT_INVALID_STATE_TRANSITION")
-    void refund_CANCELLED상태_예외() {
+    @DisplayName("refund() — CANCELLED 상태에서 호출 → REFUNDED 전이 성공")
+    void refund_CANCELLED상태_성공() {
         Payment payment = pendingPayment();
         payment.expire();
 
-        assertThatThrownBy(payment::refund)
-                .isInstanceOf(BusinessException.class)
-                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
-                        .isEqualTo(PaymentErrorCode.PAYMENT_INVALID_STATE_TRANSITION));
+        payment.refund();
+
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
     }
 
     // ── fail() ────────────────────────────────────────────────────────

--- a/src/test/java/com/gongu/server/domain/payment/service/PaymentExpireServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/service/PaymentExpireServiceTest.java
@@ -1,0 +1,206 @@
+package com.gongu.server.domain.payment.service;
+
+import com.gongu.server.domain.order.entity.Order;
+import com.gongu.server.domain.order.entity.OrderItem;
+import com.gongu.server.domain.order.entity.OrderStatus;
+import com.gongu.server.domain.order.repository.OrderItemRepository;
+import com.gongu.server.domain.order.repository.OrderRepository;
+import com.gongu.server.domain.payment.domain.Payment;
+import com.gongu.server.domain.payment.domain.PaymentStatus;
+import com.gongu.server.domain.payment.repository.PaymentRepository;
+import com.gongu.server.domain.product.entity.Product;
+import com.gongu.server.domain.product.entity.ProductStatus;
+import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentExpireServiceTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private OrderItemRepository orderItemRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private PaymentExpireService paymentExpireService;
+
+    @Test
+    @DisplayName("만료된_PENDING_Payment_취소_및_Order_취소_재고_복구")
+    void cancelExpiredPayment_만료된_PENDING_Payment_취소_및_Order_취소_재고_복구() {
+        // given
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(10);
+        User user = user(1L);
+        Store store = store(1L);
+        // totalStock=12, remainingStock을 10으로 설정 (2개 주문 차감된 상태)
+        Product product = product(1L, store, 12);
+        ReflectionTestUtils.setField(product, "remainingStock", 10);
+        Order order = order(1L, user, 10_000L);
+        ReflectionTestUtils.setField(order, "createdAt", threshold.minusMinutes(5));
+        OrderItem item = orderItem(order, product, 2L);
+        Payment payment = payment(order);
+
+        given(paymentRepository.findByIdWithLock(1L)).willReturn(Optional.of(payment));
+        given(orderRepository.findByIdWithLock(1L)).willReturn(Optional.of(order));
+        given(orderItemRepository.findAllByOrder(order)).willReturn(List.of(item));
+        given(productRepository.findByIdWithLock(1L)).willReturn(Optional.of(product));
+
+        // when
+        paymentExpireService.cancelExpiredPayment(1L, threshold);
+
+        // then
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+        assertThat(product.getRemainingStock()).isEqualTo(12);
+    }
+
+    @Test
+    @DisplayName("이미_PAID된_Payment_skip")
+    void cancelExpiredPayment_이미_PAID된_Payment_skip() {
+        // given
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(10);
+        User user = user(1L);
+        Order order = order(1L, user, 10_000L);
+        Payment payment = payment(order);
+        ReflectionTestUtils.setField(payment, "status", PaymentStatus.PAID);
+
+        given(paymentRepository.findByIdWithLock(1L)).willReturn(Optional.of(payment));
+
+        // when
+        paymentExpireService.cancelExpiredPayment(1L, threshold);
+
+        // then
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID);
+        verify(orderRepository, never()).findByIdWithLock(order.getId());
+    }
+
+    @Test
+    @DisplayName("Order가_이미_PAID_상태_skip")
+    void cancelExpiredPayment_Order가_이미_PAID_상태_skip() {
+        // given
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(10);
+        User user = user(1L);
+        Order order = order(1L, user, 10_000L);
+        ReflectionTestUtils.setField(order, "status", OrderStatus.PAID);
+        ReflectionTestUtils.setField(order, "createdAt", threshold.minusMinutes(5));
+        Payment payment = payment(order);
+
+        given(paymentRepository.findByIdWithLock(1L)).willReturn(Optional.of(payment));
+        given(orderRepository.findByIdWithLock(1L)).willReturn(Optional.of(order));
+
+        // when
+        paymentExpireService.cancelExpiredPayment(1L, threshold);
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID);
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PENDING);
+        verify(orderItemRepository, never()).findAllByOrder(order);
+    }
+
+    @Test
+    @DisplayName("아직_유효한_Payment_skip")
+    void cancelExpiredPayment_아직_유효한_Payment_skip() {
+        // given
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(10);
+        User user = user(1L);
+        Order order = order(1L, user, 10_000L);
+        ReflectionTestUtils.setField(order, "createdAt", threshold.plusMinutes(5));
+        Payment payment = payment(order);
+
+        given(paymentRepository.findByIdWithLock(1L)).willReturn(Optional.of(payment));
+        given(orderRepository.findByIdWithLock(1L)).willReturn(Optional.of(order));
+
+        // when
+        paymentExpireService.cancelExpiredPayment(1L, threshold);
+
+        // then
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PENDING);
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.RESERVED);
+        verify(orderItemRepository, never()).findAllByOrder(order);
+    }
+
+    @Test
+    @DisplayName("존재하지_않는_Payment_예외_없음")
+    void cancelExpiredPayment_존재하지_않는_Payment_예외_없음() {
+        // given
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(10);
+        given(paymentRepository.findByIdWithLock(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatCode(() -> paymentExpireService.cancelExpiredPayment(999L, threshold))
+                .doesNotThrowAnyException();
+        verifyNoInteractions(orderRepository);
+        verifyNoInteractions(orderItemRepository);
+    }
+
+    // --- fixture helpers ---
+
+    private User user(Long id) {
+        User user = User.of("홍길동" + id, "010-1234-567" + id);
+        setId(user, id);
+        return user;
+    }
+
+    private Store store(Long id) {
+        Store store = Store.create("매장" + id, "서울시 강남구", "02-1234-5678");
+        setId(store, id);
+        return store;
+    }
+
+    private Product product(Long id, Store store, int totalStock) {
+        Product product = Product.create(
+                store, "상품" + id, "상품 설명", 10_000L, totalStock,
+                ProductStatus.ACTIVE,
+                LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1)
+        );
+        setId(product, id);
+        return product;
+    }
+
+    private Order order(Long id, User user, long totalPrice) {
+        Order order = Order.create(user, totalPrice);
+        setId(order, id);
+        return order;
+    }
+
+    private OrderItem orderItem(Order order, Product product, Long quantity) {
+        OrderItem item = OrderItem.create(order, product, quantity);
+        setId(item, 1L);
+        return item;
+    }
+
+    private Payment payment(Order order) {
+        Payment p = Payment.initiate(order, "idem-key", "pay-uuid", order.getTotalPrice());
+        setId(p, 1L);
+        return p;
+    }
+
+    private void setId(Object target, Long id) {
+        ReflectionTestUtils.setField(target, "id", id);
+    }
+}

--- a/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
@@ -430,6 +430,7 @@ class PaymentServiceTest {
 
         verify(portOneClient).cancelPayment(eq(PAYMENT_ID), anyString());
         verify(payment, never()).refund();
+        verify(payment).expire();
     }
 
     @Test

--- a/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
@@ -28,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -87,6 +88,7 @@ class PaymentServiceTest {
     void preparePayment_성공() {
         // given
         given(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).willReturn(Optional.of(user));
+        given(paymentRepository.existsByOrderIdAndStatusIn(eq(ORDER_ID), any(List.class))).willReturn(false);
         given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
         Payment savedPayment = Mockito.mock(Payment.class);
         given(paymentRepository.save(any(Payment.class))).willReturn(savedPayment);
@@ -117,10 +119,28 @@ class PaymentServiceTest {
     }
 
     @Test
+    @DisplayName("preparePayment_활성결제_존재_예외")
+    void preparePayment_활성결제_존재_예외() {
+        // given
+        given(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).willReturn(Optional.of(user));
+        given(paymentRepository.existsByOrderIdAndStatusIn(eq(ORDER_ID), any(List.class))).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.preparePayment(USER_ID, ORDER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.PAYMENT_ACTIVE_EXISTS));
+
+        verify(orderRepository, never()).findByIdWithLock(any());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
     @DisplayName("preparePayment_소유권_불일치")
     void preparePayment_소유권_불일치() {
         // given
         given(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).willReturn(Optional.of(user));
+        given(paymentRepository.existsByOrderIdAndStatusIn(eq(ORDER_ID), any(List.class))).willReturn(false);
         given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
         given(order.isOwnedBy(USER_ID)).willReturn(false);
 
@@ -136,6 +156,7 @@ class PaymentServiceTest {
     void preparePayment_주문상태_비RESERVED() {
         // given
         given(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).willReturn(Optional.of(user));
+        given(paymentRepository.existsByOrderIdAndStatusIn(eq(ORDER_ID), any(List.class))).willReturn(false);
         given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
         given(order.getStatus()).willReturn(OrderStatus.PAID);
 
@@ -207,7 +228,7 @@ class PaymentServiceTest {
         given(payment.getMerchantUid()).willReturn(PAYMENT_ID);
         given(payment.getAmount()).willReturn(AMOUNT);
         given(payment.getPaidAt()).willReturn(LocalDateTime.now());
-        given(order.getStatus()).willReturn(OrderStatus.PAID);
+        given(order.getStatus()).willReturn(OrderStatus.RESERVED);
         given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
 
         PortOnePaymentResponse portOneResponse = new PortOnePaymentResponse(
@@ -353,8 +374,30 @@ class PaymentServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH));
 
-        verify(payment).cancelByMismatch();
+        verify(payment).refund();
         verify(order).cancel(anyString());
         verify(portOneClient).cancelPayment(eq(PAYMENT_ID), anyString());
+    }
+
+    @Test
+    @DisplayName("completePayment_ORDER_EXPIRED_환불_성공")
+    void completePayment_ORDER_EXPIRED_환불_성공() {
+        // given
+        Payment payment = Mockito.mock(Payment.class);
+        given(paymentRepository.findByMerchantUidWithLock(PAYMENT_ID)).willReturn(Optional.of(payment));
+        given(payment.getStatus()).willReturn(PaymentStatus.PENDING);
+        given(payment.getOrder()).willReturn(order);
+        given(order.getStatus()).willReturn(OrderStatus.CANCELLED);
+        given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
+        given(portOneClient.cancelPayment(eq(PAYMENT_ID), anyString())).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.completePayment(PAYMENT_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.ORDER_EXPIRED_REFUNDED));
+
+        verify(portOneClient).cancelPayment(eq(PAYMENT_ID), anyString());
+        verify(payment).refund();
     }
 }

--- a/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
@@ -410,6 +410,29 @@ class PaymentServiceTest {
     }
 
     @Test
+    @DisplayName("completePayment_ORDER_EXPIRED_PG결제없음_환불미호출")
+    void completePayment_ORDER_EXPIRED_PG결제없음_환불미호출() {
+        // given
+        Payment payment = Mockito.mock(Payment.class);
+        given(paymentRepository.findByMerchantUidWithLock(PAYMENT_ID)).willReturn(Optional.of(payment));
+        given(payment.getStatus()).willReturn(PaymentStatus.PENDING);
+        given(payment.getOrder()).willReturn(order);
+        given(order.getStatus()).willReturn(OrderStatus.CANCELLED);
+        given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
+        given(portOneClient.cancelPayment(eq(PAYMENT_ID), anyString()))
+                .willThrow(new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.completePayment(PAYMENT_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.ORDER_EXPIRED_REFUNDED));
+
+        verify(portOneClient).cancelPayment(eq(PAYMENT_ID), anyString());
+        verify(payment, never()).refund();
+    }
+
+    @Test
     @DisplayName("completePayment_CANCELLED_Payment_ORDER_EXPIRED_환불_성공")
     void completePayment_CANCELLED_Payment_ORDER_EXPIRED_환불_성공() {
         // given

--- a/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
@@ -456,6 +456,27 @@ class PaymentServiceTest {
     }
 
     @Test
+    @DisplayName("completePayment_REFUNDED_CANCELLED_Order_멱등_ORDER_EXPIRED_REFUNDED")
+    void completePayment_REFUNDED_CANCELLED_Order_멱등_ORDER_EXPIRED_REFUNDED() {
+        // given
+        Payment payment = Mockito.mock(Payment.class);
+        given(paymentRepository.findByMerchantUidWithLock(PAYMENT_ID)).willReturn(Optional.of(payment));
+        given(payment.getStatus()).willReturn(PaymentStatus.REFUNDED);
+        given(payment.getOrder()).willReturn(order);
+        given(order.getStatus()).willReturn(OrderStatus.CANCELLED);
+        given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.completePayment(PAYMENT_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.ORDER_EXPIRED_REFUNDED));
+
+        verify(portOneClient, never()).cancelPayment(anyString(), anyString());
+        verify(payment, never()).refund();
+    }
+
+    @Test
     @DisplayName("completePayment_ORDER_EXPIRED_서킷오픈_InfraException_전파")
     void completePayment_ORDER_EXPIRED_서킷오픈_InfraException_전파() {
         // given

--- a/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
@@ -124,6 +124,8 @@ class PaymentServiceTest {
         // given
         given(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).willReturn(Optional.of(user));
         given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
+        given(order.isOwnedBy(USER_ID)).willReturn(true);
+        given(order.getStatus()).willReturn(OrderStatus.RESERVED);
         given(paymentRepository.existsByOrderIdAndStatusIn(eq(ORDER_ID), any(List.class))).willReturn(true);
 
         // when & then
@@ -140,7 +142,6 @@ class PaymentServiceTest {
     void preparePayment_소유권_불일치() {
         // given
         given(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).willReturn(Optional.of(user));
-        given(paymentRepository.existsByOrderIdAndStatusIn(eq(ORDER_ID), any(List.class))).willReturn(false);
         given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
         given(order.isOwnedBy(USER_ID)).willReturn(false);
 
@@ -149,6 +150,8 @@ class PaymentServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(PaymentErrorCode.PAYMENT_NOT_ALLOWED));
+
+        verify(paymentRepository, never()).existsByOrderIdAndStatusIn(eq(ORDER_ID), any(List.class));
     }
 
     @Test
@@ -156,7 +159,6 @@ class PaymentServiceTest {
     void preparePayment_주문상태_비RESERVED() {
         // given
         given(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).willReturn(Optional.of(user));
-        given(paymentRepository.existsByOrderIdAndStatusIn(eq(ORDER_ID), any(List.class))).willReturn(false);
         given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
         given(order.getStatus()).willReturn(OrderStatus.PAID);
 
@@ -165,6 +167,8 @@ class PaymentServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(PaymentErrorCode.PAYMENT_NOT_ALLOWED));
+
+        verify(paymentRepository, never()).existsByOrderIdAndStatusIn(eq(ORDER_ID), any(List.class));
     }
 
     // ────────────────────────────────────────────────────────────
@@ -293,6 +297,9 @@ class PaymentServiceTest {
         Payment payment = Mockito.mock(Payment.class);
         given(paymentRepository.findByMerchantUidWithLock(PAYMENT_ID)).willReturn(Optional.of(payment));
         given(payment.getStatus()).willReturn(PaymentStatus.FAILED);
+        given(payment.getOrder()).willReturn(order);
+        given(order.getStatus()).willReturn(OrderStatus.RESERVED);
+        given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
 
         // when & then
         assertThatThrownBy(() -> paymentService.completePayment(PAYMENT_ID))
@@ -386,6 +393,29 @@ class PaymentServiceTest {
         Payment payment = Mockito.mock(Payment.class);
         given(paymentRepository.findByMerchantUidWithLock(PAYMENT_ID)).willReturn(Optional.of(payment));
         given(payment.getStatus()).willReturn(PaymentStatus.PENDING);
+        given(payment.getOrder()).willReturn(order);
+        given(order.getStatus()).willReturn(OrderStatus.CANCELLED);
+        given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
+        given(portOneClient.cancelPayment(eq(PAYMENT_ID), anyString()))
+                .willReturn(Mockito.mock(PortOnePaymentResponse.class));
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.completePayment(PAYMENT_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(PaymentErrorCode.ORDER_EXPIRED_REFUNDED));
+
+        verify(portOneClient).cancelPayment(eq(PAYMENT_ID), anyString());
+        verify(payment).refund();
+    }
+
+    @Test
+    @DisplayName("completePayment_CANCELLED_Payment_ORDER_EXPIRED_환불_성공")
+    void completePayment_CANCELLED_Payment_ORDER_EXPIRED_환불_성공() {
+        // given
+        Payment payment = Mockito.mock(Payment.class);
+        given(paymentRepository.findByMerchantUidWithLock(PAYMENT_ID)).willReturn(Optional.of(payment));
+        given(payment.getStatus()).willReturn(PaymentStatus.CANCELLED);
         given(payment.getOrder()).willReturn(order);
         given(order.getStatus()).willReturn(OrderStatus.CANCELLED);
         given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));

--- a/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
@@ -123,6 +123,7 @@ class PaymentServiceTest {
     void preparePayment_활성결제_존재_예외() {
         // given
         given(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).willReturn(Optional.of(user));
+        given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
         given(paymentRepository.existsByOrderIdAndStatusIn(eq(ORDER_ID), any(List.class))).willReturn(true);
 
         // when & then
@@ -131,7 +132,6 @@ class PaymentServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(PaymentErrorCode.PAYMENT_ACTIVE_EXISTS));
 
-        verify(orderRepository, never()).findByIdWithLock(any());
         verify(paymentRepository, never()).save(any());
     }
 
@@ -389,7 +389,8 @@ class PaymentServiceTest {
         given(payment.getOrder()).willReturn(order);
         given(order.getStatus()).willReturn(OrderStatus.CANCELLED);
         given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
-        given(portOneClient.cancelPayment(eq(PAYMENT_ID), anyString())).willReturn(null);
+        given(portOneClient.cancelPayment(eq(PAYMENT_ID), anyString()))
+                .willReturn(Mockito.mock(PortOnePaymentResponse.class));
 
         // when & then
         assertThatThrownBy(() -> paymentService.completePayment(PAYMENT_ID))
@@ -399,5 +400,25 @@ class PaymentServiceTest {
 
         verify(portOneClient).cancelPayment(eq(PAYMENT_ID), anyString());
         verify(payment).refund();
+    }
+
+    @Test
+    @DisplayName("completePayment_ORDER_EXPIRED_서킷오픈_InfraException_전파")
+    void completePayment_ORDER_EXPIRED_서킷오픈_InfraException_전파() {
+        // given
+        Payment payment = Mockito.mock(Payment.class);
+        given(paymentRepository.findByMerchantUidWithLock(PAYMENT_ID)).willReturn(Optional.of(payment));
+        given(payment.getStatus()).willReturn(PaymentStatus.PENDING);
+        given(payment.getOrder()).willReturn(order);
+        given(order.getStatus()).willReturn(OrderStatus.CANCELLED);
+        given(orderRepository.findByIdWithLock(ORDER_ID)).willReturn(Optional.of(order));
+        given(portOneClient.cancelPayment(eq(PAYMENT_ID), anyString()))
+                .willThrow(new InfraException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE));
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.completePayment(PAYMENT_ID))
+                .isInstanceOf(InfraException.class);
+
+        verify(payment, never()).refund();
     }
 }


### PR DESCRIPTION
## Issue ID
close #139

## 작업 내용

### 도메인 모델 변경
- `PaymentStatus`에 `REFUNDED` 추가
- `Payment.cancel()` → `Payment.refund()`로 명칭 변경 (의미 명확화)
- `Payment.expire()` 신규 추가 (PENDING → CANCELLED 전이)

### Repository 쿼리 추가
- `PaymentRepository.findExpiredPendingPaymentIds()`: 만료된 PENDING Payment ID 목록 조회 (NOT EXISTS로 이미 처리된 Order 제외)
- `OrderRepository.findExpiredReservedOrderIds()`: NOT EXISTS 조건 추가 — 연결된 PENDING Payment가 존재하면 제외 (PaymentExpireService에 위임)
- `PaymentRepository.findByIdWithLock()`: 비관적 락 조회

### PaymentExpireService 신규 구현
- 만료된 PENDING Payment → Order 함께 취소 + 재고 복구
- double-check 패턴: payment.status, order.status, createdAt 검증 후 처리

### PaymentExpiryScheduler 추가
- 60초 주기 스케줄러, 만료 Payment ID 목록 조회 후 PaymentExpireService에 위임

### completePayment() 보상 처리
- PortOne 검증 성공 후 Order 상태가 CANCELLED인 경우 감지 → PortOne 환불 API 호출 + Payment REFUNDED 처리

### 단위 테스트
- `PaymentExpireServiceTest`: 5개 케이스 (정상 만료, PAID skip, Order PAID skip, 유효 Payment skip, 존재하지 않는 Payment)
- `OrderExpireServiceTest` 기존 테스트 유지

## 참고사항
- Order 만료(#136)와 Payment 만료(#139)의 조회 쿼리가 상호 배타적으로 동작하도록 NOT EXISTS 조건으로 분기
- completePayment 보상 처리는 PortOne 취소 실패 시 예외를 그대로 전파하여 호출자가 감지할 수 있도록 함