### PR TITLE
[FIX] 03-scheduler-webhook-race setup 계정·startAt·setupTimeout 수정 (#157)

### DIFF
--- a/load-test/scenarios/03-scheduler-webhook-race.js
+++ b/load-test/scenarios/03-scheduler-webhook-race.js
@@ -5,6 +5,7 @@ import { createOrder, preparePayment, mockCompletePayment, verifyPayment } from 
 const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
 
 export const options = {
+  setupTimeout: '3m',
   scenarios: {
     verify_call: {
       executor: 'shared-iterations',
@@ -33,7 +34,7 @@ export function setup() {
   // 1. 로그인
   const loginRes = http.post(
     `${BASE_URL}/auth/store-admin/login`,
-    JSON.stringify({ email: __ENV.ADMIN_EMAIL || 'admin@test.com', password: __ENV.ADMIN_PASSWORD || 'password' }),
+    JSON.stringify({ email: __ENV.ADMIN_EMAIL || 'uiwang_gongu@email.com', password: __ENV.ADMIN_PASSWORD || '1234' }),
     { headers: { 'Content-Type': 'application/json' } },
   );
   check(loginRes, { 'admin login 200': (r) => r.status === 200 });
@@ -42,7 +43,8 @@ export function setup() {
   // 2. 테스트 상품 생성 (KST 기준 시각)
   const now = new Date();
   const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
-  const startAt = toKSTLocal(now);
+  const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+  const startAt = toKSTLocal(oneHourAgo);
   const endAt = toKSTLocal(tomorrow);
 
   const productRes = http.post(
@@ -61,6 +63,15 @@ export function setup() {
   const productId = productRes.json('data.id');
   const storeId = productRes.json('data.storeId');
   const amount = 10000;
+
+  for (let i = 0; i < 70; i++) {
+    const statusRes = http.get(
+      `${BASE_URL}/admin/products/${productId}`,
+      { headers: { Authorization: `Bearer ${adminToken}` } },
+    );
+    if (statusRes.json().data.status === 'ACTIVE') break;
+    sleep(1);
+  }
 
   // 3. 유저 토큰 발급
   const tokenRes = http.post(


### PR DESCRIPTION
## Issue ID
close #157

## 작업 내용
`load-test/scenarios/03-scheduler-webhook-race.js` setup 함수의 세 가지 버그 수정

- **어드민 기본 계정 수정**: `admin@test.com / password` → `uiwang_gongu@email.com / 1234` (lib/setup.js와 동일)
- **상품 startAt 변경**: `now` → `oneHourAgo` + ACTIVE 상태 폴링 루프 추가 (상품이 ACTIVE 상태가 되기 전에 주문 생성을 시도하던 버그 수정)
- **setupTimeout 추가**: sleep(130)으로 인해 기본 60초를 초과하던 문제를 `setupTimeout: '3m'` 설정으로 해결

## 참고사항
- lib/setup.js의 `oneHourAgo` 패턴과 ACTIVE 폴링 루프 패턴을 동일하게 적용
- 수정 대상 파일: `load-test/scenarios/03-scheduler-webhook-race.js` 단일 파일