### PR TITLE
[FEAT] Grafana 대시보드 자동 프로비저닝 추가 (#150)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
     volumes:
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
       - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus

--- a/docs/superpowers/plans/2026-06-08-grafana-dashboard.md
+++ b/docs/superpowers/plans/2026-06-08-grafana-dashboard.md
@@ -1,0 +1,165 @@
+# Grafana 대시보드 자동 프로비저닝 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Grafana 기동 시 "Gongu Service Overview" 대시보드가 자동으로 프로비저닝되도록 JSON 파일 추가 및 docker-compose 볼륨 마운트 연결
+
+**Spec:** `docs/superpowers/specs/2026-06-08-grafana-dashboard-design.md`
+
+**Tech Stack:** Grafana 11.1.0, Prometheus, Micrometer (Spring Boot Actuator)
+
+---
+
+## File Map
+
+| 파일 | 변경 |
+|------|------|
+| `monitoring/grafana/dashboards/gongu-dashboard.json` | 신규 생성 |
+| `docker-compose.yml` | grafana volumes에 dashboards 마운트 추가 |
+
+**읽기 전용 참조:**
+- `monitoring/grafana/provisioning/dashboards/dashboard.yml` — path 설정 확인
+- `monitoring/grafana/provisioning/datasources/prometheus.yml` — 데이터소스 이름 확인
+- `src/main/java/com/gongu/server/global/config/MetricsConfig.java` — 메트릭명 확인
+
+---
+
+## Task 1: docker-compose.yml — dashboards 볼륨 마운트 추가
+
+**참고 문서/파일:**
+- `docker-compose.yml` — 현재 grafana 서비스 volumes 구조 확인
+- `monitoring/grafana/provisioning/dashboards/dashboard.yml` — `path: /var/lib/grafana/dashboards` 확인
+
+**수정 대상 파일:**
+- Modify: `docker-compose.yml`
+
+**금지 사항:**
+- grafana 서비스 외 다른 서비스(prometheus, redis, mysql) 변경 금지
+
+**구현 방향:**
+- grafana 서비스 `volumes` 블록에 아래 1줄 추가 (기존 두 줄 사이가 아닌 끝에):
+  ```yaml
+  - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+  ```
+- 위치: `- grafana-data:/var/lib/grafana` 바로 앞에 삽입
+
+**검증:**
+```bash
+grep "grafana/dashboards" docker-compose.yml
+```
+Expected: `- ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro` 출력
+
+**커밋:** 다음 Task와 함께 하나의 커밋으로 처리
+
+---
+
+## Task 2: gongu-dashboard.json 생성
+
+**참고 문서/파일:**
+- `docs/superpowers/specs/2026-06-08-grafana-dashboard-design.md` — 전체 패널 목록 및 PromQL
+- `monitoring/grafana/provisioning/datasources/prometheus.yml` — datasource name이 `Prometheus`임을 확인
+- `src/main/java/com/gongu/server/global/config/MetricsConfig.java` — 메트릭명 확인
+
+**수정 대상 파일:**
+- Create: `monitoring/grafana/dashboards/gongu-dashboard.json`
+
+**금지 사항:**
+- `monitoring/grafana/provisioning/` 하위 파일 변경 금지 (이미 올바르게 설정됨)
+
+**구현 방향:**
+
+유효한 Grafana dashboard JSON을 생성한다. 아래 구조와 패널 목록을 반드시 포함할 것.
+
+**상단 메타데이터:**
+- `"title": "Gongu Service Overview"`
+- `"uid": "gongu-service-overview"`
+- `"schemaVersion": 38`
+- `"timezone": "browser"`
+- `"time": { "from": "now-1h", "to": "now" }`
+- `"refresh": "30s"`
+- 데이터소스: `{ "type": "prometheus", "uid": "${datasource}" }` + `"templating"` 변수로 datasource 선택 변수 추가
+
+**Row 1 — 비즈니스 플로우 Overview (패널 4개, type: stat)**
+
+| 패널 제목 | expr |
+|----------|------|
+| 주문 생성률 (건/분) | `rate(gongu_order_created_total[1m]) * 60` |
+| 결제 완료률 (건/분) | `rate(gongu_payment_completed_total[1m]) * 60` |
+| 결제 실패률 (건/분) | `rate(gongu_payment_failed_total[1m]) * 60` |
+| 주문 만료률 (건/분) | `rate(gongu_order_expired_total[1m]) * 60` |
+
+"결제 실패률" 패널에 threshold 설정: `0` 초과 시 빨간색(`#F2495C`), 기본 초록색(`#73BF69`).
+
+**Row 2 — 결제 실패 상세 (패널 2개)**
+
+| 패널 제목 | type | expr |
+|----------|------|------|
+| 결제 실패 사유별 추이 | timeseries | `rate(gongu_payment_failed_total[1m]) * 60`, legend: `{{reason}}`, stacking: normal |
+| 결제 실패 사유 비율 | piechart | `increase(gongu_payment_failed_total[1h])`, legend: `{{reason}}` |
+
+**Row 3 — DB 락 & 스케줄러 성능 (패널 3개, type: timeseries)**
+
+| 패널 제목 | expr |
+|----------|------|
+| Order 락 쿼리 시간 | p50: `histogram_quantile(0.5, rate(gongu_db_lock_query_duration_seconds_bucket{entity="order"}[1m]))` / p95: `histogram_quantile(0.95, ...)` / p99: `histogram_quantile(0.99, ...)` — 3개 target, legend: `p50` / `p95` / `p99` |
+| Product 락 쿼리 시간 | 동일, `entity="product"` |
+| 만료 스케줄러 실행 시간 p95 | `histogram_quantile(0.95, rate(gongu_order_expire_duration_seconds_bucket[5m]))` |
+
+단위: `s` (seconds)
+
+**Row 4 — JVM / HTTP / HikariCP (패널 4개)**
+
+| 패널 제목 | type | expr |
+|----------|------|------|
+| JVM 힙 사용량 | timeseries | `jvm_memory_used_bytes{area="heap"}`, 단위: bytes |
+| HTTP 요청률 & 5xx 에러율 | timeseries | `rate(http_server_requests_seconds_count[1m])` by `status`, legend: `{{status}}` |
+| HTTP 응답 시간 p95 | timeseries | `histogram_quantile(0.95, rate(http_server_requests_seconds_bucket[1m]))`, 단위: s |
+| HikariCP 활성 커넥션 | gauge | `hikaricp_connections_active` |
+
+**검증:**
+```bash
+# JSON 문법 검증
+python3 -m json.tool monitoring/grafana/dashboards/gongu-dashboard.json > /dev/null && echo "JSON valid"
+
+# 파일 존재 확인
+ls -la monitoring/grafana/dashboards/
+```
+Expected: `JSON valid` 출력, 파일 존재
+
+**커밋:**
+```bash
+git add monitoring/grafana/dashboards/gongu-dashboard.json docker-compose.yml
+git commit -m "feat: Grafana 대시보드 자동 프로비저닝 추가 (#이슈번호)"
+```
+
+---
+
+## Task 3: 동작 확인
+
+**검증:**
+```bash
+# 컨테이너 재시작
+docker compose down grafana && docker compose up -d grafana
+
+# Grafana 헬스체크
+sleep 5 && curl -s http://localhost:3001/api/health | python3 -m json.tool
+
+# 대시보드 프로비저닝 확인 (admin/admin 기본 계정)
+curl -s http://admin:admin@localhost:3001/api/dashboards/uid/gongu-service-overview | python3 -m json.tool | grep '"title"'
+```
+Expected: `"title": "Gongu Service Overview"` 포함된 응답
+
+---
+
+## GitHub 워크플로우
+
+이슈 생성:
+```bash
+gh issue create --template feat-template.md \
+  --title "Grafana 대시보드 자동 프로비저닝 추가" \
+  --milestone 9
+```
+
+브랜치: `feat/#{이슈번호}-grafana-dashboard`
+
+PR 생성 후 CLAUDE.md 리뷰 프로세스(Codex 리뷰 위임 → 판정 → 반영) 따름.

--- a/docs/superpowers/specs/2026-06-08-grafana-dashboard-design.md
+++ b/docs/superpowers/specs/2026-06-08-grafana-dashboard-design.md
@@ -1,0 +1,87 @@
+# Grafana 대시보드 설계 — Gongu Service Overview
+
+## 목적
+
+비즈니스 플로우(주문→결제→만료) 디버깅을 위한 단일 Grafana 대시보드 구성.
+문제 발생 시 비즈니스 지표 이상 → DB 락 / 인프라 원인으로 빠르게 좁혀가는 흐름을 제공한다.
+
+---
+
+## 변경 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `monitoring/grafana/dashboards/gongu-dashboard.json` | 신규 생성 |
+| `docker-compose.yml` | grafana 서비스에 dashboards 볼륨 마운트 추가 |
+
+---
+
+## 대시보드 구조
+
+대시보드 이름: **Gongu Service Overview**
+데이터소스: Prometheus (프로비저닝된 기본 소스)
+기본 시간 범위: Last 1 hour
+
+### Row 1 — 비즈니스 플로우 Overview
+
+주문 생성 → 결제 완료 → 결제 실패 → 주문 만료 흐름을 왼쪽에서 오른쪽으로 배치.
+각 패널은 Stat 시각화, 1분 rate 기준.
+
+| 패널 제목 | PromQL | 시각화 |
+|----------|--------|--------|
+| 주문 생성률 (req/min) | `rate(gongu_order_created_total[1m]) * 60` | Stat |
+| 결제 완료률 (req/min) | `rate(gongu_payment_completed_total[1m]) * 60` | Stat |
+| 결제 실패률 (req/min) | `rate(gongu_payment_failed_total[1m]) * 60` | Stat (임계 >0 → 빨간색) |
+| 주문 만료률 (req/min) | `rate(gongu_order_expired_total[1m]) * 60` | Stat |
+
+### Row 2 — 결제 실패 상세
+
+실패 원인별 breakdown. 어떤 reason이 급증하는지 파악.
+
+| 패널 제목 | PromQL | 시각화 |
+|----------|--------|--------|
+| 결제 실패 사유별 추이 | `rate(gongu_payment_failed_total[1m]) * 60` by `reason` | Time series (스택) |
+| 결제 실패 사유 비율 | `increase(gongu_payment_failed_total[1h])` by `reason` | Pie chart |
+
+reason 값 6종: `order_expired_idempotent`, `order_expired_cancel`, `pg_error`, `pg_null_response`, `pg_status_mismatch`, `amount_mismatch`
+
+### Row 3 — DB 락 & 스케줄러 성능
+
+락 대기 시간 급증은 비즈니스 지연의 직접 원인. 스케줄러 실행 시간으로 만료 처리 부하 파악.
+
+| 패널 제목 | PromQL | 시각화 |
+|----------|--------|--------|
+| Order 락 쿼리 시간 | `histogram_quantile(0.5\|0.95\|0.99, rate(gongu_db_lock_query_duration_seconds_bucket{entity="order"}[1m]))` | Time series (3개 라인) |
+| Product 락 쿼리 시간 | 동일, `entity="product"` | Time series (3개 라인) |
+| 만료 스케줄러 실행 시간 | `histogram_quantile(0.95, rate(gongu_order_expire_duration_seconds_bucket[5m]))` | Time series |
+
+### Row 4 — JVM / HTTP / HikariCP
+
+인프라 이상이 비즈니스 지표에 영향을 주는지 확인.
+
+| 패널 제목 | PromQL | 시각화 |
+|----------|--------|--------|
+| JVM 힙 사용량 | `jvm_memory_used_bytes{area="heap"}` | Time series |
+| HTTP 요청률 & 5xx 에러율 | `rate(http_server_requests_seconds_count[1m])` by `status` | Time series |
+| HTTP 응답 시간 p95 | `histogram_quantile(0.95, rate(http_server_requests_seconds_bucket[1m]))` | Time series |
+| HikariCP 활성 커넥션 | `hikaricp_connections_active` | Gauge |
+
+---
+
+## docker-compose 변경
+
+grafana 서비스 `volumes`에 아래 1줄 추가:
+
+```yaml
+- ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+```
+
+기존 `dashboard.yml`의 `path: /var/lib/grafana/dashboards` 설정과 일치.
+
+---
+
+## 완료 기준
+
+- `docker compose up -d prometheus grafana` 후 Grafana(`http://localhost:3001`) 접속
+- Gongu 폴더에 "Gongu Service Overview" 대시보드 자동 표시
+- 4개 Row 패널 전부 데이터 로딩 (서버 기동 상태 기준)

--- a/monitoring/grafana/dashboards/gongu-dashboard.json
+++ b/monitoring/grafana/dashboards/gongu-dashboard.json
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "10.0.0"
+      "version": "11.1.0"
     },
     {
       "type": "datasource",

--- a/monitoring/grafana/dashboards/gongu-dashboard.json
+++ b/monitoring/grafana/dashboards/gongu-dashboard.json
@@ -10,14 +10,46 @@
     }
   ],
   "__requires": [
-    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
-    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
-    { "type": "panel", "id": "stat", "name": "Stat", "version": "" },
-    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
-    { "type": "panel", "id": "piechart", "name": "Pie chart", "version": "" },
-    { "type": "panel", "id": "gauge", "name": "Gauge", "version": "" }
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    }
   ],
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -29,24 +61,46 @@
       "type": "row",
       "title": "비즈니스 플로우 Overview",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "panels": []
     },
     {
       "id": 2,
       "type": "stat",
       "title": "주문 생성률 (건/분)",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "rate(gongu_order_created_total[1m]) * 60",
           "refId": "A"
         }
       ],
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "orientation": "auto",
         "textMode": "auto",
         "colorMode": "value",
@@ -62,17 +116,34 @@
       "id": 3,
       "type": "stat",
       "title": "결제 완료률 (건/분)",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "rate(gongu_payment_completed_total[1m]) * 60",
           "refId": "A"
         }
       ],
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "orientation": "auto",
         "textMode": "auto",
         "colorMode": "value",
@@ -88,17 +159,34 @@
       "id": 4,
       "type": "stat",
       "title": "결제 실패률 (건/분)",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "rate(gongu_payment_failed_total[1m]) * 60",
           "refId": "A"
         }
       ],
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "orientation": "auto",
         "textMode": "auto",
         "colorMode": "value",
@@ -110,8 +198,14 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 0.001 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.001
+              }
             ]
           }
         },
@@ -122,17 +216,34 @@
       "id": 5,
       "type": "stat",
       "title": "주문 만료률 (건/분)",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "rate(gongu_order_expired_total[1m]) * 60",
           "refId": "A"
         }
       ],
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "orientation": "auto",
         "textMode": "auto",
         "colorMode": "value",
@@ -149,33 +260,62 @@
       "type": "row",
       "title": "결제 실패 상세",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
       "panels": []
     },
     {
       "id": 7,
       "type": "timeseries",
       "title": "결제 실패 사유별 추이",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "rate(gongu_payment_failed_total[1m]) * 60",
           "legendFormat": "{{reason}}",
           "refId": "A"
         }
       ],
       "options": {
-        "tooltip": { "mode": "single", "sort": "none" },
-        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
-        "stacking": { "group": "A", "mode": "normal" }
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "stacking": {
+          "group": "A",
+          "mode": "normal"
+        }
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "reqps",
+          "unit": "short",
           "custom": {
-            "stacking": { "group": "A", "mode": "normal" }
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
           }
         },
         "overrides": []
@@ -185,21 +325,45 @@
       "id": 8,
       "type": "piechart",
       "title": "결제 실패 사유 비율",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "increase(gongu_payment_failed_total[1h])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "increase(gongu_payment_failed_total[$__range])",
           "legendFormat": "{{reason}}",
           "refId": "A"
         }
       ],
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "pieType": "pie",
-        "tooltip": { "mode": "single", "sort": "none" },
-        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
       },
       "fieldConfig": {
         "defaults": {},
@@ -211,41 +375,72 @@
       "type": "row",
       "title": "DB 락 & 스케줄러 성능",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
       "panels": []
     },
     {
       "id": 10,
       "type": "timeseries",
       "title": "Order 락 쿼리 시간",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 15 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 15
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.5, rate(gongu_db_lock_query_duration_seconds_bucket{entity=\"order\"}[1m]))",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.95, rate(gongu_db_lock_query_duration_seconds_bucket{entity=\"order\"}[1m]))",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.99, rate(gongu_db_lock_query_duration_seconds_bucket{entity=\"order\"}[1m]))",
           "legendFormat": "p99",
           "refId": "C"
         }
       ],
       "options": {
-        "tooltip": { "mode": "single", "sort": "none" },
-        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
       },
       "fieldConfig": {
-        "defaults": { "unit": "s" },
+        "defaults": {
+          "unit": "s"
+        },
         "overrides": []
       }
     },
@@ -253,34 +448,60 @@
       "id": 11,
       "type": "timeseries",
       "title": "Product 락 쿼리 시간",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 15 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 15
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.5, rate(gongu_db_lock_query_duration_seconds_bucket{entity=\"product\"}[1m]))",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.95, rate(gongu_db_lock_query_duration_seconds_bucket{entity=\"product\"}[1m]))",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.99, rate(gongu_db_lock_query_duration_seconds_bucket{entity=\"product\"}[1m]))",
           "legendFormat": "p99",
           "refId": "C"
         }
       ],
       "options": {
-        "tooltip": { "mode": "single", "sort": "none" },
-        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
       },
       "fieldConfig": {
-        "defaults": { "unit": "s" },
+        "defaults": {
+          "unit": "s"
+        },
         "overrides": []
       }
     },
@@ -288,22 +509,42 @@
       "id": 12,
       "type": "timeseries",
       "title": "만료 스케줄러 실행 시간 p95",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 15 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 15
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.95, rate(gongu_order_expire_duration_seconds_bucket[5m]))",
           "legendFormat": "p95",
           "refId": "A"
         }
       ],
       "options": {
-        "tooltip": { "mode": "single", "sort": "none" },
-        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
       },
       "fieldConfig": {
-        "defaults": { "unit": "s" },
+        "defaults": {
+          "unit": "s"
+        },
         "overrides": []
       }
     },
@@ -312,29 +553,54 @@
       "type": "row",
       "title": "JVM / HTTP / HikariCP",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
       "panels": []
     },
     {
       "id": 14,
       "type": "timeseries",
       "title": "JVM 힙 사용량",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 24 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 24
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "jvm_memory_used_bytes{area=\"heap\"}",
           "legendFormat": "heap used",
           "refId": "A"
         }
       ],
       "options": {
-        "tooltip": { "mode": "single", "sort": "none" },
-        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
       },
       "fieldConfig": {
-        "defaults": { "unit": "bytes" },
+        "defaults": {
+          "unit": "bytes"
+        },
         "overrides": []
       }
     },
@@ -342,22 +608,42 @@
       "id": 15,
       "type": "timeseries",
       "title": "HTTP 요청률 & 에러율",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 24 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 24
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "rate(http_server_requests_seconds_count[1m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (status) (rate(http_server_requests_seconds_count[1m]))",
           "legendFormat": "{{status}}",
           "refId": "A"
         }
       ],
       "options": {
-        "tooltip": { "mode": "single", "sort": "none" },
-        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
       },
       "fieldConfig": {
-        "defaults": { "unit": "reqps" },
+        "defaults": {
+          "unit": "short"
+        },
         "overrides": []
       }
     },
@@ -365,22 +651,42 @@
       "id": 16,
       "type": "timeseries",
       "title": "HTTP 응답 시간 p95",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 24 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 24
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.95, rate(http_server_requests_seconds_bucket[1m]))",
           "legendFormat": "p95",
           "refId": "A"
         }
       ],
       "options": {
-        "tooltip": { "mode": "single", "sort": "none" },
-        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
       },
       "fieldConfig": {
-        "defaults": { "unit": "s" },
+        "defaults": {
+          "unit": "s"
+        },
         "overrides": []
       }
     },
@@ -388,26 +694,42 @@
       "id": 17,
       "type": "gauge",
       "title": "HikariCP 활성 커넥션",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 24 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 24
+      },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "hikaricp_connections_active",
           "legendFormat": "active",
           "refId": "A"
         }
       ],
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "orientation": "auto",
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
       "fieldConfig": {
         "defaults": {
-          "min": 0,
-          "max": 10
+          "min": 0
         },
         "overrides": []
       }
@@ -415,7 +737,10 @@
   ],
   "refresh": "30s",
   "schemaVersion": 38,
-  "tags": ["gongu", "spring-boot"],
+  "tags": [
+    "gongu",
+    "spring-boot"
+  ],
   "templating": {
     "list": [
       {
@@ -431,7 +756,10 @@
       }
     ]
   },
-  "time": { "from": "now-1h", "to": "now" },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "browser",
   "title": "Gongu Service Overview",

--- a/monitoring/grafana/dashboards/gongu-dashboard.json
+++ b/monitoring/grafana/dashboards/gongu-dashboard.json
@@ -1,0 +1,440 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "piechart", "name": "Pie chart", "version": "" },
+    { "type": "panel", "id": "gauge", "name": "Gauge", "version": "" }
+  ],
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "비즈니스 플로우 Overview",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "주문 생성률 (건/분)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(gongu_order_created_total[1m]) * 60",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "결제 완료률 (건/분)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(gongu_payment_completed_total[1m]) * 60",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "결제 실패률 (건/분)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(gongu_payment_failed_total[1m]) * 60",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.001 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "주문 만료률 (건/분)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(gongu_order_expired_total[1m]) * 60",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      }
+    },
+    {
+      "id": 6,
+      "type": "row",
+      "title": "결제 실패 상세",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "panels": []
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "결제 실패 사유별 추이",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(gongu_payment_failed_total[1m]) * 60",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "stacking": { "group": "A", "mode": "normal" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "stacking": { "group": "A", "mode": "normal" }
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 8,
+      "type": "piechart",
+      "title": "결제 실패 사유 비율",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "increase(gongu_payment_failed_total[1h])",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "pieType": "pie",
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      }
+    },
+    {
+      "id": 9,
+      "type": "row",
+      "title": "DB 락 & 스케줄러 성능",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "panels": []
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Order 락 쿼리 시간",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 15 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.5, rate(gongu_db_lock_query_duration_seconds_bucket{entity=\"order\"}[1m]))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, rate(gongu_db_lock_query_duration_seconds_bucket{entity=\"order\"}[1m]))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.99, rate(gongu_db_lock_query_duration_seconds_bucket{entity=\"order\"}[1m]))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      }
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Product 락 쿼리 시간",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 15 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.5, rate(gongu_db_lock_query_duration_seconds_bucket{entity=\"product\"}[1m]))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, rate(gongu_db_lock_query_duration_seconds_bucket{entity=\"product\"}[1m]))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.99, rate(gongu_db_lock_query_duration_seconds_bucket{entity=\"product\"}[1m]))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      }
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "만료 스케줄러 실행 시간 p95",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 15 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, rate(gongu_order_expire_duration_seconds_bucket[5m]))",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      }
+    },
+    {
+      "id": 13,
+      "type": "row",
+      "title": "JVM / HTTP / HikariCP",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "panels": []
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "JVM 힙 사용량",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 24 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "jvm_memory_used_bytes{area=\"heap\"}",
+          "legendFormat": "heap used",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "bytes" },
+        "overrides": []
+      }
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "HTTP 요청률 & 에러율",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 24 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(http_server_requests_seconds_count[1m])",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": []
+      }
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "HTTP 응답 시간 p95",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 24 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, rate(http_server_requests_seconds_bucket[1m]))",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      }
+    },
+    {
+      "id": 17,
+      "type": "gauge",
+      "title": "HikariCP 활성 커넥션",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 24 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "hikaricp_connections_active",
+          "legendFormat": "active",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 10
+        },
+        "overrides": []
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["gongu", "spring-boot"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource",
+        "label": "Data Source"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Gongu Service Overview",
+  "uid": "gongu-service-overview",
+  "version": 1
+}


### PR DESCRIPTION
## Issue ID
close #150

## 작업 내용

### Task 1 — docker-compose.yml 볼륨 마운트 추가
- grafana 서비스 volumes에 `./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro` 추가
- 기존 `dashboard.yml`의 `path: /var/lib/grafana/dashboards` 설정과 연결

### Task 2 — gongu-dashboard.json 생성
- `monitoring/grafana/dashboards/gongu-dashboard.json` 신규 생성
- **Row 1** 비즈니스 플로우 Overview: 주문 생성률 / 결제 완료률 / 결제 실패률 / 주문 만료률 (Stat)
- **Row 2** 결제 실패 상세: 사유별 Time series (스택) + Pie chart (`$__range` 연동)
- **Row 3** DB 락 & 스케줄러 성능: Order/Product 락 쿼리 시간 p50/p95/p99, 만료 스케줄러 p95
- **Row 4** JVM / HTTP / HikariCP: 힙 사용량, 요청률(`sum by status`), 응답 시간 p95, 활성 커넥션

## 참고사항
- 스펙: `docs/superpowers/specs/2026-06-08-grafana-dashboard-design.md`
- `docker compose up -d prometheus grafana` 후 Grafana(`http://localhost:3001`) → Gongu 폴더에서 대시보드 자동 표시 확인