### PR TITLE
[FEAT] 모니터링 인프라 구축 — Prometheus/Grafana/Micrometer 계측 (#143)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 	// Actuator (CircuitBreaker health indicator)
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+	// Micrometer Prometheus registry
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       retries: 10
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v2.53.0
     container_name: gongu-prometheus
     restart: unless-stopped
     ports:
@@ -48,11 +48,16 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.retention.time=30d'
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     networks:
       - gongu-net
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:11.1.0
     container_name: gongu-grafana
     restart: unless-stopped
     ports:
@@ -65,6 +70,11 @@ services:
       - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
     networks:
       - gongu-net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,42 @@ services:
       timeout: 5s
       retries: 10
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: gongu-prometheus
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.retention.time=30d'
+    networks:
+      - gongu-net
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: gongu-grafana
+    restart: unless-stopped
+    ports:
+      - "3001:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    networks:
+      - gongu-net
+
 volumes:
   mysql-data:
+  prometheus-data:
+  grafana-data:
 
 networks:
   gongu-net:

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: 'Gongu'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'gongu-server'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+    relabel_configs:
+      - target_label: application
+        replacement: gongu-server

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -6,6 +6,7 @@ scrape_configs:
   - job_name: 'gongu-server'
     metrics_path: '/actuator/prometheus'
     static_configs:
+      # host.docker.internal: Mac/Docker Desktop only. Linux: use 172.17.0.1 or --add-host flag
       - targets: ['host.docker.internal:8080']
     relabel_configs:
       - target_label: application

--- a/src/main/java/com/gongu/server/domain/order/scheduler/OrderExpiryScheduler.java
+++ b/src/main/java/com/gongu/server/domain/order/scheduler/OrderExpiryScheduler.java
@@ -3,6 +3,8 @@ package com.gongu.server.domain.order.scheduler;
 import com.gongu.server.domain.order.entity.OrderStatus;
 import com.gongu.server.domain.order.repository.OrderRepository;
 import com.gongu.server.domain.order.service.OrderExpireService;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -20,25 +22,30 @@ public class OrderExpiryScheduler {
 
     private final OrderExpireService orderExpireService;
     private final OrderRepository orderRepository;
+    private final Counter orderExpiredCounter;
+    private final Timer orderExpireDuration;
 
     @Value("${order.reservation-ttl-minutes}")
     private long reservationTtlMinutes;
 
     @Scheduled(fixedDelay = 60_000)
     public void expireReservedOrders() {
-        LocalDateTime threshold = LocalDateTime.now().minusMinutes(reservationTtlMinutes);
-        List<Long> expiredIds = orderRepository.findExpiredReservedOrderIds(
-                OrderStatus.RESERVED, threshold, PageRequest.of(0, 100));
+        orderExpireDuration.record(() -> {
+            LocalDateTime threshold = LocalDateTime.now().minusMinutes(reservationTtlMinutes);
+            List<Long> expiredIds = orderRepository.findExpiredReservedOrderIds(
+                    OrderStatus.RESERVED, threshold, PageRequest.of(0, 100));
 
-        int count = 0;
-        for (Long id : expiredIds) {
-            try {
-                orderExpireService.cancelExpiredOrder(id, threshold);
-                count++;
-            } catch (Exception e) {
-                log.warn("만료 주문 취소 실패: orderId={}", id, e);
+            int[] count = {0};
+            for (Long id : expiredIds) {
+                try {
+                    orderExpireService.cancelExpiredOrder(id, threshold);
+                    count[0]++;
+                    orderExpiredCounter.increment();
+                } catch (Exception e) {
+                    log.warn("만료 주문 취소 실패: orderId={}", id, e);
+                }
             }
-        }
-        log.info("만료 주문 처리 완료: {}건", count);
+            log.info("만료 주문 처리 완료: {}건", count[0]);
+        });
     }
 }

--- a/src/main/java/com/gongu/server/domain/order/scheduler/OrderExpiryScheduler.java
+++ b/src/main/java/com/gongu/server/domain/order/scheduler/OrderExpiryScheduler.java
@@ -7,6 +7,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -22,7 +23,9 @@ public class OrderExpiryScheduler {
 
     private final OrderExpireService orderExpireService;
     private final OrderRepository orderRepository;
+    @Qualifier("orderExpiredCounter")
     private final Counter orderExpiredCounter;
+    @Qualifier("orderExpireDuration")
     private final Timer orderExpireDuration;
 
     @Value("${order.reservation-ttl-minutes}")
@@ -30,22 +33,27 @@ public class OrderExpiryScheduler {
 
     @Scheduled(fixedDelay = 60_000)
     public void expireReservedOrders() {
-        orderExpireDuration.record(() -> {
-            LocalDateTime threshold = LocalDateTime.now().minusMinutes(reservationTtlMinutes);
-            List<Long> expiredIds = orderRepository.findExpiredReservedOrderIds(
-                    OrderStatus.RESERVED, threshold, PageRequest.of(0, 100));
+        try {
+            int count = orderExpireDuration.recordCallable(() -> {
+                LocalDateTime threshold = LocalDateTime.now().minusMinutes(reservationTtlMinutes);
+                List<Long> expiredIds = orderRepository.findExpiredReservedOrderIds(
+                        OrderStatus.RESERVED, threshold, PageRequest.of(0, 100));
 
-            int[] count = {0};
-            for (Long id : expiredIds) {
-                try {
-                    orderExpireService.cancelExpiredOrder(id, threshold);
-                    count[0]++;
-                    orderExpiredCounter.increment();
-                } catch (Exception e) {
-                    log.warn("만료 주문 취소 실패: orderId={}", id, e);
+                int processedCount = 0;
+                for (Long id : expiredIds) {
+                    try {
+                        orderExpireService.cancelExpiredOrder(id, threshold);
+                        processedCount++;
+                        orderExpiredCounter.increment();
+                    } catch (Exception e) {
+                        log.warn("만료 주문 취소 실패: orderId={}", id, e);
+                    }
                 }
-            }
-            log.info("만료 주문 처리 완료: {}건", count[0]);
-        });
+                return processedCount;
+            });
+            log.info("만료 주문 처리 완료: {}건", count);
+        } catch (Exception e) {
+            throw new IllegalStateException("만료 주문 처리 중 예외 발생", e);
+        }
     }
 }

--- a/src/main/java/com/gongu/server/domain/order/service/OrderExpireService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderExpireService.java
@@ -35,7 +35,7 @@ public class OrderExpireService {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void cancelExpiredOrder(Long orderId, LocalDateTime threshold) {
-        Optional<Order> optionalOrder = Timer.builder("gongu.product.lock.wait")
+        Optional<Order> optionalOrder = Timer.builder("gongu.db.lock.wait")
                 .tag("entity", "order")
                 .register(meterRegistry)
                 .record(() -> orderRepository.findByIdWithLock(orderId));
@@ -61,7 +61,7 @@ public class OrderExpireService {
         items.stream()
                 .sorted(Comparator.comparingLong(item -> item.getProduct().getId()))
                 .forEach(item -> {
-                    Product product = Timer.builder("gongu.product.lock.wait")
+                    Product product = Timer.builder("gongu.db.lock.wait")
                             .tag("entity", "product")
                             .register(meterRegistry)
                             .record(() -> productRepository.findByIdWithLock(item.getProduct().getId()))

--- a/src/main/java/com/gongu/server/domain/order/service/OrderExpireService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderExpireService.java
@@ -11,6 +11,8 @@ import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.repository.ProductRepository;
 import com.gongu.server.global.exception.BusinessException;
 import com.gongu.server.global.exception.errorcode.ProductErrorCode;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -29,10 +31,14 @@ public class OrderExpireService {
     private final OrderItemRepository orderItemRepository;
     private final ProductRepository productRepository;
     private final PaymentRepository paymentRepository;
+    private final MeterRegistry meterRegistry;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void cancelExpiredOrder(Long orderId, LocalDateTime threshold) {
-        Optional<Order> optionalOrder = orderRepository.findByIdWithLock(orderId);
+        Optional<Order> optionalOrder = Timer.builder("gongu.product.lock.wait")
+                .tag("entity", "order")
+                .register(meterRegistry)
+                .record(() -> orderRepository.findByIdWithLock(orderId));
         if (optionalOrder.isEmpty()) {
             return;
         }
@@ -55,7 +61,10 @@ public class OrderExpireService {
         items.stream()
                 .sorted(Comparator.comparingLong(item -> item.getProduct().getId()))
                 .forEach(item -> {
-                    Product product = productRepository.findByIdWithLock(item.getProduct().getId())
+                    Product product = Timer.builder("gongu.product.lock.wait")
+                            .tag("entity", "product")
+                            .register(meterRegistry)
+                            .record(() -> productRepository.findByIdWithLock(item.getProduct().getId()))
                             .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
                     product.restoreStock(Math.toIntExact(item.getQuantity()));
                 });

--- a/src/main/java/com/gongu/server/domain/order/service/OrderExpireService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderExpireService.java
@@ -11,9 +11,9 @@ import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.repository.ProductRepository;
 import com.gongu.server.global.exception.BusinessException;
 import com.gongu.server.global.exception.errorcode.ProductErrorCode;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,13 +31,14 @@ public class OrderExpireService {
     private final OrderItemRepository orderItemRepository;
     private final ProductRepository productRepository;
     private final PaymentRepository paymentRepository;
-    private final MeterRegistry meterRegistry;
+    @Qualifier("lockWaitOrderTimer")
+    private final Timer lockWaitOrderTimer;
+    @Qualifier("lockWaitProductTimer")
+    private final Timer lockWaitProductTimer;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void cancelExpiredOrder(Long orderId, LocalDateTime threshold) {
-        Optional<Order> optionalOrder = Timer.builder("gongu.db.lock.wait")
-                .tag("entity", "order")
-                .register(meterRegistry)
+        Optional<Order> optionalOrder = lockWaitOrderTimer
                 .record(() -> orderRepository.findByIdWithLock(orderId));
         if (optionalOrder.isEmpty()) {
             return;
@@ -61,9 +62,7 @@ public class OrderExpireService {
         items.stream()
                 .sorted(Comparator.comparingLong(item -> item.getProduct().getId()))
                 .forEach(item -> {
-                    Product product = Timer.builder("gongu.db.lock.wait")
-                            .tag("entity", "product")
-                            .register(meterRegistry)
+                    Product product = lockWaitProductTimer
                             .record(() -> productRepository.findByIdWithLock(item.getProduct().getId()))
                             .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
                     product.restoreStock(Math.toIntExact(item.getQuantity()));

--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -23,6 +23,8 @@ import com.gongu.server.global.exception.errorcode.ProductErrorCode;
 import com.gongu.server.global.exception.errorcode.StoreErrorCode;
 import com.gongu.server.global.exception.errorcode.UserErrorCode;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
@@ -51,6 +53,7 @@ public class OrderService {
     private final StoreAdminRepository storeAdminRepository;
     private final UserStoreRepository userStoreRepository;
     private final Counter orderCreatedCounter;
+    private final MeterRegistry meterRegistry;
 
     @Transactional
     public OrderDetailResponse createOrder(Long userId, Long productId, int quantity) {
@@ -66,7 +69,10 @@ public class OrderService {
         }
 
         entityManager.detach(product);
-        product = productRepository.findByIdWithLock(productId)
+        product = Timer.builder("gongu.product.lock.wait")
+                .tag("entity", "product")
+                .register(meterRegistry)
+                .record(() -> productRepository.findByIdWithLock(productId))
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         product.decreaseStock(quantity);
@@ -87,7 +93,10 @@ public class OrderService {
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        Order order = orderRepository.findByIdWithLock(orderId)
+        Order order = Timer.builder("gongu.product.lock.wait")
+                .tag("entity", "order")
+                .register(meterRegistry)
+                .record(() -> orderRepository.findByIdWithLock(orderId))
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
         if (!order.getUser().getId().equals(user.getId())) {
             throw new BusinessException(OrderErrorCode.ORDER_NOT_FOUND);
@@ -99,7 +108,10 @@ public class OrderService {
         items.stream()
                 .sorted(Comparator.comparingLong(item -> item.getProduct().getId()))
                 .forEach(item -> {
-                    Product product = productRepository.findByIdWithLock(item.getProduct().getId())
+                    Product product = Timer.builder("gongu.product.lock.wait")
+                            .tag("entity", "product")
+                            .register(meterRegistry)
+                            .record(() -> productRepository.findByIdWithLock(item.getProduct().getId()))
                             .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
                     product.restoreStock(Math.toIntExact(item.getQuantity()));
                 });
@@ -131,7 +143,10 @@ public class OrderService {
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        Order order = orderRepository.findByIdWithLock(orderId)
+        Order order = Timer.builder("gongu.product.lock.wait")
+                .tag("entity", "order")
+                .register(meterRegistry)
+                .record(() -> orderRepository.findByIdWithLock(orderId))
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
         if (!order.getUser().getId().equals(user.getId())) {

--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -74,11 +74,11 @@ public class OrderService {
 
         Order order = Order.create(user, totalPrice);
         orderRepository.save(order);
-        orderCreatedCounter.increment();
 
         OrderItem item = OrderItem.create(order, product, Long.valueOf(quantity));
         orderItemRepository.save(item);
 
+        orderCreatedCounter.increment();
         return OrderDetailResponse.of(order, List.of(item));
     }
 

--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -22,6 +22,7 @@ import com.gongu.server.global.exception.errorcode.OrderErrorCode;
 import com.gongu.server.global.exception.errorcode.ProductErrorCode;
 import com.gongu.server.global.exception.errorcode.StoreErrorCode;
 import com.gongu.server.global.exception.errorcode.UserErrorCode;
+import io.micrometer.core.instrument.Counter;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
@@ -49,6 +50,7 @@ public class OrderService {
     private final OrderItemRepository orderItemRepository;
     private final StoreAdminRepository storeAdminRepository;
     private final UserStoreRepository userStoreRepository;
+    private final Counter orderCreatedCounter;
 
     @Transactional
     public OrderDetailResponse createOrder(Long userId, Long productId, int quantity) {
@@ -72,6 +74,7 @@ public class OrderService {
 
         Order order = Order.create(user, totalPrice);
         orderRepository.save(order);
+        orderCreatedCounter.increment();
 
         OrderItem item = OrderItem.create(order, product, Long.valueOf(quantity));
         orderItemRepository.save(item);

--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -23,11 +23,11 @@ import com.gongu.server.global.exception.errorcode.ProductErrorCode;
 import com.gongu.server.global.exception.errorcode.StoreErrorCode;
 import com.gongu.server.global.exception.errorcode.UserErrorCode;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -52,8 +52,12 @@ public class OrderService {
     private final OrderItemRepository orderItemRepository;
     private final StoreAdminRepository storeAdminRepository;
     private final UserStoreRepository userStoreRepository;
+    @Qualifier("orderCreatedCounter")
     private final Counter orderCreatedCounter;
-    private final MeterRegistry meterRegistry;
+    @Qualifier("lockWaitOrderTimer")
+    private final Timer lockWaitOrderTimer;
+    @Qualifier("lockWaitProductTimer")
+    private final Timer lockWaitProductTimer;
 
     @Transactional
     public OrderDetailResponse createOrder(Long userId, Long productId, int quantity) {
@@ -69,9 +73,7 @@ public class OrderService {
         }
 
         entityManager.detach(product);
-        product = Timer.builder("gongu.db.lock.wait")
-                .tag("entity", "product")
-                .register(meterRegistry)
+        product = lockWaitProductTimer
                 .record(() -> productRepository.findByIdWithLock(productId))
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
@@ -93,9 +95,7 @@ public class OrderService {
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        Order order = Timer.builder("gongu.db.lock.wait")
-                .tag("entity", "order")
-                .register(meterRegistry)
+        Order order = lockWaitOrderTimer
                 .record(() -> orderRepository.findByIdWithLock(orderId))
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
         if (!order.getUser().getId().equals(user.getId())) {
@@ -108,9 +108,7 @@ public class OrderService {
         items.stream()
                 .sorted(Comparator.comparingLong(item -> item.getProduct().getId()))
                 .forEach(item -> {
-                    Product product = Timer.builder("gongu.db.lock.wait")
-                            .tag("entity", "product")
-                            .register(meterRegistry)
+                    Product product = lockWaitProductTimer
                             .record(() -> productRepository.findByIdWithLock(item.getProduct().getId()))
                             .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
                     product.restoreStock(Math.toIntExact(item.getQuantity()));
@@ -143,9 +141,7 @@ public class OrderService {
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        Order order = Timer.builder("gongu.db.lock.wait")
-                .tag("entity", "order")
-                .register(meterRegistry)
+        Order order = lockWaitOrderTimer
                 .record(() -> orderRepository.findByIdWithLock(orderId))
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 

--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -69,7 +69,7 @@ public class OrderService {
         }
 
         entityManager.detach(product);
-        product = Timer.builder("gongu.product.lock.wait")
+        product = Timer.builder("gongu.db.lock.wait")
                 .tag("entity", "product")
                 .register(meterRegistry)
                 .record(() -> productRepository.findByIdWithLock(productId))
@@ -93,7 +93,7 @@ public class OrderService {
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        Order order = Timer.builder("gongu.product.lock.wait")
+        Order order = Timer.builder("gongu.db.lock.wait")
                 .tag("entity", "order")
                 .register(meterRegistry)
                 .record(() -> orderRepository.findByIdWithLock(orderId))
@@ -108,7 +108,7 @@ public class OrderService {
         items.stream()
                 .sorted(Comparator.comparingLong(item -> item.getProduct().getId()))
                 .forEach(item -> {
-                    Product product = Timer.builder("gongu.product.lock.wait")
+                    Product product = Timer.builder("gongu.db.lock.wait")
                             .tag("entity", "product")
                             .register(meterRegistry)
                             .record(() -> productRepository.findByIdWithLock(item.getProduct().getId()))
@@ -143,7 +143,7 @@ public class OrderService {
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        Order order = Timer.builder("gongu.product.lock.wait")
+        Order order = Timer.builder("gongu.db.lock.wait")
                 .tag("entity", "order")
                 .register(meterRegistry)
                 .record(() -> orderRepository.findByIdWithLock(orderId))

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
@@ -17,6 +17,7 @@ import com.gongu.server.global.exception.errorcode.UserErrorCode;
 import com.gongu.server.global.infrastructure.portone.PortOneClient;
 import com.gongu.server.global.infrastructure.portone.dto.PortOnePaymentResponse;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -36,7 +37,7 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final PortOneClient portOneClient;
     private final Counter paymentCompletedCounter;
-    private final Counter paymentFailedCounter;
+    private final MeterRegistry meterRegistry;
 
     @Transactional
     public PaymentPrepareResult preparePayment(Long userId, Long orderId) {
@@ -90,6 +91,10 @@ public class PaymentService {
         if (order.getStatus() == OrderStatus.CANCELLED) {
             if (payment.getStatus() == PaymentStatus.REFUNDED) {
                 // 이미 환불 완료 — 멱등 처리
+                Counter.builder("gongu.payment.failed")
+                        .tag("reason", "order_expired")
+                        .register(meterRegistry)
+                        .increment();
                 throw new BusinessException(PaymentErrorCode.ORDER_EXPIRED_REFUNDED);
             }
             if (payment.getStatus() != PaymentStatus.PENDING
@@ -102,6 +107,10 @@ public class PaymentService {
             } else if (payment.getStatus() == PaymentStatus.PENDING) {
                 payment.expire();
             }
+            Counter.builder("gongu.payment.failed")
+                    .tag("reason", "order_expired")
+                    .register(meterRegistry)
+                    .increment();
             throw new BusinessException(PaymentErrorCode.ORDER_EXPIRED_REFUNDED);
         }
 
@@ -114,19 +123,28 @@ public class PaymentService {
             portOneResponse = portOneClient.getPayment(paymentId);
         } catch (InfraException e) {
             payment.fail();
-            paymentFailedCounter.increment();
+            Counter.builder("gongu.payment.failed")
+                    .tag("reason", "pg_error")
+                    .register(meterRegistry)
+                    .increment();
             throw e;
         }
 
         if (portOneResponse == null) {
             payment.fail();
-            paymentFailedCounter.increment();
+            Counter.builder("gongu.payment.failed")
+                    .tag("reason", "pg_null_response")
+                    .register(meterRegistry)
+                    .increment();
             throw new BusinessException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE);
         }
 
         if (!"PAID".equals(portOneResponse.status())) {
             payment.fail();
-            paymentFailedCounter.increment();
+            Counter.builder("gongu.payment.failed")
+                    .tag("reason", "pg_status_mismatch")
+                    .register(meterRegistry)
+                    .increment();
             throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_COMPLETED);
         }
 
@@ -141,7 +159,10 @@ public class PaymentService {
         } else {
             executePGCancel(paymentId, "결제 금액 불일치");
             payment.refund();
-            paymentFailedCounter.increment();
+            Counter.builder("gongu.payment.failed")
+                    .tag("reason", "amount_mismatch")
+                    .register(meterRegistry)
+                    .increment();
             order.cancel("결제 금액 불일치");
             throw new BusinessException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
@@ -16,6 +16,7 @@ import com.gongu.server.global.exception.errorcode.PaymentErrorCode;
 import com.gongu.server.global.exception.errorcode.UserErrorCode;
 import com.gongu.server.global.infrastructure.portone.PortOneClient;
 import com.gongu.server.global.infrastructure.portone.dto.PortOnePaymentResponse;
+import io.micrometer.core.instrument.Counter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,8 @@ public class PaymentService {
     private final OrderRepository orderRepository;
     private final PaymentRepository paymentRepository;
     private final PortOneClient portOneClient;
+    private final Counter paymentCompletedCounter;
+    private final Counter paymentFailedCounter;
 
     @Transactional
     public PaymentPrepareResult preparePayment(Long userId, Long orderId) {
@@ -110,17 +113,20 @@ public class PaymentService {
         try {
             portOneResponse = portOneClient.getPayment(paymentId);
         } catch (InfraException e) {
-            payment.fail();   // dirty checking will persist this on transaction commit
+            payment.fail();
+            paymentFailedCounter.increment();
             throw e;
         }
 
         if (portOneResponse == null) {
             payment.fail();
+            paymentFailedCounter.increment();
             throw new BusinessException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE);
         }
 
         if (!"PAID".equals(portOneResponse.status())) {
-            payment.fail();   // dirty checking will persist this
+            payment.fail();
+            paymentFailedCounter.increment();
             throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_COMPLETED);
         }
 
@@ -130,10 +136,12 @@ public class PaymentService {
         if (expectedAmount.equals(actualAmount)) {
             order.pay();
             payment.confirm(actualAmount, portOneResponse.paidAt().toLocalDateTime());
+            paymentCompletedCounter.increment();
             return VerifyPaymentResponse.of(order, payment);
         } else {
             executePGCancel(paymentId, "결제 금액 불일치");
             payment.refund();
+            paymentFailedCounter.increment();
             order.cancel("결제 금액 불일치");
             throw new BusinessException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
@@ -17,9 +17,9 @@ import com.gongu.server.global.exception.errorcode.UserErrorCode;
 import com.gongu.server.global.infrastructure.portone.PortOneClient;
 import com.gongu.server.global.infrastructure.portone.dto.PortOnePaymentResponse;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,8 +36,20 @@ public class PaymentService {
     private final OrderRepository orderRepository;
     private final PaymentRepository paymentRepository;
     private final PortOneClient portOneClient;
+    @Qualifier("paymentCompletedCounter")
     private final Counter paymentCompletedCounter;
-    private final MeterRegistry meterRegistry;
+    @Qualifier("paymentFailedOrderExpiredIdempotentCounter")
+    private final Counter paymentFailedOrderExpiredIdempotentCounter;
+    @Qualifier("paymentFailedOrderExpiredCancelCounter")
+    private final Counter paymentFailedOrderExpiredCancelCounter;
+    @Qualifier("paymentFailedPgErrorCounter")
+    private final Counter paymentFailedPgErrorCounter;
+    @Qualifier("paymentFailedPgNullCounter")
+    private final Counter paymentFailedPgNullCounter;
+    @Qualifier("paymentFailedPgStatusMismatchCounter")
+    private final Counter paymentFailedPgStatusMismatchCounter;
+    @Qualifier("paymentFailedAmountMismatchCounter")
+    private final Counter paymentFailedAmountMismatchCounter;
 
     @Transactional
     public PaymentPrepareResult preparePayment(Long userId, Long orderId) {
@@ -91,10 +103,7 @@ public class PaymentService {
         if (order.getStatus() == OrderStatus.CANCELLED) {
             if (payment.getStatus() == PaymentStatus.REFUNDED) {
                 // 이미 환불 완료 — 멱등 처리
-                Counter.builder("gongu.payment.failed")
-                        .tag("reason", "order_expired")
-                        .register(meterRegistry)
-                        .increment();
+                paymentFailedOrderExpiredIdempotentCounter.increment();
                 throw new BusinessException(PaymentErrorCode.ORDER_EXPIRED_REFUNDED);
             }
             if (payment.getStatus() != PaymentStatus.PENDING
@@ -107,10 +116,7 @@ public class PaymentService {
             } else if (payment.getStatus() == PaymentStatus.PENDING) {
                 payment.expire();
             }
-            Counter.builder("gongu.payment.failed")
-                    .tag("reason", "order_expired")
-                    .register(meterRegistry)
-                    .increment();
+            paymentFailedOrderExpiredCancelCounter.increment();
             throw new BusinessException(PaymentErrorCode.ORDER_EXPIRED_REFUNDED);
         }
 
@@ -123,28 +129,19 @@ public class PaymentService {
             portOneResponse = portOneClient.getPayment(paymentId);
         } catch (InfraException e) {
             payment.fail();
-            Counter.builder("gongu.payment.failed")
-                    .tag("reason", "pg_error")
-                    .register(meterRegistry)
-                    .increment();
+            paymentFailedPgErrorCounter.increment();
             throw e;
         }
 
         if (portOneResponse == null) {
             payment.fail();
-            Counter.builder("gongu.payment.failed")
-                    .tag("reason", "pg_null_response")
-                    .register(meterRegistry)
-                    .increment();
+            paymentFailedPgNullCounter.increment();
             throw new BusinessException(PaymentErrorCode.PAYMENT_PG_UNAVAILABLE);
         }
 
         if (!"PAID".equals(portOneResponse.status())) {
             payment.fail();
-            Counter.builder("gongu.payment.failed")
-                    .tag("reason", "pg_status_mismatch")
-                    .register(meterRegistry)
-                    .increment();
+            paymentFailedPgStatusMismatchCounter.increment();
             throw new BusinessException(PaymentErrorCode.PAYMENT_NOT_COMPLETED);
         }
 
@@ -159,10 +156,7 @@ public class PaymentService {
         } else {
             executePGCancel(paymentId, "결제 금액 불일치");
             payment.refund();
-            Counter.builder("gongu.payment.failed")
-                    .tag("reason", "amount_mismatch")
-                    .register(meterRegistry)
-                    .increment();
+            paymentFailedAmountMismatchCounter.increment();
             order.cancel("결제 금액 불일치");
             throw new BusinessException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }

--- a/src/main/java/com/gongu/server/domain/product/service/ProductService.java
+++ b/src/main/java/com/gongu/server/domain/product/service/ProductService.java
@@ -19,6 +19,8 @@ import com.gongu.server.global.exception.BusinessException;
 import com.gongu.server.global.exception.errorcode.ProductErrorCode;
 import com.gongu.server.global.exception.errorcode.StoreErrorCode;
 import com.gongu.server.global.exception.errorcode.UserErrorCode;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -37,6 +39,7 @@ public class ProductService {
     private final UserStoreRepository userStoreRepository;
     private final StoreRepository storeRepository;
     private final StoreAdminRepository storeAdminRepository;
+    private final MeterRegistry meterRegistry;
 
     // 회원: 상품 목록 조회
     public Page<ProductSummaryResponse> getProducts(Long userId, Long storeId, Pageable pageable) {
@@ -147,7 +150,10 @@ public class ProductService {
     // 재고 차감 (비관적 락)
     @Transactional
     public void decreaseStock(Long productId, int quantity) {
-        Product product = productRepository.findByIdWithLock(productId)
+        Product product = Timer.builder("gongu.product.lock.wait")
+                .tag("entity", "product")
+                .register(meterRegistry)
+                .record(() -> productRepository.findByIdWithLock(productId))
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
         product.decreaseStock(quantity);
     }

--- a/src/main/java/com/gongu/server/domain/product/service/ProductService.java
+++ b/src/main/java/com/gongu/server/domain/product/service/ProductService.java
@@ -150,7 +150,7 @@ public class ProductService {
     // 재고 차감 (비관적 락)
     @Transactional
     public void decreaseStock(Long productId, int quantity) {
-        Product product = Timer.builder("gongu.product.lock.wait")
+        Product product = Timer.builder("gongu.db.lock.wait")
                 .tag("entity", "product")
                 .register(meterRegistry)
                 .record(() -> productRepository.findByIdWithLock(productId))

--- a/src/main/java/com/gongu/server/global/config/MetricsConfig.java
+++ b/src/main/java/com/gongu/server/global/config/MetricsConfig.java
@@ -3,17 +3,15 @@ package com.gongu.server.global.config;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RequiredArgsConstructor
 public class MetricsConfig {
 
     private final MeterRegistry meterRegistry;
-
-    public MetricsConfig(MeterRegistry meterRegistry) {
-        this.meterRegistry = meterRegistry;
-    }
 
     @Bean
     public Counter orderCreatedCounter() {
@@ -40,6 +38,56 @@ public class MetricsConfig {
     public Timer orderExpireDuration() {
         return Timer.builder("gongu.order.expire.duration")
                 .description("만료 스케줄러 1회 실행 시간")
+                .register(meterRegistry);
+    }
+
+    @Bean
+    public Timer lockWaitOrderTimer() {
+        return Timer.builder("gongu.db.lock.query_duration")
+                .tag("entity", "order")
+                .register(meterRegistry);
+    }
+
+    @Bean
+    public Timer lockWaitProductTimer() {
+        return Timer.builder("gongu.db.lock.query_duration")
+                .tag("entity", "product")
+                .register(meterRegistry);
+    }
+
+    @Bean
+    public Counter paymentFailedOrderExpiredIdempotentCounter() {
+        return paymentFailedCounter("order_expired_idempotent");
+    }
+
+    @Bean
+    public Counter paymentFailedOrderExpiredCancelCounter() {
+        return paymentFailedCounter("order_expired_cancel");
+    }
+
+    @Bean
+    public Counter paymentFailedPgErrorCounter() {
+        return paymentFailedCounter("pg_error");
+    }
+
+    @Bean
+    public Counter paymentFailedPgNullCounter() {
+        return paymentFailedCounter("pg_null_response");
+    }
+
+    @Bean
+    public Counter paymentFailedPgStatusMismatchCounter() {
+        return paymentFailedCounter("pg_status_mismatch");
+    }
+
+    @Bean
+    public Counter paymentFailedAmountMismatchCounter() {
+        return paymentFailedCounter("amount_mismatch");
+    }
+
+    private Counter paymentFailedCounter(String reason) {
+        return Counter.builder("gongu.payment.failed")
+                .tag("reason", reason)
                 .register(meterRegistry);
     }
 }

--- a/src/main/java/com/gongu/server/global/config/MetricsConfig.java
+++ b/src/main/java/com/gongu/server/global/config/MetricsConfig.java
@@ -30,13 +30,6 @@ public class MetricsConfig {
     }
 
     @Bean
-    public Counter paymentFailedCounter() {
-        return Counter.builder("gongu.payment.failed")
-                .description("실패한 결제 수")
-                .register(meterRegistry);
-    }
-
-    @Bean
     public Counter orderExpiredCounter() {
         return Counter.builder("gongu.order.expired")
                 .description("만료 처리된 주문 수")

--- a/src/main/java/com/gongu/server/global/config/MetricsConfig.java
+++ b/src/main/java/com/gongu/server/global/config/MetricsConfig.java
@@ -1,0 +1,52 @@
+package com.gongu.server.global.config;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MetricsConfig {
+
+    private final MeterRegistry meterRegistry;
+
+    public MetricsConfig(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Bean
+    public Counter orderCreatedCounter() {
+        return Counter.builder("gongu.order.created")
+                .description("생성된 주문 수")
+                .register(meterRegistry);
+    }
+
+    @Bean
+    public Counter paymentCompletedCounter() {
+        return Counter.builder("gongu.payment.completed")
+                .description("완료된 결제 수")
+                .register(meterRegistry);
+    }
+
+    @Bean
+    public Counter paymentFailedCounter() {
+        return Counter.builder("gongu.payment.failed")
+                .description("실패한 결제 수")
+                .register(meterRegistry);
+    }
+
+    @Bean
+    public Counter orderExpiredCounter() {
+        return Counter.builder("gongu.order.expired")
+                .description("만료 처리된 주문 수")
+                .register(meterRegistry);
+    }
+
+    @Bean
+    public Timer orderExpireDuration() {
+        return Timer.builder("gongu.order.expire.duration")
+                .description("만료 스케줄러 1회 실행 시간")
+                .register(meterRegistry);
+    }
+}

--- a/src/main/java/com/gongu/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/gongu/server/global/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/stores/**").permitAll()
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/products/**").permitAll()
                         .requestMatchers(org.springframework.http.HttpMethod.POST, "/payments/webhook").permitAll()
+                        .requestMatchers("/actuator/prometheus", "/actuator/health").permitAll() // Prometheus scraper 요청에 JWT 없음
                         .requestMatchers("/payments/**").authenticated()
                         .anyRequest().authenticated()
                 )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,3 +59,17 @@ resilience4j:
 
 order:
   reservation-ttl-minutes: 10
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus,metrics
+  endpoint:
+    health:
+      show-details: when-authorized
+    prometheus:
+      enabled: true
+  metrics:
+    tags:
+      application: gongu-server

--- a/src/test/java/com/gongu/server/domain/order/service/OrderExpireServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/order/service/OrderExpireServiceTest.java
@@ -12,14 +12,13 @@ import com.gongu.server.domain.product.entity.ProductStatus;
 import com.gongu.server.domain.product.repository.ProductRepository;
 import com.gongu.server.domain.store.entity.Store;
 import com.gongu.server.domain.user.entity.User;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -49,11 +48,28 @@ class OrderExpireServiceTest {
     @Mock
     private PaymentRepository paymentRepository;
 
-    @Spy
-    private MeterRegistry meterRegistry = new SimpleMeterRegistry();
-
-    @InjectMocks
+    private Timer lockWaitOrderTimer;
+    private Timer lockWaitProductTimer;
     private OrderExpireService orderExpireService;
+
+    @BeforeEach
+    void setUp() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        lockWaitOrderTimer = Timer.builder("gongu.db.lock.query_duration")
+                .tag("entity", "order")
+                .register(meterRegistry);
+        lockWaitProductTimer = Timer.builder("gongu.db.lock.query_duration")
+                .tag("entity", "product")
+                .register(meterRegistry);
+        orderExpireService = new OrderExpireService(
+                orderRepository,
+                orderItemRepository,
+                productRepository,
+                paymentRepository,
+                lockWaitOrderTimer,
+                lockWaitProductTimer
+        );
+    }
 
     @Test
     @DisplayName("만료된_RESERVED_주문_취소_및_재고_복구")

--- a/src/test/java/com/gongu/server/domain/order/service/OrderExpireServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/order/service/OrderExpireServiceTest.java
@@ -12,11 +12,14 @@ import com.gongu.server.domain.product.entity.ProductStatus;
 import com.gongu.server.domain.product.repository.ProductRepository;
 import com.gongu.server.domain.store.entity.Store;
 import com.gongu.server.domain.user.entity.User;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -45,6 +48,9 @@ class OrderExpireServiceTest {
 
     @Mock
     private PaymentRepository paymentRepository;
+
+    @Spy
+    private MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     @InjectMocks
     private OrderExpireService orderExpireService;

--- a/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
@@ -24,6 +24,8 @@ import com.gongu.server.global.exception.errorcode.ProductErrorCode;
 import com.gongu.server.global.exception.errorcode.StoreErrorCode;
 import com.gongu.server.global.exception.errorcode.UserErrorCode;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,6 +34,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -78,6 +81,9 @@ class OrderServiceTest {
 
     @Mock
     private Counter orderCreatedCounter;
+
+    @Spy
+    private MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     @InjectMocks
     private OrderService orderService;

--- a/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
@@ -23,6 +23,7 @@ import com.gongu.server.global.exception.errorcode.OrderErrorCode;
 import com.gongu.server.global.exception.errorcode.ProductErrorCode;
 import com.gongu.server.global.exception.errorcode.StoreErrorCode;
 import com.gongu.server.global.exception.errorcode.UserErrorCode;
+import io.micrometer.core.instrument.Counter;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -74,6 +75,9 @@ class OrderServiceTest {
 
     @Mock
     private EntityManager entityManager;
+
+    @Mock
+    private Counter orderCreatedCounter;
 
     @InjectMocks
     private OrderService orderService;

--- a/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
@@ -24,7 +24,7 @@ import com.gongu.server.global.exception.errorcode.ProductErrorCode;
 import com.gongu.server.global.exception.errorcode.StoreErrorCode;
 import com.gongu.server.global.exception.errorcode.UserErrorCode;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,9 +32,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -79,17 +77,32 @@ class OrderServiceTest {
     @Mock
     private EntityManager entityManager;
 
-    @Mock
     private Counter orderCreatedCounter;
-
-    @Spy
-    private MeterRegistry meterRegistry = new SimpleMeterRegistry();
-
-    @InjectMocks
+    private Timer lockWaitOrderTimer;
+    private Timer lockWaitProductTimer;
     private OrderService orderService;
 
     @BeforeEach
-    void injectEntityManager() {
+    void setUp() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        orderCreatedCounter = Counter.builder("gongu.order.created").register(meterRegistry);
+        lockWaitOrderTimer = Timer.builder("gongu.db.lock.query_duration")
+                .tag("entity", "order")
+                .register(meterRegistry);
+        lockWaitProductTimer = Timer.builder("gongu.db.lock.query_duration")
+                .tag("entity", "product")
+                .register(meterRegistry);
+        orderService = new OrderService(
+                userRepository,
+                productRepository,
+                orderRepository,
+                orderItemRepository,
+                storeAdminRepository,
+                userStoreRepository,
+                orderCreatedCounter,
+                lockWaitOrderTimer,
+                lockWaitProductTimer
+        );
         ReflectionTestUtils.setField(orderService, "entityManager", entityManager);
     }
 

--- a/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
@@ -16,6 +16,7 @@ import com.gongu.server.global.exception.errorcode.PaymentErrorCode;
 import com.gongu.server.global.exception.errorcode.UserErrorCode;
 import com.gongu.server.global.infrastructure.portone.PortOneClient;
 import com.gongu.server.global.infrastructure.portone.dto.PortOnePaymentResponse;
+import io.micrometer.core.instrument.Counter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,12 @@ class PaymentServiceTest {
 
     @Mock
     private PortOneClient portOneClient;
+
+    @Mock
+    private Counter paymentCompletedCounter;
+
+    @Mock
+    private Counter paymentFailedCounter;
 
     @InjectMocks
     private PaymentService paymentService;

--- a/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
@@ -17,13 +17,11 @@ import com.gongu.server.global.exception.errorcode.UserErrorCode;
 import com.gongu.server.global.infrastructure.portone.PortOneClient;
 import com.gongu.server.global.infrastructure.portone.dto.PortOnePaymentResponse;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -59,10 +57,13 @@ class PaymentServiceTest {
     @Mock
     private PortOneClient portOneClient;
 
-    @Mock
     private Counter paymentCompletedCounter;
-
-    private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private Counter paymentFailedOrderExpiredIdempotentCounter;
+    private Counter paymentFailedOrderExpiredCancelCounter;
+    private Counter paymentFailedPgErrorCounter;
+    private Counter paymentFailedPgNullCounter;
+    private Counter paymentFailedPgStatusMismatchCounter;
+    private Counter paymentFailedAmountMismatchCounter;
 
     private PaymentService paymentService;
 
@@ -76,9 +77,25 @@ class PaymentServiceTest {
 
     @BeforeEach
     void setUp() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        paymentCompletedCounter = Counter.builder("gongu.payment.completed").register(meterRegistry);
+        paymentFailedOrderExpiredIdempotentCounter = paymentFailedCounter(meterRegistry, "order_expired_idempotent");
+        paymentFailedOrderExpiredCancelCounter = paymentFailedCounter(meterRegistry, "order_expired_cancel");
+        paymentFailedPgErrorCounter = paymentFailedCounter(meterRegistry, "pg_error");
+        paymentFailedPgNullCounter = paymentFailedCounter(meterRegistry, "pg_null_response");
+        paymentFailedPgStatusMismatchCounter = paymentFailedCounter(meterRegistry, "pg_status_mismatch");
+        paymentFailedAmountMismatchCounter = paymentFailedCounter(meterRegistry, "amount_mismatch");
         paymentService = new PaymentService(
                 userRepository, orderRepository, paymentRepository,
-                portOneClient, paymentCompletedCounter, meterRegistry);
+                portOneClient,
+                paymentCompletedCounter,
+                paymentFailedOrderExpiredIdempotentCounter,
+                paymentFailedOrderExpiredCancelCounter,
+                paymentFailedPgErrorCounter,
+                paymentFailedPgNullCounter,
+                paymentFailedPgStatusMismatchCounter,
+                paymentFailedAmountMismatchCounter
+        );
 
         user = Mockito.mock(User.class);
         lenient().when(user.getId()).thenReturn(USER_ID);
@@ -88,6 +105,12 @@ class PaymentServiceTest {
         lenient().when(order.getStatus()).thenReturn(OrderStatus.RESERVED);
         lenient().when(order.getTotalPrice()).thenReturn(AMOUNT);
         lenient().when(order.isOwnedBy(USER_ID)).thenReturn(true);
+    }
+
+    private Counter paymentFailedCounter(SimpleMeterRegistry meterRegistry, String reason) {
+        return Counter.builder("gongu.payment.failed")
+                .tag("reason", reason)
+                .register(meterRegistry);
     }
 
     // ────────────────────────────────────────────────────────────

--- a/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
@@ -17,6 +17,8 @@ import com.gongu.server.global.exception.errorcode.UserErrorCode;
 import com.gongu.server.global.infrastructure.portone.PortOneClient;
 import com.gongu.server.global.infrastructure.portone.dto.PortOnePaymentResponse;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -60,10 +62,8 @@ class PaymentServiceTest {
     @Mock
     private Counter paymentCompletedCounter;
 
-    @Mock
-    private Counter paymentFailedCounter;
+    private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
-    @InjectMocks
     private PaymentService paymentService;
 
     private User user;
@@ -76,6 +76,10 @@ class PaymentServiceTest {
 
     @BeforeEach
     void setUp() {
+        paymentService = new PaymentService(
+                userRepository, orderRepository, paymentRepository,
+                portOneClient, paymentCompletedCounter, meterRegistry);
+
         user = Mockito.mock(User.class);
         lenient().when(user.getId()).thenReturn(USER_ID);
 

--- a/src/test/java/com/gongu/server/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/product/service/ProductServiceTest.java
@@ -19,11 +19,14 @@ import com.gongu.server.global.exception.BusinessException;
 import com.gongu.server.global.exception.errorcode.ProductErrorCode;
 import com.gongu.server.global.exception.errorcode.StoreErrorCode;
 import com.gongu.server.global.exception.errorcode.UserErrorCode;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -57,6 +60,9 @@ class ProductServiceTest {
 
     @Mock
     private StoreAdminRepository storeAdminRepository;
+
+    @Spy
+    private MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     @InjectMocks
     private ProductService productService;


### PR DESCRIPTION
## Issue ID
close #143

## 작업 내용

### Task 1 — Micrometer Prometheus 레지스트리 & Actuator 설정
- `build.gradle`: `micrometer-registry-prometheus` 의존성 추가
- `application.yml`: `/actuator/prometheus` 엔드포인트 노출, 기본 메트릭 태그(`app=gongu-server`) 설정

### Task 2 — Prometheus + Grafana Docker Compose
- `docker-compose.yml`: Prometheus(v2.55.1), Grafana(11.4.0) 서비스 추가
- `prometheus/prometheus.yml`: Spring Boot 스크레이핑 설정 (15s interval)
- Prometheus → Grafana 헬스체크 의존성 설정

### Task 3 — 비즈니스 커스텀 메트릭 계측
- `MetricsConfig`: `gongu.order.created`, `gongu.payment.completed`, `gongu.order.expired` Counter 3종 + `gongu.order.expire.duration` Timer 등록
- `OrderService`: 주문 생성 시 `orderCreatedCounter.increment()`
- `PaymentService` / `OrderExpireService`: 결제 완료·실패(`reason` 태그)·만료 계측

### Task 4 — 비관적 락 대기 시간 Timer 계측
- `OrderService`, `OrderExpireService`, `ProductService`: `findByIdWithLock()` 호출부를 `Timer.record(Supplier)` 로 래핑
- 메트릭 이름 `gongu.product.lock.wait`, 태그 `entity={order|product}` 로 락 대기 시간 구분 계측
- 테스트: `@Spy SimpleMeterRegistry` 주입으로 기존 단위 테스트 호환성 유지

## 참고사항
- Micrometer 레지스트리 캐싱: 동일 name+tag 조합은 단일 Timer 인스턴스 재사용 (중복 등록 없음)
- `Timer.record(Supplier<T>)` API: 반환값을 그대로 전달하므로 `Optional` 체이닝 유지