### PR TITLE
[FEAT] Redis 재고 예약 계층 도입 — 비관적 락 병목 해소 (#144)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     container_name: gongu-mysql
     restart: unless-stopped
     environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       TZ: ${TZ:-Asia/Seoul}
     ports:
@@ -122,6 +122,27 @@ services:
     depends_on:
       server:
         condition: service_started
+    networks:
+      - gongu-net
+
+  k6:
+    image: grafana/k6:latest
+    profiles:
+      - k6
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 2g
+    volumes:
+      - ./load-test:/scripts
+    environment:
+      - BASE_URL=http://gongu-server:8080
+      - MOCK_PG_URL=http://gongu-mock-pg:8090
+      - ADMIN_EMAIL=${ADMIN_EMAIL:-uiwang_gongu@email.com}
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD:-1234}
+      - VU_COUNT=${VU_COUNT:-200}
+      - STORE_ID=${STORE_ID:-1}
     networks:
       - gongu-net
 

--- a/docs/superpowers/plans/2026-06-23-redis-stock-reservation.md
+++ b/docs/superpowers/plans/2026-06-23-redis-stock-reservation.md
@@ -1,0 +1,467 @@
+# Redis 재고 예약 계층 (A안) 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redis DECR/INCR를 이용한 재고 예약 계층을 도입해 비관적 락(SELECT FOR UPDATE) 병목을 제거하고 주문 생성 TPS를 향상시킨다
+
+**Spec:** GitHub 이슈 hkjbrian/gongu #144
+
+**Tech Stack:** Spring Boot 3.5, Java 25, Redis (StringRedisTemplate), MySQL 8.0
+
+---
+
+## 변경 파일 맵
+
+### 신규 생성
+| 파일 | 역할 |
+|------|------|
+| `src/main/java/com/gongu/server/domain/product/service/StockRedisService.java` | Redis 재고 연산 캡슐화 |
+| `src/test/java/com/gongu/server/domain/product/service/StockRedisServiceTest.java` | StockRedisService 단위 테스트 |
+
+### 수정
+| 파일 | 변경 내용 요약 |
+|------|--------------|
+| `src/main/java/com/gongu/server/domain/product/entity/Product.java` | `confirmStock(int quantity)` 메서드 추가 |
+| `src/main/java/com/gongu/server/domain/product/service/ProductService.java` | `createProduct` 내 Redis 재고 초기화 추가 |
+| `src/main/java/com/gongu/server/domain/order/service/OrderService.java` | `createOrder` SELECT FOR UPDATE 제거 → Redis DECR, `cancelOrder` restoreStock → Redis INCR |
+| `src/main/java/com/gongu/server/domain/order/service/OrderExpireService.java` | `cancelExpiredOrder` restoreStock → Redis INCR |
+| `src/main/java/com/gongu/server/domain/payment/service/PaymentService.java` | `completePayment` 결제 확정 시 MySQL remaining_stock 차감 추가 |
+| `src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java` | StockRedisService 목 반영 |
+| `src/test/java/com/gongu/server/domain/order/service/OrderExpireServiceTest.java` | StockRedisService 목 반영 |
+
+### 참조 전용 (수정 금지)
+- `src/main/java/com/gongu/server/global/security/jwt/RefreshTokenStore.java` — StringRedisTemplate 사용 패턴
+- `src/main/java/com/gongu/server/domain/order/entity/Order.java` — cancel() 상태 조건 확인
+- `src/main/java/com/gongu/server/domain/order/entity/OrderItem.java` — 필드 구조 확인
+- `src/main/java/com/gongu/server/global/exception/errorcode/ProductErrorCode.java` — 기존 에러코드 확인
+- `docs/schema/ddl.sql` — products 테이블 컬럼명 확인
+
+### 수정 금지 (이번 범위 밖)
+- `src/main/java/com/gongu/server/global/config/MetricsConfig.java` — 기존 메트릭 빈 유지
+- `src/main/java/com/gongu/server/domain/product/service/ProductService.java` 내 `decreaseStock()` 메서드 — 현행 비관적 락 경로 유지 (대조군 보존)
+- `src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusTransactionHelper.java` — 스케줄러 활성화 로직 수정 없음 (Redis 초기화는 createProduct 시점에만)
+
+---
+
+## 설계 전제 (구현자 필독)
+
+### Redis 키 구조
+```
+stock:product:{productId}   # String, Long 값, TTL 없음
+```
+
+### 재고 상태 분리
+| 계층 | 저장소 | 의미 | 갱신 시점 |
+|------|--------|------|---------|
+| available_stock | Redis | 주문 가능한 재고 | createOrder(DECR), cancelOrder(INCR), expireOrder(INCR) |
+| remaining_stock (MySQL) | DB | 결제 확정된 재고 차감 누계 | completePayment |
+
+초기값: `available_stock = Redis = totalStock`, `remaining_stock = MySQL = totalStock`
+
+### SOLD_OUT 처리
+결제 확정 시 MySQL `remaining_stock`이 0이 되면 `product.soldOut()` 호출.  
+Redis available_stock이 0이 되는 시점에는 MySQL 상태 변경 없음 (실험 범위 외).
+
+### 취소 대상 범위
+`order.cancel()`은 `status == RESERVED`인 경우만 허용 (Order.java 확인).  
+따라서 취소 시 MySQL `remaining_stock` 복원 불필요 — Redis INCR만 수행.
+
+---
+
+## Task 1: StockRedisService 생성
+
+- [ ] `StockRedisService` 구현
+- [ ] `StockRedisServiceTest` 작성
+
+**참고 문서/파일 (읽어야 할 것):**
+- `src/main/java/com/gongu/server/global/security/jwt/RefreshTokenStore.java` — `StringRedisTemplate` 사용 패턴 (`opsForValue()`, 빈 주입 방식)
+- `src/main/java/com/gongu/server/global/exception/errorcode/ProductErrorCode.java` — `INSUFFICIENT_STOCK` 에러코드 확인
+
+**수정 대상 파일:**
+- Create: `src/main/java/com/gongu/server/domain/product/service/StockRedisService.java`
+- Create: `src/test/java/com/gongu/server/domain/product/service/StockRedisServiceTest.java`
+
+**금지 사항:**
+- `StringRedisTemplate` 이외의 Redis 클라이언트 도입 금지 (이미 설정된 빈 재사용)
+- TTL 설정 금지 (재고 키는 영구 보관)
+
+**구현 방향:**
+
+`StockRedisService`는 `@Service` + `@RequiredArgsConstructor`로 작성. `StringRedisTemplate` 단일 의존성.
+
+세 개의 public 메서드 구현:
+
+1. **`initializeStock(Long productId, int totalStock)`**
+   - `stringRedisTemplate.opsForValue().set("stock:product:" + productId, String.valueOf(totalStock))`
+   - 반환값 없음 (void)
+
+2. **`reserveStock(Long productId, int quantity)`**
+   - `stringRedisTemplate.opsForValue().decrement("stock:product:" + productId, quantity)`로 DECR
+   - 반환된 `Long result`가 `< 0`이면 `increment("stock:product:" + productId, quantity)`로 롤백 후 `BusinessException(ProductErrorCode.INSUFFICIENT_STOCK)` 던짐
+   - `result`가 `null`이면 (키 없음) `BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND)` 던짐
+
+3. **`releaseStock(Long productId, int quantity)`**
+   - `stringRedisTemplate.opsForValue().increment("stock:product:" + productId, quantity)`
+   - 반환값 없음 (void)
+
+**`StockRedisServiceTest` 단위 테스트 (`@ExtendWith(MockitoExtension.class)`):**
+- `@Mock StringRedisTemplate` 사용
+- `reserveStock` 정상 케이스: decrement가 0 이상 반환 → 예외 없음
+- `reserveStock` 재고 부족: decrement가 음수 반환 → `INSUFFICIENT_STOCK` 예외 + rollback INCR 호출 검증
+- `reserveStock` 키 없음: decrement가 null 반환 → `PRODUCT_NOT_FOUND` 예외
+- `releaseStock` 정상 케이스: increment 호출 검증
+- `initializeStock` 정상 케이스: set 호출 검증
+
+**검증:**
+```bash
+./gradlew test --tests "com.gongu.server.domain.product.service.StockRedisServiceTest"
+```
+Expected: BUILD SUCCESSFUL, 5개 테스트 통과
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/product/service/StockRedisService.java
+git add src/test/java/com/gongu/server/domain/product/service/StockRedisServiceTest.java
+git commit -m "feat: StockRedisService Redis 재고 예약 서비스 추가 (#144)"
+```
+
+---
+
+## Task 2: Product.confirmStock 추가 + 상품 생성 시 Redis 초기화
+
+- [ ] `Product.confirmStock` 메서드 추가
+- [ ] `ProductService.createProduct` Redis 초기화 추가
+- [ ] `ProductServiceTest` 업데이트
+
+**참고 문서/파일 (읽어야 할 것):**
+- `src/main/java/com/gongu/server/domain/product/entity/Product.java` — 기존 `decreaseStock`, `soldOut`, `restoreStock` 패턴
+- `src/main/java/com/gongu/server/domain/product/service/ProductService.java` — `createProduct` 메서드 전체
+- `src/test/java/com/gongu/server/domain/product/service/ProductServiceTest.java` — 기존 테스트 구조
+
+**수정 대상 파일:**
+- Modify: `src/main/java/com/gongu/server/domain/product/entity/Product.java`
+- Modify: `src/main/java/com/gongu/server/domain/product/service/ProductService.java`
+- Modify: `src/test/java/com/gongu/server/domain/product/service/ProductServiceTest.java`
+
+**금지 사항:**
+- `Product.decreaseStock()` 수정 금지 (현행 비관적 락 경로에서 계속 사용)
+- `ProductService.decreaseStock()` 수정 금지 (대조군 보존)
+- `ProductService` 내 다른 메서드(`updateProduct`, `closeProduct` 등) 수정 금지
+
+**구현 방향:**
+
+**`Product.java`에 `confirmStock(int quantity)` 추가:**
+- `remainingStock -= quantity`
+- `remainingStock < 0`이면 `throw new BusinessException(ProductErrorCode.INSUFFICIENT_STOCK)` (안전장치)
+- `remainingStock == 0`이고 `status == ProductStatus.ACTIVE`이면 `this.status = ProductStatus.SOLD_OUT`
+
+**`ProductService.createProduct` 수정:**
+- `StockRedisService` 필드 추가: `private final StockRedisService stockRedisService;`
+- `productRepository.save(product)` 직후 (save 반환 후 product.getId() 사용 가능한 시점):
+  `stockRedisService.initializeStock(product.getId(), product.getTotalStock());`
+- 나머지 로직 변경 없음
+
+**`ProductServiceTest` 업데이트:**
+- `@Mock StockRedisService stockRedisService;` 추가
+- 생성자 주입 구성에 `stockRedisService` 추가
+- `createProduct` 테스트에 `verify(stockRedisService).initializeStock(any(), anyInt())` 검증 추가
+
+**검증:**
+```bash
+./gradlew test --tests "com.gongu.server.domain.product.service.ProductServiceTest"
+./gradlew test --tests "com.gongu.server.domain.product.entity.ProductTest"
+```
+Expected: BUILD SUCCESSFUL
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/product/entity/Product.java
+git add src/main/java/com/gongu/server/domain/product/service/ProductService.java
+git add src/test/java/com/gongu/server/domain/product/service/ProductServiceTest.java
+git commit -m "feat: 상품 생성 시 Redis 재고 초기화 + Product.confirmStock 추가 (#144)"
+```
+
+---
+
+## Task 3: OrderService — createOrder/cancelOrder Redis 재고 연산으로 교체
+
+- [ ] `createOrder` 비관적 락 → Redis DECR 교체
+- [ ] `cancelOrder` restoreStock → Redis INCR 교체
+- [ ] `OrderServiceTest` 업데이트
+
+**참고 문서/파일 (읽어야 할 것):**
+- `src/main/java/com/gongu/server/domain/order/service/OrderService.java` — 현재 `createOrder`, `cancelOrder` 전체
+- `src/main/java/com/gongu/server/domain/order/entity/Order.java` — `cancel()` 메서드: `status == RESERVED`만 허용
+- `src/main/java/com/gongu/server/domain/product/entity/Product.java` — `getStatus()`, `getPrice()` 확인
+- `src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java` — 전체 테스트 구조
+
+**수정 대상 파일:**
+- Modify: `src/main/java/com/gongu/server/domain/order/service/OrderService.java`
+- Modify: `src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java`
+
+**금지 사항:**
+- `receiveOrder`, `arriveOrder`, `getMyOrders`, `getOrder`, `getOrdersByProduct`, `getOrdersByUser` 수정 금지
+- `lockWaitOrderTimer` 제거 금지 (`cancelOrder`에서 order 행 락에 여전히 사용)
+- `MetricsConfig.java` 수정 금지
+
+**구현 방향:**
+
+**`OrderService` 필드 변경:**
+- `StockRedisService stockRedisService` 필드 추가
+- `@PersistenceContext EntityManager entityManager` 필드 제거 (Task 3 이후 불필요)
+- `@Qualifier("lockWaitProductTimer") Timer lockWaitProductTimer` 필드 제거
+
+**`createOrder` 메서드 변경:**
+1. `productRepository.findById(productId)` 호출 유지 — 상품 존재 여부 + 가격 조회용
+2. 이후 `userStoreRepository.existsByUserAndStore(user, store)` 체크 유지
+3. **제거할 코드 블록 전체:**
+   ```java
+   entityManager.detach(product);
+   product = lockWaitProductTimer
+           .record(() -> productRepository.findByIdWithLock(productId))
+           .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+   product.decreaseStock(quantity);
+   ```
+4. **추가할 코드 (위 블록 자리에):**
+   ```java
+   // status는 findById 결과의 product에서 확인 (ACTIVE 여부)
+   if (product.getStatus() != ProductStatus.ACTIVE) {
+       throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_STATUS);
+   }
+   if (quantity <= 0) {
+       throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_DATA);
+   }
+   stockRedisService.reserveStock(productId, quantity);
+   ```
+5. `totalPrice` 계산은 기존 `(long) product.getPrice() * quantity` 유지 (findById 결과 사용)
+
+**`cancelOrder` 메서드 변경:**
+1. `order.cancel(reason)` 호출 유지 (order 행 락 + 상태 변경)
+2. **제거할 코드:**
+   ```java
+   items.stream()
+       .sorted(Comparator.comparingLong(item -> item.getProduct().getId()))
+       .forEach(item -> {
+           Product product = lockWaitProductTimer
+                   .record(() -> productRepository.findByIdWithLock(item.getProduct().getId()))
+                   .orElseThrow(() -> ...);
+           product.restoreStock(Math.toIntExact(item.getQuantity()));
+       });
+   ```
+3. **추가할 코드 (위 블록 자리에):**
+   ```java
+   items.forEach(item ->
+       stockRedisService.releaseStock(item.getProduct().getId(), Math.toIntExact(item.getQuantity()))
+   );
+   ```
+   (정렬 불필요 — Redis 연산은 락 없음)
+4. `productRepository` 필드가 `cancelOrder`에서만 사용되었다면 제거 가능. 단, 다른 메서드에서 사용하면 유지.
+
+**import 정리:** `ProductStatus` import 추가, `EntityManager`/`PersistenceContext` import 제거, `Comparator` import 확인 (다른 곳에서 사용 없으면 제거)
+
+**`OrderServiceTest` 업데이트:**
+- `@Mock StockRedisService stockRedisService` 추가
+- `EntityManager` mock 제거
+- `lockWaitProductTimer` mock 제거
+- `createOrder` 성공 케이스: `productRepository.findByIdWithLock` mock 제거, `stockRedisService.reserveStock` 호출 검증 추가
+- `createOrder` 실패 케이스 (재고 부족): `stockRedisService.reserveStock`이 `INSUFFICIENT_STOCK` 예외를 던지도록 stubbing
+- `createOrder` 실패 케이스 (ACTIVE 아님): `product.getStatus()` 반환값 `UPCOMING`으로 설정 → `INVALID_PRODUCT_STATUS` 예외 검증
+- `cancelOrder` 성공 케이스: `stockRedisService.releaseStock` 호출 검증
+
+**검증:**
+```bash
+./gradlew test --tests "com.gongu.server.domain.order.service.OrderServiceTest"
+```
+Expected: BUILD SUCCESSFUL
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/order/service/OrderService.java
+git add src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
+git commit -m "feat: createOrder 비관적 락 제거, Redis 재고 예약으로 교체 (#144)"
+```
+
+---
+
+## Task 4: OrderExpireService — 만료 취소 시 Redis 재고 반환
+
+- [ ] `cancelExpiredOrder` restoreStock → Redis INCR 교체
+- [ ] `OrderExpireServiceTest` 업데이트
+
+**참고 문서/파일 (읽어야 할 것):**
+- `src/main/java/com/gongu/server/domain/order/service/OrderExpireService.java` — 전체
+- `src/test/java/com/gongu/server/domain/order/service/OrderExpireServiceTest.java` — 전체
+
+**수정 대상 파일:**
+- Modify: `src/main/java/com/gongu/server/domain/order/service/OrderExpireService.java`
+- Modify: `src/test/java/com/gongu/server/domain/order/service/OrderExpireServiceTest.java`
+
+**금지 사항:**
+- `lockWaitOrderTimer` 제거 금지 (order 행 락에 여전히 사용)
+- `paymentRepository` 관련 코드 수정 금지
+
+**구현 방향:**
+
+**`OrderExpireService` 필드 변경:**
+- `StockRedisService stockRedisService` 필드 추가
+- `@Qualifier("lockWaitProductTimer") Timer lockWaitProductTimer` 필드 제거
+- `ProductRepository productRepository` 의존성 제거 (Task 4 이후 불필요)
+
+**`cancelExpiredOrder` 메서드 변경:**
+- **제거할 코드:**
+  ```java
+  items.stream()
+      .sorted(Comparator.comparingLong(item -> item.getProduct().getId()))
+      .forEach(item -> {
+          Product product = lockWaitProductTimer
+                  .record(() -> productRepository.findByIdWithLock(item.getProduct().getId()))
+                  .orElseThrow(() -> ...);
+          product.restoreStock(Math.toIntExact(item.getQuantity()));
+      });
+  ```
+- **추가할 코드 (위 블록 자리에):**
+  ```java
+  items.forEach(item ->
+      stockRedisService.releaseStock(item.getProduct().getId(), Math.toIntExact(item.getQuantity()))
+  );
+  ```
+- `order.cancel("결제 시간 초과")` 호출 위치 및 기타 로직 변경 없음
+
+**`OrderExpireServiceTest` 업데이트:**
+- `@Mock StockRedisService stockRedisService` 추가
+- `productRepository` mock 제거
+- `lockWaitProductTimer` mock 제거
+- 만료 취소 성공 케이스: `stockRedisService.releaseStock` 호출 검증 추가
+
+**검증:**
+```bash
+./gradlew test --tests "com.gongu.server.domain.order.service.OrderExpireServiceTest"
+```
+Expected: BUILD SUCCESSFUL
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/order/service/OrderExpireService.java
+git add src/test/java/com/gongu/server/domain/order/service/OrderExpireServiceTest.java
+git commit -m "feat: 주문 만료 취소 시 Redis 재고 반환으로 교체 (#144)"
+```
+
+---
+
+## Task 5: PaymentService — 결제 확정 시 MySQL remaining_stock 차감
+
+- [ ] `completePayment` 결제 확정 후 `Product.confirmStock` 호출
+- [ ] `PaymentExpireServiceTest` 영향 없음 확인
+
+**참고 문서/파일 (읽어야 할 것):**
+- `src/main/java/com/gongu/server/domain/payment/service/PaymentService.java` — `completePayment` 전체 (특히 `order.pay()` 호출 후 분기)
+- `src/main/java/com/gongu/server/domain/order/entity/OrderItem.java` — 필드 구조 (`getProduct()`, `getQuantity()`)
+- `src/main/java/com/gongu/server/domain/product/entity/Product.java` — `confirmStock` 시그니처 (Task 2에서 추가)
+- `src/main/java/com/gongu/server/domain/order/repository/OrderItemRepository.java` — `findAllByOrder(Order order)` 메서드 존재 여부
+
+**수정 대상 파일:**
+- Modify: `src/main/java/com/gongu/server/domain/payment/service/PaymentService.java`
+
+**금지 사항:**
+- `PortOneClient`, `PaymentRepository` 관련 로직 수정 금지
+- 결제 금액 불일치(`order.cancel()`) 케이스에서 Redis INCR 추가 금지 (이 경우 order는 RESERVED→CANCELLED지만 결제는 실패이므로 별도 정합성 처리 필요 — 이번 범위 밖)
+
+**구현 방향:**
+
+**`PaymentService` 필드 추가:**
+- `private final OrderItemRepository orderItemRepository;`
+- `private final ProductRepository productRepository;`
+
+**`completePayment` 수정 — 결제 금액 일치 분기 내:**
+
+현재 코드:
+```java
+if (expectedAmount.equals(actualAmount)) {
+    order.pay();
+    payment.confirm(actualAmount, portOneResponse.paidAt().toLocalDateTime());
+    paymentCompletedCounter.increment();
+    return VerifyPaymentResponse.of(order, payment);
+}
+```
+
+변경 후:
+```java
+if (expectedAmount.equals(actualAmount)) {
+    order.pay();
+    payment.confirm(actualAmount, portOneResponse.paidAt().toLocalDateTime());
+
+    // MySQL remaining_stock 차감 (결제 확정 시점)
+    List<OrderItem> items = orderItemRepository.findAllByOrder(order);
+    items.forEach(item -> {
+        Product product = productRepository.findByIdWithLock(item.getProduct().getId())
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+        product.confirmStock(Math.toIntExact(item.getQuantity()));
+    });
+
+    paymentCompletedCounter.increment();
+    return VerifyPaymentResponse.of(order, payment);
+}
+```
+
+**import 추가:**
+- `com.gongu.server.domain.order.entity.OrderItem`
+- `com.gongu.server.domain.order.repository.OrderItemRepository`
+- `com.gongu.server.domain.product.entity.Product`
+- `com.gongu.server.domain.product.repository.ProductRepository`
+- `com.gongu.server.global.exception.errorcode.ProductErrorCode`
+- `java.util.List`
+
+**검증:**
+```bash
+./gradlew test --tests "com.gongu.server.domain.payment.service.*"
+```
+Expected: BUILD SUCCESSFUL (기존 PaymentService 테스트 통과)
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+git commit -m "feat: 결제 확정 시 MySQL remaining_stock 차감 추가 (#144)"
+```
+
+---
+
+## Task 6: 전체 빌드 및 통합 검증
+
+- [ ] 전체 빌드 통과
+- [ ] 전체 테스트 통과
+
+**참고 문서/파일 (읽어야 할 것):**
+- `src/test/java/com/gongu/server/domain/product/service/ProductStockConcurrencyTest.java` — 기존 동시성 테스트 구조
+
+**수정 대상 파일:**
+- 없음 (빌드/테스트 검증만)
+
+**검증:**
+```bash
+./gradlew build
+```
+Expected: BUILD SUCCESSFUL, 전체 테스트 통과
+
+---
+
+## 완료 후 작업
+
+PR 생성 후 CLAUDE.md 9~11단계(Codex 리뷰 위임 → 판정 → 반영) 적용.
+
+### 브랜치명
+```
+feat/#144-redis-stock-reservation
+```
+
+### PR 제목
+```
+[FEAT] Redis 재고 예약 계층 도입 — 비관적 락 병목 해소 (#144)
+```
+
+### TPS 측정 (PR 머지 전)
+```bash
+docker compose up --build -d server
+./load-test/cleanup.sh
+docker compose run --rm k6 run /scripts/scenarios/07-order-tps.js
+```
+결과를 이슈 #144 코멘트에 베이스라인과 비교 업데이트.

--- a/load-test/cleanup.sh
+++ b/load-test/cleanup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# k6 테스트로 생성된 데이터 삭제
+# 사용: ./load-test/cleanup.sh
+# 전제: .env 파일이 프로젝트 루트에 있거나, 환경 변수가 이미 설정되어 있어야 함
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# .env 파일이 있으면 로드
+if [ -f "$ROOT_DIR/.env" ]; then
+  export $(grep -v '^#' "$ROOT_DIR/.env" | xargs)
+fi
+
+DB_ROOT_PW="${MYSQL_PASSWORD:?MYSQL_PASSWORD 환경변수가 필요합니다}"
+DB_NAME="${MYSQL_DATABASE:?MYSQL_DATABASE 환경변수가 필요합니다}"
+CONTAINER="${MYSQL_CONTAINER:-gongu-mysql}"
+
+echo "🧹 k6 테스트 데이터 삭제 시작 (DB: $DB_NAME, container: $CONTAINER)"
+
+docker exec -i "$CONTAINER" mysql -uroot -p"$DB_ROOT_PW" --default-character-set=utf8mb4 "$DB_NAME" <<'SQL'
+-- order_id를 임시 테이블에 먼저 저장 (이후 링크가 끊겨도 삭제 가능)
+CREATE TEMPORARY TABLE tmp_k6_order_ids AS
+  SELECT DISTINCT o.id AS order_id
+  FROM orders o
+  INNER JOIN order_items oi ON oi.order_id = o.id
+  INNER JOIN products pr    ON oi.product_id = pr.id
+  WHERE pr.name = 'k6 테스트 상품';
+
+-- Step 1: payments 삭제 (orders FK)
+DELETE FROM payments WHERE order_id IN (SELECT order_id FROM tmp_k6_order_ids);
+
+-- Step 2: order_items 삭제 (orders FK)
+DELETE FROM order_items WHERE order_id IN (SELECT order_id FROM tmp_k6_order_ids);
+
+-- Step 3: orders 삭제
+DELETE FROM orders WHERE id IN (SELECT order_id FROM tmp_k6_order_ids);
+
+-- Step 4: products 삭제
+DELETE FROM products WHERE name = 'k6 테스트 상품';
+
+DROP TEMPORARY TABLE tmp_k6_order_ids;
+SQL
+
+echo "✅ 완료"

--- a/load-test/lib/setup.js
+++ b/load-test/lib/setup.js
@@ -1,5 +1,6 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
+import { expectedStatuses } from 'k6/http';
 
 const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
 const ADMIN_EMAIL = __ENV.ADMIN_EMAIL || 'uiwang_gongu@email.com';
@@ -80,11 +81,25 @@ export function setup(options) {
     const subRes = http.post(
       `${BASE_URL}/users/me/stores`,
       JSON.stringify({ storeId, isPreferred: false }),
-      { headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${tokens[i]}` } },
+      {
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${tokens[i]}` },
+        responseCallback: expectedStatuses(201, 409),
+      },
     );
-    // 201 Created 또는 이미 구독된 경우(409 등)도 허용
+    // 201 Created 또는 이미 구독된 경우(409)도 정상으로 처리
     check(subRes, { [`store subscribe userId=${i + 1}`]: (r) => r.status === 201 || r.status === 409 });
   }
 
   return { tokens, productId, adminToken, storeId };
+}
+
+export function teardown(data) {
+  const { adminToken, productId } = data;
+  if (!adminToken || !productId) return;
+
+  http.del(
+    `${BASE_URL}/admin/products/${productId}`,
+    null,
+    { headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken}` } },
+  );
 }

--- a/load-test/mock-pg/server.js
+++ b/load-test/mock-pg/server.js
@@ -105,4 +105,6 @@ app.post('/payments/:id/cancel', (req, res) => {
   return res.json({ ok: true });
 });
 
-app.listen(PORT, () => console.log(`Mock PG listening on port ${PORT}`));
+const server = app.listen(PORT, () => console.log(`Mock PG listening on port ${PORT}`));
+server.keepAliveTimeout = 120000;   // 2분 (기본 5초 → 테스트 시간 커버)
+server.headersTimeout = 121000;

--- a/load-test/scenarios/03-scheduler-webhook-race.js
+++ b/load-test/scenarios/03-scheduler-webhook-race.js
@@ -5,7 +5,7 @@ import { createOrder, preparePayment, mockCompletePayment, verifyPayment } from 
 const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
 
 export const options = {
-  setupTimeout: '3m',
+  setupTimeout: '6m',
   scenarios: {
     verify_call: {
       executor: 'shared-iterations',
@@ -105,9 +105,8 @@ export function setup() {
   const mockRes = mockCompletePayment(paymentId, amount, 0, 0);
   check(mockRes, { 'mock PG registered': (r) => r.status === 200 });
 
-  // 8. TTL 2분 + 10초 여유 대기 — 스케줄러가 만료 처리하도록
-  // 주의: k6 setup phase에서 실행되므로 테스트 시작이 130초 지연됨. 의도된 동작.
-  sleep(130);
+  // 8. Payment 생성 이후 2분이 지나 스케줄러( 1분 간격 실행 )가 만료 처리하도록 대기
+  sleep(200);
 
   return { token, orderId, paymentId, amount };
 }

--- a/load-test/scenarios/04-circuit-breaker.js
+++ b/load-test/scenarios/04-circuit-breaker.js
@@ -10,12 +10,14 @@
 //
 // setup 순서:
 //   1. 상품/유저 준비 (lib/setup.js)
-//   2. VU 수만큼 주문 + 결제 prepare → 실제 paymentId 확보
+//   2. PHASE1_SLOTS(200)개 주문 + 결제 prepare → 실제 paymentId 확보
 //   3. Mock PG server-error 활성화
+//   4. Phase 2 전용 recoveryInfos 3건 별도 준비 (Phase 1에서 사용하지 않음)
 //      → 이 순서를 지켜야 PortOne 조회 단계까지 도달 가능
 
 import http from 'k6/http';
 import { check, sleep } from 'k6';
+import exec from 'k6/execution';
 import { setup as baseSetup } from '../lib/setup.js';
 import {
   createOrder,
@@ -29,6 +31,7 @@ import {
 const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
 const MOCK_PG_URL = __ENV.MOCK_PG_URL || 'http://localhost:8090';
 const CB_VUS = 20;
+const PHASE1_SLOTS = 200;
 
 export const options = {
   scenarios: {
@@ -46,7 +49,7 @@ export const options = {
       executor: 'shared-iterations',
       vus: 1,
       iterations: 1,
-      startTime: '40s',
+      startTime: '30s',
       exec: 'resetMockPG',
     },
     // Phase 2: HALF_OPEN 상태에서 정상 결제 성공 → Circuit CLOSE 확인
@@ -54,18 +57,19 @@ export const options = {
       executor: 'shared-iterations',
       vus: 3,
       iterations: 3,
-      startTime: '42s', // reset 후 2초 여유
+      startTime: '40s', // reset 후 8초 여유
       exec: 'runRecovery',
     },
   },
 };
 
 export function setup() {
-  const base = baseSetup({ totalStock: CB_VUS });
+  const base = baseSetup({ totalStock: PHASE1_SLOTS + 3 });
 
-  // 실제 paymentId를 CB_VUS개 확보 (주문 생성 + 결제 prepare)
-  const paymentInfos = [];
-  for (let i = 0; i < CB_VUS; i++) {
+  // 실제 paymentId를 Phase 1용 PHASE1_SLOTS개 + Phase 2용 3개 확보
+  const phase1Infos = [];
+  const recoveryInfos = [];
+  for (let i = 0; i < PHASE1_SLOTS + 3; i++) {
     const token = base.tokens[i % base.tokens.length];
 
     const orderRes = createOrder(token, base.productId, 1);
@@ -76,25 +80,34 @@ export function setup() {
     if (prepareRes.status !== 200 && prepareRes.status !== 201) continue;
     const paymentId = prepareRes.json('data.paymentId');
 
-    paymentInfos.push({ token, orderId, paymentId });
+    const info = { token, orderId, paymentId };
+    if (i < PHASE1_SLOTS) {
+      phase1Infos.push(info);
+    } else {
+      recoveryInfos.push(info);
+    }
   }
 
-  // setup 검증 — 준비된 결제건이 CB_VUS보다 적으면 테스트가 왜곡됨
-  if (paymentInfos.length !== CB_VUS) {
-    throw new Error(`setup failed: expected ${CB_VUS} paymentInfos, got ${paymentInfos.length}`);
+  // setup 검증
+  if (phase1Infos.length !== PHASE1_SLOTS) {
+    throw new Error(`setup failed: expected ${PHASE1_SLOTS} paymentInfos, got ${phase1Infos.length}`);
+  }
+  if (recoveryInfos.length !== 3) {
+    throw new Error(`setup failed: expected 3 recoveryInfos, got ${recoveryInfos.length}`);
   }
 
   // 결제 prepare 완료 후 Mock PG 장애 주입
   // (이 순서를 지켜야 prepare 성공 → PG 조회 실패 흐름이 만들어짐)
   mockServerError();
 
-  return { ...base, paymentInfos };
+  return { ...base, paymentInfos: phase1Infos, recoveryInfos };
 }
 
 // Phase 1: Circuit OPEN 유도 — PG 에러(500) 반복 → Resilience4j 503 fast-fail 확인
 export default function (data) {
-  const info = data.paymentInfos[(__VU - 1) % data.paymentInfos.length];
-  if (!info) return;
+  const idx = exec.scenario.iterationInTest;
+  if (idx >= data.paymentInfos.length) return;
+  const info = data.paymentInfos[idx];
 
   const res = verifyPayment(info.token, info.orderId, info.paymentId);
 
@@ -114,7 +127,7 @@ export function resetMockPG() {
 
 // Phase 2: HALF_OPEN 상태에서 정상 결제 성공 → Circuit CLOSE 검증
 export function runRecovery(data) {
-  const info = data.paymentInfos[(__VU - 1) % data.paymentInfos.length];
+  const info = data.recoveryInfos[exec.scenario.iterationInTest];
   if (!info) return;
 
   // reset 후 Mock PG에 결제 완료 상태 재등록

--- a/load-test/scenarios/05-cancel-deadlock.js
+++ b/load-test/scenarios/05-cancel-deadlock.js
@@ -1,10 +1,13 @@
-// 목표: 동일 상품 포함 주문 동시 취소 시 데드락 없음 증명
-// 30개 VU가 각자의 주문을 동시에 취소 → DB row-level lock 경합 시 deadlock 발생 여부 확인
+// 목표: 동일 상품 포함 주문 동시 취소 시 데드락 없음 + 재고 완전 복원 증명
+// 30개 VU가 각자의 주문을 동시에 취소 → DB row-level lock 경합 시 deadlock 발생 여부 및
+// 전체 취소 완료 후 remainingStock이 totalStock으로 정확히 복원되었는지 검증
 
 import http from 'k6/http';
 import { check } from 'k6';
 import { createOrder, cancelOrder } from '../lib/client.js';
 import { setup as libSetup } from '../lib/setup.js';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
 
 export const options = {
   scenarios: {
@@ -20,13 +23,15 @@ export const options = {
   },
 };
 
-export function setup() {
-  // 30 VU 각각 주문 생성이 필요하므로 totalStock: 50 이상 확보
-  const setupData = libSetup({ totalStock: 50 });
+const TOTAL_STOCK = 50;
+const ORDER_COUNT = 30;
 
-  // 30개 VU 각각에 대해 주문 생성
+export function setup() {
+  const setupData = libSetup({ totalStock: TOTAL_STOCK });
+
+  // ORDER_COUNT개 VU 각각에 대해 주문 생성
   const orderIds = [];
-  for (let i = 0; i < 30; i++) {
+  for (let i = 0; i < ORDER_COUNT; i++) {
     const token = setupData.tokens[i];
     const orderRes = createOrder(token, setupData.productId, 1);
     check(orderRes, { [`setup order created userId=${i + 1}`]: (r) => r.status === 200 || r.status === 201 });
@@ -45,6 +50,22 @@ export default function (data) {
 
   check(res, {
     'cancel: no deadlock (no 5xx)': (r) => r.status < 500,
-    'cancel: success or already cancelled': (r) => r.status === 200 || r.status === 400,
+    'cancel: success or already cancelled': (r) => r.status === 204 || r.status === 409,
+  });
+}
+
+export function teardown(data) {
+  const res = http.get(
+    `${BASE_URL}/admin/products/${data.productId}`,
+    { headers: { Authorization: `Bearer ${data.adminToken}` } },
+  );
+
+  const remainingStock = res.json('data.remainingStock');
+  const expectedStock = TOTAL_STOCK; // 주문 30건 취소 → 재고 전량 복원
+
+  check(res, {
+    'teardown: product stock query 200': (r) => r.status === 200,
+    [`teardown: stock fully restored (expected=${expectedStock}, actual=${remainingStock})`]:
+      () => remainingStock === expectedStock,
   });
 }

--- a/load-test/scenarios/06-stress.js
+++ b/load-test/scenarios/06-stress.js
@@ -15,7 +15,7 @@ import { setup as libSetup } from '../lib/setup.js';
 
 // 커넥션 풀 고갈 탐색용 — 충분한 재고로 전체 결제 흐름이 지속 실행되도록
 export function setup() {
-  return libSetup({ totalStock: 10000 });
+  return libSetup({ totalStock: 1_000_000 });
 }
 
 export const options = {
@@ -77,6 +77,4 @@ export default function (data) {
   check(verifyRes, {
     'payment verified': (r) => r.status === 200,
   });
-
-  sleep(1);
 }

--- a/load-test/scenarios/07-order-tps.js
+++ b/load-test/scenarios/07-order-tps.js
@@ -1,0 +1,74 @@
+ // 목적: 순수 주문 생성 TPS 베이스라인 측정
+// executor: constant-arrival-rate — 요청 도달률(req/s)을 직접 제어
+// 결제 플로우 없음 — createOrder 단일 엔드포인트만 호출
+// stock=1_000_000 으로 재고 소진 변수 제거
+// 병목 포인트: ProductRepository.findByIdWithLock (비관적 락 직렬화)
+
+import { check, sleep } from 'k6';
+import { createOrder } from '../lib/client.js';
+
+import { setup as libSetup } from '../lib/setup.js';
+export { teardown } from '../lib/setup.js';
+
+export function setup() {
+  return libSetup({ totalStock: 1_000_000 });
+}
+
+export const options = {
+  scenarios: {
+    order_tps_550: {
+      executor: 'constant-arrival-rate',
+      rate: 550,
+      timeUnit: '1s',
+      duration: '2m',
+      preAllocatedVUs: 600,
+      maxVUs: 1200,
+      startTime: '0s',
+    },
+    order_tps_600: {
+      executor: 'constant-arrival-rate',
+      rate: 600,
+      timeUnit: '1s',
+      duration: '2m',
+      preAllocatedVUs: 650,
+      maxVUs: 1300,
+      startTime: '130s',
+    },
+    order_tps_650: {
+      executor: 'constant-arrival-rate',
+      rate: 650,
+      timeUnit: '1s',
+      duration: '2m',
+      preAllocatedVUs: 700,
+      maxVUs: 1400,
+      startTime: '260s',
+    },
+    order_tps_700: {
+      executor: 'constant-arrival-rate',
+      rate: 700,
+      timeUnit: '1s',
+      duration: '2m',
+      preAllocatedVUs: 750,
+      maxVUs: 1500,
+      startTime: '390s',
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.05'],
+    http_req_duration: ['p(95)<1000'],
+  },
+};
+
+export default function (data) {
+  const token = data.tokens[(__VU - 1) % data.tokens.length];
+  const productId = data.productId;
+
+  const res = createOrder(token, productId, 1);
+  const ok = check(res, {
+    'order created': (r) => r.status === 200 || r.status === 201,
+  });
+  if (!ok) {
+    sleep(0.5);
+    return;
+  }
+}

--- a/src/main/java/com/gongu/server/domain/order/service/OrderExpireService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderExpireService.java
@@ -7,10 +7,7 @@ import com.gongu.server.domain.order.repository.OrderItemRepository;
 import com.gongu.server.domain.order.repository.OrderRepository;
 import com.gongu.server.domain.payment.domain.PaymentStatus;
 import com.gongu.server.domain.payment.repository.PaymentRepository;
-import com.gongu.server.domain.product.entity.Product;
-import com.gongu.server.domain.product.repository.ProductRepository;
-import com.gongu.server.global.exception.BusinessException;
-import com.gongu.server.global.exception.errorcode.ProductErrorCode;
+import com.gongu.server.domain.product.service.StockRedisService;
 import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -19,7 +16,6 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,12 +25,10 @@ public class OrderExpireService {
 
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
-    private final ProductRepository productRepository;
+    private final StockRedisService stockRedisService;
     private final PaymentRepository paymentRepository;
     @Qualifier("lockWaitOrderTimer")
     private final Timer lockWaitOrderTimer;
-    @Qualifier("lockWaitProductTimer")
-    private final Timer lockWaitProductTimer;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void cancelExpiredOrder(Long orderId, LocalDateTime threshold) {
@@ -59,14 +53,9 @@ public class OrderExpireService {
         }
 
         List<OrderItem> items = orderItemRepository.findAllByOrder(order);
-        items.stream()
-                .sorted(Comparator.comparingLong(item -> item.getProduct().getId()))
-                .forEach(item -> {
-                    Product product = lockWaitProductTimer
-                            .record(() -> productRepository.findByIdWithLock(item.getProduct().getId()))
-                            .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
-                    product.restoreStock(Math.toIntExact(item.getQuantity()));
-                });
+        items.forEach(item ->
+                stockRedisService.releaseStock(item.getProduct().getId(), Math.toIntExact(item.getQuantity()))
+        );
 
         order.cancel("결제 시간 초과");
     }

--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -10,7 +10,9 @@ import com.gongu.server.domain.order.entity.OrderStatus;
 import com.gongu.server.domain.order.repository.OrderItemRepository;
 import com.gongu.server.domain.order.repository.OrderRepository;
 import com.gongu.server.domain.product.entity.Product;
+import com.gongu.server.domain.product.entity.ProductStatus;
 import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.product.service.StockRedisService;
 import com.gongu.server.domain.store.entity.Store;
 import com.gongu.server.domain.store.entity.StoreAdmin;
 import com.gongu.server.domain.store.repository.StoreAdminRepository;
@@ -24,8 +26,6 @@ import com.gongu.server.global.exception.errorcode.StoreErrorCode;
 import com.gongu.server.global.exception.errorcode.UserErrorCode;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Page;
@@ -33,7 +33,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -43,21 +42,17 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class OrderService {
 
-    @PersistenceContext
-    private EntityManager entityManager;
-
     private final UserRepository userRepository;
     private final ProductRepository productRepository;
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
     private final StoreAdminRepository storeAdminRepository;
     private final UserStoreRepository userStoreRepository;
+    private final StockRedisService stockRedisService;
     @Qualifier("orderCreatedCounter")
     private final Counter orderCreatedCounter;
     @Qualifier("lockWaitOrderTimer")
     private final Timer lockWaitOrderTimer;
-    @Qualifier("lockWaitProductTimer")
-    private final Timer lockWaitProductTimer;
 
     @Transactional
     public OrderDetailResponse createOrder(Long userId, Long productId, int quantity) {
@@ -72,12 +67,13 @@ public class OrderService {
             throw new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND);
         }
 
-        entityManager.detach(product);
-        product = lockWaitProductTimer
-                .record(() -> productRepository.findByIdWithLock(productId))
-                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
-
-        product.decreaseStock(quantity);
+        if (product.getStatus() != ProductStatus.ACTIVE) {
+            throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_STATUS);
+        }
+        if (quantity <= 0) {
+            throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_DATA);
+        }
+        stockRedisService.reserveStock(productId, quantity);
         long totalPrice = (long) product.getPrice() * quantity;
 
         Order order = Order.create(user, totalPrice);
@@ -105,14 +101,9 @@ public class OrderService {
         order.cancel(reason);
 
         List<OrderItem> items = orderItemRepository.findAllByOrder(order);
-        items.stream()
-                .sorted(Comparator.comparingLong(item -> item.getProduct().getId()))
-                .forEach(item -> {
-                    Product product = lockWaitProductTimer
-                            .record(() -> productRepository.findByIdWithLock(item.getProduct().getId()))
-                            .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
-                    product.restoreStock(Math.toIntExact(item.getQuantity()));
-                });
+        items.forEach(item ->
+                stockRedisService.releaseStock(item.getProduct().getId(), Math.toIntExact(item.getQuantity()))
+        );
     }
 
     @Transactional

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentExpireService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentExpireService.java
@@ -10,6 +10,7 @@ import com.gongu.server.domain.payment.domain.PaymentStatus;
 import com.gongu.server.domain.payment.repository.PaymentRepository;
 import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.product.service.StockRedisService;
 import com.gongu.server.global.exception.BusinessException;
 import com.gongu.server.global.exception.errorcode.ProductErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,7 @@ public class PaymentExpireService {
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
     private final ProductRepository productRepository;
+    private final StockRedisService stockRedisService;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void cancelExpiredPayment(Long paymentId, LocalDateTime threshold) {
@@ -70,5 +72,8 @@ public class PaymentExpireService {
 
         payment.expire();
         order.cancel("결제 시간 초과");
+        items.forEach(item ->
+                stockRedisService.releaseStock(item.getProduct().getId(), Math.toIntExact(item.getQuantity()))
+        );
     }
 }

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
@@ -1,18 +1,23 @@
 package com.gongu.server.domain.payment.service;
 
 import com.gongu.server.domain.order.entity.Order;
+import com.gongu.server.domain.order.entity.OrderItem;
 import com.gongu.server.domain.order.entity.OrderStatus;
+import com.gongu.server.domain.order.repository.OrderItemRepository;
 import com.gongu.server.domain.order.repository.OrderRepository;
 import com.gongu.server.domain.payment.domain.Payment;
 import com.gongu.server.domain.payment.domain.PaymentStatus;
 import com.gongu.server.domain.payment.dto.PaymentPrepareResult;
 import com.gongu.server.domain.payment.dto.response.VerifyPaymentResponse;
 import com.gongu.server.domain.payment.repository.PaymentRepository;
+import com.gongu.server.domain.product.entity.Product;
+import com.gongu.server.domain.product.repository.ProductRepository;
 import com.gongu.server.domain.user.repository.UserRepository;
 import com.gongu.server.global.exception.BusinessException;
 import com.gongu.server.global.exception.InfraException;
 import com.gongu.server.global.exception.errorcode.OrderErrorCode;
 import com.gongu.server.global.exception.errorcode.PaymentErrorCode;
+import com.gongu.server.global.exception.errorcode.ProductErrorCode;
 import com.gongu.server.global.exception.errorcode.UserErrorCode;
 import com.gongu.server.global.infrastructure.portone.PortOneClient;
 import com.gongu.server.global.infrastructure.portone.dto.PortOnePaymentResponse;
@@ -34,6 +39,8 @@ public class PaymentService {
 
     private final UserRepository userRepository;
     private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final ProductRepository productRepository;
     private final PaymentRepository paymentRepository;
     private final PortOneClient portOneClient;
     @Qualifier("paymentCompletedCounter")
@@ -151,6 +158,15 @@ public class PaymentService {
         if (expectedAmount.equals(actualAmount)) {
             order.pay();
             payment.confirm(actualAmount, portOneResponse.paidAt().toLocalDateTime());
+
+            // MySQL remaining_stock 차감 (결제 확정 시점)
+            List<OrderItem> items = orderItemRepository.findAllByOrder(order);
+            items.forEach(item -> {
+                Product product = productRepository.findByIdWithLock(item.getProduct().getId())
+                        .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+                product.confirmStock(Math.toIntExact(item.getQuantity()));
+            });
+
             paymentCompletedCounter.increment();
             return VerifyPaymentResponse.of(order, payment);
         } else {

--- a/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/gongu/server/domain/payment/service/PaymentService.java
@@ -12,6 +12,7 @@ import com.gongu.server.domain.payment.dto.response.VerifyPaymentResponse;
 import com.gongu.server.domain.payment.repository.PaymentRepository;
 import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.product.service.StockRedisService;
 import com.gongu.server.domain.user.repository.UserRepository;
 import com.gongu.server.global.exception.BusinessException;
 import com.gongu.server.global.exception.InfraException;
@@ -42,6 +43,7 @@ public class PaymentService {
     private final OrderItemRepository orderItemRepository;
     private final ProductRepository productRepository;
     private final PaymentRepository paymentRepository;
+    private final StockRedisService stockRedisService;
     private final PortOneClient portOneClient;
     @Qualifier("paymentCompletedCounter")
     private final Counter paymentCompletedCounter;
@@ -174,6 +176,10 @@ public class PaymentService {
             payment.refund();
             paymentFailedAmountMismatchCounter.increment();
             order.cancel("결제 금액 불일치");
+            List<OrderItem> cancelledItems = orderItemRepository.findAllByOrder(order);
+            cancelledItems.forEach(item ->
+                    stockRedisService.releaseStock(item.getProduct().getId(), Math.toIntExact(item.getQuantity()))
+            );
             throw new BusinessException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
     }

--- a/src/main/java/com/gongu/server/domain/product/entity/Product.java
+++ b/src/main/java/com/gongu/server/domain/product/entity/Product.java
@@ -109,6 +109,16 @@ public class Product extends BaseEntity {
         }
     }
 
+    public void confirmStock(int quantity) {
+        this.remainingStock -= quantity;
+        if (this.remainingStock < 0) {
+            throw new BusinessException(ProductErrorCode.INSUFFICIENT_STOCK);
+        }
+        if (this.remainingStock == 0 && this.status == ProductStatus.ACTIVE) {
+            this.status = ProductStatus.SOLD_OUT;
+        }
+    }
+
     public void update(String name, String description, Long price,
                        Integer totalStock, LocalDateTime startAt, LocalDateTime endAt) {
         if (this.status != ProductStatus.UPCOMING) {

--- a/src/main/java/com/gongu/server/domain/product/entity/Product.java
+++ b/src/main/java/com/gongu/server/domain/product/entity/Product.java
@@ -110,10 +110,10 @@ public class Product extends BaseEntity {
     }
 
     public void confirmStock(int quantity) {
-        this.remainingStock -= quantity;
-        if (this.remainingStock < 0) {
+        if (this.remainingStock < quantity) {
             throw new BusinessException(ProductErrorCode.INSUFFICIENT_STOCK);
         }
+        this.remainingStock -= quantity;
         if (this.remainingStock == 0 && this.status == ProductStatus.ACTIVE) {
             this.status = ProductStatus.SOLD_OUT;
         }

--- a/src/main/java/com/gongu/server/domain/product/service/ProductService.java
+++ b/src/main/java/com/gongu/server/domain/product/service/ProductService.java
@@ -39,6 +39,7 @@ public class ProductService {
     private final UserStoreRepository userStoreRepository;
     private final StoreRepository storeRepository;
     private final StoreAdminRepository storeAdminRepository;
+    private final StockRedisService stockRedisService;
     private final MeterRegistry meterRegistry;
 
     // 회원: 상품 목록 조회
@@ -126,6 +127,7 @@ public class ProductService {
                 request.price(), request.totalStock(), ProductStatus.UPCOMING,
                 request.startAt(), request.endAt());
         productRepository.save(product);
+        stockRedisService.initializeStock(product.getId(), product.getTotalStock());
 
         return ProductDetailResponse.from(product);
     }

--- a/src/main/java/com/gongu/server/domain/product/service/StockRedisService.java
+++ b/src/main/java/com/gongu/server/domain/product/service/StockRedisService.java
@@ -1,0 +1,46 @@
+package com.gongu.server.domain.product.service;
+
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.ProductErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StockRedisService {
+
+    private static final String STOCK_KEY_PREFIX = "stock:product:";
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public void initializeStock(Long productId, int totalStock) {
+        stringRedisTemplate.opsForValue()
+                .set(stockKey(productId), String.valueOf(totalStock));
+    }
+
+    public void reserveStock(Long productId, int quantity) {
+        String key = stockKey(productId);
+        Long result = stringRedisTemplate.opsForValue()
+                .decrement(key, quantity);
+
+        if (result == null) {
+            throw new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND);
+        }
+
+        if (result < 0) {
+            stringRedisTemplate.opsForValue()
+                    .increment(key, quantity);
+            throw new BusinessException(ProductErrorCode.INSUFFICIENT_STOCK);
+        }
+    }
+
+    public void releaseStock(Long productId, int quantity) {
+        stringRedisTemplate.opsForValue()
+                .increment(stockKey(productId), quantity);
+    }
+
+    private String stockKey(Long productId) {
+        return STOCK_KEY_PREFIX + productId;
+    }
+}

--- a/src/main/java/com/gongu/server/global/config/MetricsConfig.java
+++ b/src/main/java/com/gongu/server/global/config/MetricsConfig.java
@@ -45,6 +45,7 @@ public class MetricsConfig {
     public Timer lockWaitOrderTimer() {
         return Timer.builder("gongu.db.lock.query_duration")
                 .tag("entity", "order")
+                .publishPercentileHistogram()
                 .register(meterRegistry);
     }
 
@@ -52,6 +53,7 @@ public class MetricsConfig {
     public Timer lockWaitProductTimer() {
         return Timer.builder("gongu.db.lock.query_duration")
                 .tag("entity", "product")
+                .publishPercentileHistogram()
                 .register(meterRegistry);
     }
 

--- a/src/main/resources/application-perf.yml
+++ b/src/main/resources/application-perf.yml
@@ -2,4 +2,8 @@ portone:
   base-url: http://gongu-mock-pg:8090
 
 order:
-  reservation-ttl-minutes: 2
+  reservation-ttl-minutes: 5
+
+logging:
+  level:
+    io.github.resilience4j.circuitbreaker: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,8 +45,10 @@ resilience4j:
         wait-duration-in-open-state: 30s
         permitted-number-of-calls-in-half-open-state: 3
         register-health-indicator: true
+        record-exceptions:
+          - org.springframework.web.client.HttpServerErrorException
         ignore-exceptions:
-          - com.gongu.server.global.exception.BusinessException
+            - com.gongu.server.global.exception.BusinessException
   retry:
     instances:
       portone:

--- a/src/test/java/com/gongu/server/domain/order/service/OrderExpireServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/order/service/OrderExpireServiceTest.java
@@ -9,7 +9,7 @@ import com.gongu.server.domain.payment.domain.PaymentStatus;
 import com.gongu.server.domain.payment.repository.PaymentRepository;
 import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.entity.ProductStatus;
-import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.product.service.StockRedisService;
 import com.gongu.server.domain.store.entity.Store;
 import com.gongu.server.domain.user.entity.User;
 import io.micrometer.core.instrument.Timer;
@@ -43,13 +43,12 @@ class OrderExpireServiceTest {
     private OrderItemRepository orderItemRepository;
 
     @Mock
-    private ProductRepository productRepository;
+    private StockRedisService stockRedisService;
 
     @Mock
     private PaymentRepository paymentRepository;
 
     private Timer lockWaitOrderTimer;
-    private Timer lockWaitProductTimer;
     private OrderExpireService orderExpireService;
 
     @BeforeEach
@@ -58,16 +57,12 @@ class OrderExpireServiceTest {
         lockWaitOrderTimer = Timer.builder("gongu.db.lock.query_duration")
                 .tag("entity", "order")
                 .register(meterRegistry);
-        lockWaitProductTimer = Timer.builder("gongu.db.lock.query_duration")
-                .tag("entity", "product")
-                .register(meterRegistry);
         orderExpireService = new OrderExpireService(
                 orderRepository,
                 orderItemRepository,
-                productRepository,
+                stockRedisService,
                 paymentRepository,
-                lockWaitOrderTimer,
-                lockWaitProductTimer
+                lockWaitOrderTimer
         );
     }
 
@@ -87,15 +82,13 @@ class OrderExpireServiceTest {
 
         given(orderRepository.findByIdWithLock(1L)).willReturn(Optional.of(order));
         given(orderItemRepository.findAllByOrder(order)).willReturn(List.of(item));
-        given(productRepository.findByIdWithLock(1L)).willReturn(Optional.of(product));
 
         // when
         orderExpireService.cancelExpiredOrder(1L, threshold);
 
         // then
         assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
-        assertThat(product.getRemainingStock()).isEqualTo(12);
-        verify(productRepository).findByIdWithLock(1L);
+        verify(stockRedisService).releaseStock(1L, 2);
     }
 
     @Test

--- a/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
@@ -12,6 +12,7 @@ import com.gongu.server.domain.order.repository.OrderRepository;
 import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.entity.ProductStatus;
 import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.product.service.StockRedisService;
 import com.gongu.server.domain.store.entity.Store;
 import com.gongu.server.domain.store.entity.StoreAdmin;
 import com.gongu.server.domain.store.repository.StoreAdminRepository;
@@ -26,7 +27,6 @@ import com.gongu.server.global.exception.errorcode.UserErrorCode;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,8 +47,10 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -75,11 +77,10 @@ class OrderServiceTest {
     private UserStoreRepository userStoreRepository;
 
     @Mock
-    private EntityManager entityManager;
+    private StockRedisService stockRedisService;
 
     private Counter orderCreatedCounter;
     private Timer lockWaitOrderTimer;
-    private Timer lockWaitProductTimer;
     private OrderService orderService;
 
     @BeforeEach
@@ -89,9 +90,6 @@ class OrderServiceTest {
         lockWaitOrderTimer = Timer.builder("gongu.db.lock.query_duration")
                 .tag("entity", "order")
                 .register(meterRegistry);
-        lockWaitProductTimer = Timer.builder("gongu.db.lock.query_duration")
-                .tag("entity", "product")
-                .register(meterRegistry);
         orderService = new OrderService(
                 userRepository,
                 productRepository,
@@ -99,11 +97,10 @@ class OrderServiceTest {
                 orderItemRepository,
                 storeAdminRepository,
                 userStoreRepository,
+                stockRedisService,
                 orderCreatedCounter,
-                lockWaitOrderTimer,
-                lockWaitProductTimer
+                lockWaitOrderTimer
         );
-        ReflectionTestUtils.setField(orderService, "entityManager", entityManager);
     }
 
     @Test
@@ -115,7 +112,6 @@ class OrderServiceTest {
 
         given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
         given(productRepository.findById(1L)).willReturn(Optional.of(product));
-        given(productRepository.findByIdWithLock(1L)).willReturn(Optional.of(product));
         given(userStoreRepository.existsByUserAndStore(any(User.class), any(Store.class))).willReturn(true);
         given(orderRepository.save(any(Order.class))).willAnswer(inv -> inv.getArgument(0));
         given(orderItemRepository.save(any(OrderItem.class))).willAnswer(inv -> inv.getArgument(0));
@@ -126,12 +122,12 @@ class OrderServiceTest {
         // then
         assertThat(result.getStatus()).isEqualTo(OrderStatus.RESERVED);
         assertThat(result.getTotalPrice()).isEqualTo(20_000L);
-        assertThat(product.getRemainingStock()).isEqualTo(8);
+        assertThat(product.getRemainingStock()).isEqualTo(10);
         verify(orderRepository).save(any(Order.class));
         InOrder inOrder = inOrder(productRepository, userStoreRepository);
         inOrder.verify(productRepository).findById(1L);
         inOrder.verify(userStoreRepository).existsByUserAndStore(any(User.class), any(Store.class));
-        inOrder.verify(productRepository).findByIdWithLock(1L);
+        verify(stockRedisService).reserveStock(1L, 2);
         verify(orderItemRepository).save(any(OrderItem.class));
     }
 
@@ -180,7 +176,7 @@ class OrderServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
                         .isEqualTo(ProductErrorCode.PRODUCT_NOT_FOUND));
-        verify(productRepository, never()).findByIdWithLock(anyLong());
+        verify(stockRedisService, never()).reserveStock(anyLong(), anyInt());
     }
 
     @Test
@@ -201,7 +197,46 @@ class OrderServiceTest {
                         .isEqualTo(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         assertThat(product.getRemainingStock()).isEqualTo(10);
-        verify(productRepository, never()).findByIdWithLock(anyLong());
+        verify(stockRedisService, never()).reserveStock(anyLong(), anyInt());
+    }
+
+    @Test
+    @DisplayName("createOrder_재고_부족_INSUFFICIENT_STOCK_예외")
+    void createOrder_재고_부족_INSUFFICIENT_STOCK_예외() {
+        // given
+        User user = user(1L);
+        Product product = product(1L, store(1L), 10);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(productRepository.findById(1L)).willReturn(Optional.of(product));
+        given(userStoreRepository.existsByUserAndStore(any(User.class), any(Store.class))).willReturn(true);
+        willThrow(new BusinessException(ProductErrorCode.INSUFFICIENT_STOCK))
+                .given(stockRedisService).reserveStock(1L, 11);
+
+        // when & then
+        assertThatThrownBy(() -> orderService.createOrder(1L, 1L, 11))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ProductErrorCode.INSUFFICIENT_STOCK));
+    }
+
+    @Test
+    @DisplayName("createOrder_ACTIVE_아닌_상품_INVALID_PRODUCT_STATUS_예외")
+    void createOrder_ACTIVE_아닌_상품_INVALID_PRODUCT_STATUS_예외() {
+        // given
+        User user = user(1L);
+        Product product = product(1L, store(1L), 10, ProductStatus.UPCOMING);
+
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(productRepository.findById(1L)).willReturn(Optional.of(product));
+        given(userStoreRepository.existsByUserAndStore(any(User.class), any(Store.class))).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> orderService.createOrder(1L, 1L, 1))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ProductErrorCode.INVALID_PRODUCT_STATUS));
+        verify(stockRedisService, never()).reserveStock(anyLong(), anyInt());
     }
 
     @Test
@@ -210,14 +245,12 @@ class OrderServiceTest {
         // given
         User user = user(1L);
         Product product = product(1L, 10);
-        product.decreaseStock(2);
         Order order = order(1L, user, 20_000L);
         OrderItem item = orderItem(order, product, 2L);
 
         given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
         given(orderRepository.findByIdWithLock(1L)).willReturn(Optional.of(order));
         given(orderItemRepository.findAllByOrder(order)).willReturn(List.of(item));
-        given(productRepository.findByIdWithLock(1L)).willReturn(Optional.of(product));
 
         // when
         orderService.cancelOrder(1L, 1L, "단순 변심");
@@ -226,6 +259,7 @@ class OrderServiceTest {
         assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
         assertThat(order.getCancelReason()).isEqualTo("단순 변심");
         assertThat(product.getRemainingStock()).isEqualTo(10);
+        verify(stockRedisService).releaseStock(1L, 2);
     }
 
     @Test
@@ -762,13 +796,17 @@ class OrderServiceTest {
     }
 
     private Product product(Long id, Store store, int totalStock) {
+        return product(id, store, totalStock, ProductStatus.ACTIVE);
+    }
+
+    private Product product(Long id, Store store, int totalStock, ProductStatus status) {
         Product product = Product.create(
                 store,
                 "상품" + id,
                 "상품 설명",
                 10_000L,
                 totalStock,
-                ProductStatus.ACTIVE,
+                status,
                 LocalDateTime.now().minusDays(1),
                 LocalDateTime.now().plusDays(1)
         );

--- a/src/test/java/com/gongu/server/domain/payment/service/PaymentExpireServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/service/PaymentExpireServiceTest.java
@@ -11,6 +11,7 @@ import com.gongu.server.domain.payment.repository.PaymentRepository;
 import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.entity.ProductStatus;
 import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.product.service.StockRedisService;
 import com.gongu.server.domain.store.entity.Store;
 import com.gongu.server.domain.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
@@ -47,6 +48,9 @@ class PaymentExpireServiceTest {
     @Mock
     private ProductRepository productRepository;
 
+    @Mock
+    private StockRedisService stockRedisService;
+
     @InjectMocks
     private PaymentExpireService paymentExpireService;
 
@@ -77,6 +81,7 @@ class PaymentExpireServiceTest {
         assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
         assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
         assertThat(product.getRemainingStock()).isEqualTo(12);
+        verify(stockRedisService).releaseStock(1L, 2);
     }
 
     @Test

--- a/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
@@ -12,6 +12,7 @@ import com.gongu.server.domain.payment.dto.response.VerifyPaymentResponse;
 import com.gongu.server.domain.payment.repository.PaymentRepository;
 import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.product.service.StockRedisService;
 import com.gongu.server.domain.user.entity.User;
 import com.gongu.server.domain.user.repository.UserRepository;
 import com.gongu.server.global.exception.BusinessException;
@@ -62,6 +63,9 @@ class PaymentServiceTest {
     private ProductRepository productRepository;
 
     @Mock
+    private StockRedisService stockRedisService;
+
+    @Mock
     private PaymentRepository paymentRepository;
 
     @Mock
@@ -97,7 +101,7 @@ class PaymentServiceTest {
         paymentFailedAmountMismatchCounter = paymentFailedCounter(meterRegistry, "amount_mismatch");
         paymentService = new PaymentService(
                 userRepository, orderRepository, orderItemRepository, productRepository, paymentRepository,
-                portOneClient,
+                stockRedisService, portOneClient,
                 paymentCompletedCounter,
                 paymentFailedOrderExpiredIdempotentCounter,
                 paymentFailedOrderExpiredCancelCounter,
@@ -428,6 +432,12 @@ class PaymentServiceTest {
                 OffsetDateTime.now()
         );
         given(portOneClient.getPayment(PAYMENT_ID)).willReturn(portOneResponse);
+        OrderItem orderItem = Mockito.mock(OrderItem.class);
+        Product orderProduct = Mockito.mock(Product.class);
+        given(orderItemRepository.findAllByOrder(order)).willReturn(List.of(orderItem));
+        given(orderItem.getProduct()).willReturn(orderProduct);
+        given(orderProduct.getId()).willReturn(1L);
+        given(orderItem.getQuantity()).willReturn(2L);
 
         // when & then
         assertThatThrownBy(() -> paymentService.completePayment(PAYMENT_ID))
@@ -438,6 +448,7 @@ class PaymentServiceTest {
         verify(payment).refund();
         verify(order).cancel(anyString());
         verify(portOneClient).cancelPayment(eq(PAYMENT_ID), anyString());
+        verify(stockRedisService).releaseStock(1L, 2);
     }
 
     @Test

--- a/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/payment/service/PaymentServiceTest.java
@@ -1,13 +1,17 @@
 package com.gongu.server.domain.payment.service;
 
 import com.gongu.server.domain.order.entity.Order;
+import com.gongu.server.domain.order.entity.OrderItem;
 import com.gongu.server.domain.order.entity.OrderStatus;
+import com.gongu.server.domain.order.repository.OrderItemRepository;
 import com.gongu.server.domain.order.repository.OrderRepository;
 import com.gongu.server.domain.payment.domain.Payment;
 import com.gongu.server.domain.payment.domain.PaymentStatus;
 import com.gongu.server.domain.payment.dto.PaymentPrepareResult;
 import com.gongu.server.domain.payment.dto.response.VerifyPaymentResponse;
 import com.gongu.server.domain.payment.repository.PaymentRepository;
+import com.gongu.server.domain.product.entity.Product;
+import com.gongu.server.domain.product.repository.ProductRepository;
 import com.gongu.server.domain.user.entity.User;
 import com.gongu.server.domain.user.repository.UserRepository;
 import com.gongu.server.global.exception.BusinessException;
@@ -52,6 +56,12 @@ class PaymentServiceTest {
     private OrderRepository orderRepository;
 
     @Mock
+    private OrderItemRepository orderItemRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
     private PaymentRepository paymentRepository;
 
     @Mock
@@ -86,7 +96,7 @@ class PaymentServiceTest {
         paymentFailedPgStatusMismatchCounter = paymentFailedCounter(meterRegistry, "pg_status_mismatch");
         paymentFailedAmountMismatchCounter = paymentFailedCounter(meterRegistry, "amount_mismatch");
         paymentService = new PaymentService(
-                userRepository, orderRepository, paymentRepository,
+                userRepository, orderRepository, orderItemRepository, productRepository, paymentRepository,
                 portOneClient,
                 paymentCompletedCounter,
                 paymentFailedOrderExpiredIdempotentCounter,
@@ -276,6 +286,14 @@ class PaymentServiceTest {
                 OffsetDateTime.now()
         );
         given(portOneClient.getPayment(PAYMENT_ID)).willReturn(portOneResponse);
+        OrderItem orderItem = Mockito.mock(OrderItem.class);
+        Product orderProduct = Mockito.mock(Product.class);
+        Product lockedProduct = Mockito.mock(Product.class);
+        given(orderItemRepository.findAllByOrder(order)).willReturn(List.of(orderItem));
+        given(orderItem.getProduct()).willReturn(orderProduct);
+        given(orderProduct.getId()).willReturn(1L);
+        given(orderItem.getQuantity()).willReturn(2L);
+        given(productRepository.findByIdWithLock(1L)).willReturn(Optional.of(lockedProduct));
 
         // when
         VerifyPaymentResponse result = paymentService.completePayment(PAYMENT_ID);
@@ -287,6 +305,8 @@ class PaymentServiceTest {
         InOrder inOrder = Mockito.inOrder(order, payment);
         inOrder.verify(order).pay();
         inOrder.verify(payment).confirm(eq(AMOUNT), any(LocalDateTime.class));
+        verify(productRepository).findByIdWithLock(1L);
+        verify(lockedProduct).confirmStock(2);
     }
 
     @Test

--- a/src/test/java/com/gongu/server/domain/product/entity/ProductTest.java
+++ b/src/test/java/com/gongu/server/domain/product/entity/ProductTest.java
@@ -145,6 +145,21 @@ class ProductTest {
     }
 
     @Test
+    @DisplayName("confirmStock 재고 부족 시 재고가 차감되지 않는다")
+    void confirmStock_insufficientStock_doesNotDecreaseStock() {
+        // given
+        Product product = Product.create(store, "테스트상품", "설명", 1000L, 3,
+                ProductStatus.ACTIVE, now, later);
+
+        // when & then
+        assertThatThrownBy(() -> product.confirmStock(5))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ProductErrorCode.INSUFFICIENT_STOCK));
+        assertThat(product.getRemainingStock()).isEqualTo(3);
+    }
+
+    @Test
     @DisplayName("재고가 남은 ACTIVE 상품을 soldOut 처리하면 INVALID_PRODUCT_DATA 예외가 발생한다")
     void soldOut_재고_남은_상태에서_호출_시_예외() {
         // given — ACTIVE 상태로 생성, 재고 10

--- a/src/test/java/com/gongu/server/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/product/service/ProductServiceTest.java
@@ -40,6 +40,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -60,6 +61,9 @@ class ProductServiceTest {
 
     @Mock
     private StoreAdminRepository storeAdminRepository;
+
+    @Mock
+    private StockRedisService stockRedisService;
 
     @Spy
     private MeterRegistry meterRegistry = new SimpleMeterRegistry();
@@ -362,6 +366,7 @@ class ProductServiceTest {
         assertThat(response.status()).isEqualTo(ProductStatus.UPCOMING);
         assertThat(response.remainingStock()).isEqualTo(100);
         verify(productRepository).save(any(Product.class));
+        verify(stockRedisService).initializeStock(any(), anyInt());
     }
 
     @Test

--- a/src/test/java/com/gongu/server/domain/product/service/StockRedisServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/product/service/StockRedisServiceTest.java
@@ -1,0 +1,95 @@
+package com.gongu.server.domain.product.service;
+
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.ProductErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StockRedisServiceTest {
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private StockRedisService stockRedisService;
+
+    @BeforeEach
+    void setUp() {
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    @DisplayName("reserveStock_정상케이스")
+    void reserveStock_정상케이스() {
+        // given
+        when(valueOperations.decrement("stock:product:1", 10L)).thenReturn(5L);
+
+        // when & then
+        assertThatCode(() -> stockRedisService.reserveStock(1L, 10))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("reserveStock_재고부족")
+    void reserveStock_재고부족() {
+        // given
+        when(valueOperations.decrement("stock:product:1", 10L)).thenReturn(-1L);
+
+        // when & then
+        assertThatThrownBy(() -> stockRedisService.reserveStock(1L, 10))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ProductErrorCode.INSUFFICIENT_STOCK));
+        verify(valueOperations).increment("stock:product:1", 10L);
+    }
+
+    @Test
+    @DisplayName("reserveStock_키없음")
+    void reserveStock_키없음() {
+        // given
+        when(valueOperations.decrement("stock:product:1", 10L)).thenReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> stockRedisService.reserveStock(1L, 10))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("releaseStock_정상케이스")
+    void releaseStock_정상케이스() {
+        // when
+        stockRedisService.releaseStock(1L, 10);
+
+        // then
+        verify(valueOperations).increment("stock:product:1", 10L);
+    }
+
+    @Test
+    @DisplayName("initializeStock_정상케이스")
+    void initializeStock_정상케이스() {
+        // when
+        stockRedisService.initializeStock(1L, 100);
+
+        // then
+        verify(valueOperations).set("stock:product:1", "100");
+    }
+}


### PR DESCRIPTION
## Issue ID

close #144

## 작업 내용

비관적 락(SELECT FOR UPDATE)으로 인한 주문 생성 직렬화 병목을 제거하고, Redis 원자 연산(DECR/INCR)으로 재고를 관리하는 예약 계층을 도입한다.

### 변경 흐름

| 단계 | 변경 전 | 변경 후 |
|------|--------|--------|
| 주문 생성 | `SELECT FOR UPDATE` → `product.decreaseStock()` | `Redis DECR stock:product:{id}` (락 없음) |
| 결제 확정 | MySQL remaining_stock 미변경 | `Product.confirmStock()` → MySQL remaining_stock 차감 |
| 주문 취소/만료 | `SELECT FOR UPDATE` → `product.restoreStock()` | `Redis INCR stock:product:{id}` |
| 상품 생성 | Redis 미초기화 | `SET stock:product:{id} {totalStock}` |

### 핵심 구현

- **`StockRedisService`** 신규 생성: `initializeStock` / `reserveStock` / `releaseStock`
- **`Product.confirmStock`** 추가: 결제 확정 시점 MySQL 차감 + SOLD_OUT 전이
- **`OrderService.createOrder`**: `EntityManager.detach` + `findByIdWithLock` 블록 제거
- **`OrderService.cancelOrder`**, **`OrderExpireService.cancelExpiredOrder`**: product DB 락 블록 → Redis INCR
- **`PaymentService.completePayment`**: `order.pay()` 후 `product.confirmStock()` 호출

### 트레이드오프 (인지 상태)

- Redis 장애 시 fallback 없음 (별도 이슈로 분리)
- Redis↔DB 정합성 보정 배치 없음 (별도 이슈로 분리)
- 일시적 초과 예약 가능성 존재

## 참고사항

- TPS 측정: `docker compose up --build -d server` → `docker compose run --rm k6 run /scripts/scenarios/07-order-tps.js` 실행 후 이슈 #144 코멘트에 베이스라인 대비 결과 업데이트 예정
- 전체 177개 테스트 통과 (failures: 0, errors: 0)