### PR TITLE
[FIX] OrderExpireService 락 후 PENDING Payment 재확인으로 TOCTOU 수정 (#141)

### DIFF
--- a/src/main/java/com/gongu/server/domain/order/service/OrderExpireService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderExpireService.java
@@ -5,6 +5,8 @@ import com.gongu.server.domain.order.entity.OrderItem;
 import com.gongu.server.domain.order.entity.OrderStatus;
 import com.gongu.server.domain.order.repository.OrderItemRepository;
 import com.gongu.server.domain.order.repository.OrderRepository;
+import com.gongu.server.domain.payment.domain.PaymentStatus;
+import com.gongu.server.domain.payment.repository.PaymentRepository;
 import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.repository.ProductRepository;
 import com.gongu.server.global.exception.BusinessException;
@@ -26,6 +28,7 @@ public class OrderExpireService {
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
     private final ProductRepository productRepository;
+    private final PaymentRepository paymentRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void cancelExpiredOrder(Long orderId, LocalDateTime threshold) {
@@ -41,6 +44,10 @@ public class OrderExpireService {
         }
 
         if (!order.getCreatedAt().isBefore(threshold)) {
+            return;
+        }
+
+        if (paymentRepository.existsByOrderIdAndStatusIn(orderId, List.of(PaymentStatus.PENDING))) {
             return;
         }
 

--- a/src/test/java/com/gongu/server/domain/order/service/OrderExpireServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/order/service/OrderExpireServiceTest.java
@@ -5,6 +5,8 @@ import com.gongu.server.domain.order.entity.OrderItem;
 import com.gongu.server.domain.order.entity.OrderStatus;
 import com.gongu.server.domain.order.repository.OrderItemRepository;
 import com.gongu.server.domain.order.repository.OrderRepository;
+import com.gongu.server.domain.payment.domain.PaymentStatus;
+import com.gongu.server.domain.payment.repository.PaymentRepository;
 import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.entity.ProductStatus;
 import com.gongu.server.domain.product.repository.ProductRepository;
@@ -40,6 +42,9 @@ class OrderExpireServiceTest {
 
     @Mock
     private ProductRepository productRepository;
+
+    @Mock
+    private PaymentRepository paymentRepository;
 
     @InjectMocks
     private OrderExpireService orderExpireService;
@@ -121,6 +126,28 @@ class OrderExpireServiceTest {
         assertThatCode(() -> orderExpireService.cancelExpiredOrder(999L, threshold))
                 .doesNotThrowAnyException();
         verifyNoInteractions(orderItemRepository);
+    }
+
+    @Test
+    @DisplayName("락 후 PENDING Payment 존재 시 취소 skip")
+    void cancelExpiredOrder_락_후_PENDING_Payment_존재_시_skip() {
+        // given
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(10);
+        User user = user(1L);
+        Order order = order(1L, user, 10_000L);
+        ReflectionTestUtils.setField(order, "createdAt", threshold.minusMinutes(5));
+
+        given(orderRepository.findByIdWithLock(1L)).willReturn(Optional.of(order));
+        given(paymentRepository.existsByOrderIdAndStatusIn(
+                1L, List.of(PaymentStatus.PENDING)
+        )).willReturn(true);
+
+        // when
+        orderExpireService.cancelExpiredOrder(1L, threshold);
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.RESERVED);
+        verify(orderItemRepository, never()).findAllByOrder(order);
     }
 
     // --- fixture helpers ---


### PR DESCRIPTION
## Issue ID
close #141

## 작업 내용
`OrderExpireService.cancelExpiredOrder()`에서 Order 락 획득 직후 PENDING Payment 존재 여부를 재확인하여 TOCTOU race condition 제거

### 변경 사항
- `OrderExpireService`: `PaymentRepository` 주입 + Order 락 보유 상태에서 `existsByOrderIdAndStatusIn(orderId, PENDING)` 체크 추가, 존재 시 즉시 return
- `OrderExpireServiceTest`: 락 후 PENDING Payment 존재 시 취소 skip 테스트 케이스 추가 (5/5 통과)

### 수정된 race condition 흐름
```
Before:
  1. findExpiredReservedOrderIds() → Order A 반환 (쿼리 시점 PENDING 없음)
  2. preparePayment(Order A) → PENDING Payment 생성  ← 끼어들기
  3. cancelExpiredOrder(Order A) → CANCELLED  ← PENDING Payment 고아 잔존

After:
  3. cancelExpiredOrder(Order A) → 락 획득 후 PENDING 재확인 → 존재 시 skip
```

## 참고사항
- 기존 `PaymentRepository.existsByOrderIdAndStatusIn()` 메서드 재사용, 새 쿼리 불필요
- 락 보유 중 체크이므로 완전한 race-free 보장