### PR TITLE
[FEAT] createOrder Product/Store 조회 Redis 캐싱 (#163)

### DIFF
--- a/docs/superpowers/plans/2026-06-28-product-store-cache.md
+++ b/docs/superpowers/plans/2026-06-28-product-store-cache.md
@@ -1,0 +1,296 @@
+# Product/Store Redis 캐싱 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** createOrder 핫패스의 DB read 4건을 Redis 캐싱으로 줄여 주문 처리 성능을 개선한다.
+
+**Spec:** GitHub Issue #163
+
+**Tech Stack:** Spring Boot 3.5, Spring Cache (`@EnableCaching`), Spring Data Redis, Jackson (JSON 직렬화)
+
+---
+
+## 파일 맵
+
+### 생성
+- `src/main/java/com/gongu/server/global/config/CacheConfig.java` — `@EnableCaching` + `RedisCacheManager` TTL 설정
+- `src/main/java/com/gongu/server/domain/product/dto/ProductCacheDto.java` — 캐시용 경량 DTO (record)
+- `src/main/java/com/gongu/server/domain/product/service/ProductCacheService.java` — Product 캐시 read/evict
+- `src/main/java/com/gongu/server/domain/store/service/UserStoreCacheService.java` — 구독 여부 캐시 read/evict
+- `src/test/java/com/gongu/server/domain/product/service/ProductCacheServiceTest.java`
+- `src/test/java/com/gongu/server/domain/store/service/UserStoreCacheServiceTest.java`
+
+### 수정
+- `src/main/resources/application.yml` — cache TTL 프로퍼티 추가
+- `src/main/java/com/gongu/server/domain/order/service/OrderService.java` — 캐시 서비스 사용으로 교체
+- `src/main/java/com/gongu/server/domain/product/service/ProductService.java` — update/close 시 `@CacheEvict`
+- `src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusTransactionHelper.java` — activate 시 `@CacheEvict`
+- `src/main/java/com/gongu/server/domain/store/service/StoreService.java` — registerUserStore 시 `@CacheEvict`
+- `src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java` — `ProductCacheService`/`UserStoreCacheService` Mock으로 교체
+
+### 참조만 (수정 없음)
+- `src/main/java/com/gongu/server/domain/product/entity/Product.java` — DTO 필드 기준 확인
+- `src/main/java/com/gongu/server/domain/product/entity/ProductStatus.java` — enum 값 확인
+- `src/main/java/com/gongu/server/domain/product/service/StockRedisService.java` — 패턴 참고
+- `src/main/java/com/gongu/server/global/config/AppConfig.java` — 기존 Config 패턴 참고
+
+---
+
+## Task 1: CacheConfig + application.yml TTL 설정
+
+**참고 문서/파일:**
+- `src/main/java/com/gongu/server/global/config/AppConfig.java` — 기존 Config 클래스 패턴 참고
+- `src/main/resources/application.yml` — 기존 redis 설정 위치 확인 (host/port는 이미 있음)
+
+**수정 대상 파일:**
+- Create: `src/main/java/com/gongu/server/global/config/CacheConfig.java`
+- Modify: `src/main/resources/application.yml`
+
+**금지 사항:**
+- 기존 Redis 연결 설정 (`spring.data.redis.host/port`) 변경 금지
+- `StockRedisService`의 `RedisTemplate` 빈과 충돌하지 않도록 `CacheManager` 빈만 추가
+
+**구현 방향:**
+- `CacheConfig`에 `@Configuration`, `@EnableCaching` 추가
+- `RedisCacheManager` 빈을 생성하여 기본 직렬화를 `GenericJackson2JsonRedisSerializer`로 설정
+- 캐시별 TTL을 `RedisCacheConfiguration`으로 개별 지정:
+  - `"product"` 캐시: TTL 5분
+  - `"user-store"` 캐시: TTL 10분
+- `application.yml`에 TTL 값을 환경변수로 외부화할 필요 없음 — 코드에서 상수로 관리
+
+**검증:**
+```bash
+./gradlew compileJava
+```
+Expected: BUILD SUCCESSFUL (컴파일 오류 없음)
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/global/config/CacheConfig.java src/main/resources/application.yml
+git commit -m "chore: Spring Cache RedisCacheManager 설정 추가 (#163)"
+```
+
+---
+
+## Task 2: ProductCacheDto + ProductCacheService
+
+**참고 문서/파일:**
+- `src/main/java/com/gongu/server/domain/product/entity/Product.java` — `id`, `store.id`, `price`, `status` 필드 위치 확인
+- `src/main/java/com/gongu/server/domain/product/entity/ProductStatus.java` — enum 직렬화 확인
+- `src/main/java/com/gongu/server/domain/product/service/StockRedisService.java` — 서비스 패턴 참고
+- `src/main/java/com/gongu/server/global/exception/errorcode/ProductErrorCode.java` — 예외 코드 참고
+
+**수정 대상 파일:**
+- Create: `src/main/java/com/gongu/server/domain/product/dto/ProductCacheDto.java`
+- Create: `src/main/java/com/gongu/server/domain/product/service/ProductCacheService.java`
+
+**금지 사항:**
+- `Product` JPA 엔티티를 직접 캐싱 금지 (Hibernate 프록시 직렬화 문제)
+- `remainingStock` 필드를 DTO에 포함 금지 (Redis가 소스 오브 트루스)
+
+**구현 방향:**
+
+`ProductCacheDto`:
+- `record ProductCacheDto(Long id, Long storeId, Long price, ProductStatus status)`
+- `static ProductCacheDto from(Product product)` — `product.getStore().getId()` 사용
+- `@JsonDeserialize` 등 Jackson 어노테이션 없이 record만으로 충분
+
+`ProductCacheService`:
+- `getProduct(Long productId)`: `@Cacheable(value = "product", key = "#productId")`
+  - 캐시 미스 시 `productRepository.findById(productId)` 후 `ProductCacheDto.from()` 반환
+  - 없으면 `BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND)` throw
+- `evict(Long productId)`: `@CacheEvict(value = "product", key = "#productId")`
+  - 반환값 없음 (void)
+
+**검증:**
+```bash
+./gradlew compileJava
+```
+Expected: BUILD SUCCESSFUL
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/product/dto/ProductCacheDto.java src/main/java/com/gongu/server/domain/product/service/ProductCacheService.java
+git commit -m "feat: ProductCacheDto 및 ProductCacheService 추가 (#163)"
+```
+
+---
+
+## Task 3: UserStoreCacheService
+
+**참고 문서/파일:**
+- `src/main/java/com/gongu/server/domain/store/repository/UserStoreRepository.java` — `existsByUserAndStore(User, Store)` 시그니처 확인
+- `src/main/java/com/gongu/server/domain/store/entity/UserStore.java` — 엔티티 구조 파악
+- `src/main/java/com/gongu/server/global/exception/errorcode/UserErrorCode.java` — 예외 코드 확인
+
+**수정 대상 파일:**
+- Create: `src/main/java/com/gongu/server/domain/store/service/UserStoreCacheService.java`
+
+**금지 사항:**
+- `UserStore` JPA 엔티티를 캐시값으로 저장 금지
+- `User`, `Store` 엔티티를 캐시 키로 직접 사용 금지 — `userId`, `storeId` (Long)를 키로 사용
+
+**구현 방향:**
+- `existsByUserAndStore(Long userId, Long storeId)`: `@Cacheable(value = "user-store", key = "#userId + ':' + #storeId")`
+  - 캐시 미스 시: `userRepository.findByIdAndDeletedAtIsNull(userId)`로 `User` 조회 → `storeRepository.findById(storeId)`로 `Store` 조회 → `userStoreRepository.existsByUserAndStore(user, store)` 결과(boolean) 반환
+- `evict(Long userId, Long storeId)`: `@CacheEvict(value = "user-store", key = "#userId + ':' + #storeId")`
+
+**검증:**
+```bash
+./gradlew compileJava
+```
+Expected: BUILD SUCCESSFUL
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/store/service/UserStoreCacheService.java
+git commit -m "feat: UserStoreCacheService 구독 여부 캐싱 추가 (#163)"
+```
+
+---
+
+## Task 4: OrderService.createOrder 캐시 서비스로 교체
+
+**참고 문서/파일:**
+- `src/main/java/com/gongu/server/domain/order/service/OrderService.java` — 현재 createOrder 로직 전체 숙지
+- `src/main/java/com/gongu/server/domain/product/dto/ProductCacheDto.java` — DTO 필드 확인
+- `src/main/java/com/gongu/server/global/exception/errorcode/ProductErrorCode.java` — 예외 코드 확인
+
+**수정 대상 파일:**
+- Modify: `src/main/java/com/gongu/server/domain/order/service/OrderService.java`
+
+**금지 사항:**
+- `createOrder` 이외의 메서드 수정 금지
+- `productRepository` 필드 삭제 금지 — `arriveOrder`, `getOrdersByProduct` 등에서 여전히 사용 중
+- `userStoreRepository` 필드 삭제 금지 — 다른 메서드에서 사용 중
+
+**구현 방향:**
+
+`createOrder` 메서드 안에서 아래 세 줄을 교체:
+```
+// 기존
+Product product = productRepository.findById(productId)...
+Store store = product.getStore();
+if (!userStoreRepository.existsByUserAndStore(user, store)) { ... }
+
+// 변경 후
+ProductCacheDto product = productCacheService.getProduct(productId);
+if (!userStoreCacheService.existsByUserAndStore(userId, product.storeId())) { ... }
+```
+
+- `product.getStatus()` → `product.status()`
+- `product.getPrice()` → `product.price()`
+- `OrderItem.create(order, product, ...)` 에서 Product 엔티티가 필요하다면 DTO 사용 불가 → **`productRepository.getReferenceById(productId)`** 로 프록시만 가져와서 FK 연결에 사용 (DB 조회 없이 참조 생성)
+- `OrderService` 생성자에 `ProductCacheService`, `UserStoreCacheService` 추가 (`@RequiredArgsConstructor` 사용 중이므로 필드 선언만)
+
+**검증:**
+```bash
+./gradlew compileJava
+```
+Expected: BUILD SUCCESSFUL
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/order/service/OrderService.java
+git commit -m "feat: createOrder Product/Store DB 조회를 캐시 서비스로 교체 (#163)"
+```
+
+---
+
+## Task 5: Evict 연동 — ProductService, ProductStatusTransactionHelper, StoreService
+
+**참고 문서/파일:**
+- `src/main/java/com/gongu/server/domain/product/service/ProductService.java` — `updateProduct`, `closeProduct` 위치 확인
+- `src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusTransactionHelper.java` — `activateOne` 위치 확인
+- `src/main/java/com/gongu/server/domain/store/service/StoreService.java` — `registerUserStore` 위치 확인
+
+**수정 대상 파일:**
+- Modify: `src/main/java/com/gongu/server/domain/product/service/ProductService.java`
+- Modify: `src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusTransactionHelper.java`
+- Modify: `src/main/java/com/gongu/server/domain/store/service/StoreService.java`
+
+**금지 사항:**
+- 비즈니스 로직 변경 금지 — evict 호출 추가만
+- `ProductService`의 다른 메서드 수정 금지
+
+**구현 방향:**
+
+`ProductService`:
+- `updateProduct()` 메서드에 `@CacheEvict(value = "product", key = "#productId")` 추가
+- `closeProduct()` 메서드에 `@CacheEvict(value = "product", key = "#productId")` 추가
+
+`ProductStatusTransactionHelper`:
+- `ProductCacheService` 필드 추가 (`@RequiredArgsConstructor`)
+- `activateOne(Long productId)` 내부에서 `product.activate()` 호출 후 `productCacheService.evict(productId)` 호출
+- 또는 `@CacheEvict(value = "product", key = "#productId")` 어노테이션 추가
+
+`StoreService`:
+- `UserStoreCacheService` 필드 추가
+- `registerUserStore()` 내부에서 `userStoreRepository.save(userStore)` 후 `userStoreCacheService.evict(userId, store.getId())` 호출
+
+**검증:**
+```bash
+./gradlew compileJava
+```
+Expected: BUILD SUCCESSFUL
+
+**커밋:**
+```bash
+git add src/main/java/com/gongu/server/domain/product/service/ProductService.java \
+        src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusTransactionHelper.java \
+        src/main/java/com/gongu/server/domain/store/service/StoreService.java
+git commit -m "feat: 상품/구독 상태 변경 시 캐시 evict 연동 (#163)"
+```
+
+---
+
+## Task 6: 테스트 작성 및 기존 OrderServiceTest 수정
+
+**참고 문서/파일:**
+- `src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java` — 기존 Mock 패턴 그대로 따름
+- `src/test/java/com/gongu/server/domain/product/service/StockRedisServiceTest.java` — Mock 패턴 참고
+
+**수정 대상 파일:**
+- Create: `src/test/java/com/gongu/server/domain/product/service/ProductCacheServiceTest.java`
+- Create: `src/test/java/com/gongu/server/domain/store/service/UserStoreCacheServiceTest.java`
+- Modify: `src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java`
+
+**금지 사항:**
+- 통합 테스트(실제 Redis 연결) 작성 금지 — 단위 테스트(Mockito)만
+
+**구현 방향:**
+
+`ProductCacheServiceTest` (단위 테스트):
+- `getProduct()`: 캐시 미스 시 `productRepository.findById()` 호출 검증
+- `getProduct()`: 존재하지 않는 productId → `BusinessException(PRODUCT_NOT_FOUND)` 검증
+
+`UserStoreCacheServiceTest` (단위 테스트):
+- `existsByUserAndStore()`: 구독 중인 경우 `true` 반환 검증
+- `existsByUserAndStore()`: 미구독인 경우 `false` 반환 검증
+
+`OrderServiceTest` 수정:
+- `productRepository.findById()` Mock을 `productCacheService.getProduct()` Mock으로 교체
+- `userStoreRepository.existsByUserAndStore()` Mock을 `userStoreCacheService.existsByUserAndStore()` Mock으로 교체
+- `ProductCacheDto` 반환 타입에 맞게 `given()` 수정
+
+**검증:**
+```bash
+./gradlew test --tests "com.gongu.server.domain.product.service.ProductCacheServiceTest"
+./gradlew test --tests "com.gongu.server.domain.store.service.UserStoreCacheServiceTest"
+./gradlew test --tests "com.gongu.server.domain.order.service.OrderServiceTest"
+```
+Expected: 모든 테스트 PASSED
+
+**커밋:**
+```bash
+git add src/test/java/com/gongu/server/domain/product/service/ProductCacheServiceTest.java \
+        src/test/java/com/gongu/server/domain/store/service/UserStoreCacheServiceTest.java \
+        src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
+git commit -m "test: ProductCacheService, UserStoreCacheService 단위 테스트 추가 (#163)"
+```
+
+---
+
+## PR 생성 후
+
+CLAUDE.md 9~11단계(Codex 리뷰 위임 → 판정 → 반영) 따름

--- a/src/main/java/com/gongu/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/gongu/server/domain/order/service/OrderService.java
@@ -9,14 +9,16 @@ import com.gongu.server.domain.order.entity.OrderItem;
 import com.gongu.server.domain.order.entity.OrderStatus;
 import com.gongu.server.domain.order.repository.OrderItemRepository;
 import com.gongu.server.domain.order.repository.OrderRepository;
+import com.gongu.server.domain.product.dto.ProductCacheDto;
 import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.entity.ProductStatus;
 import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.product.service.ProductCacheService;
 import com.gongu.server.domain.product.service.StockRedisService;
-import com.gongu.server.domain.store.entity.Store;
 import com.gongu.server.domain.store.entity.StoreAdmin;
 import com.gongu.server.domain.store.repository.StoreAdminRepository;
 import com.gongu.server.domain.store.repository.UserStoreRepository;
+import com.gongu.server.domain.store.service.UserStoreCacheService;
 import com.gongu.server.domain.user.entity.User;
 import com.gongu.server.domain.user.repository.UserRepository;
 import com.gongu.server.global.exception.BusinessException;
@@ -51,6 +53,8 @@ public class OrderService {
     private final StoreAdminRepository storeAdminRepository;
     private final UserStoreRepository userStoreRepository;
     private final StockRedisService stockRedisService;
+    private final ProductCacheService productCacheService;
+    private final UserStoreCacheService userStoreCacheService;
     @Qualifier("orderCreatedCounter")
     private final Counter orderCreatedCounter;
     @Qualifier("lockWaitOrderTimer")
@@ -61,15 +65,13 @@ public class OrderService {
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+        ProductCacheDto product = productCacheService.getProduct(productId);
 
-        Store store = product.getStore();
-        if (!userStoreRepository.existsByUserAndStore(user, store)) {
+        if (!userStoreCacheService.existsByUserAndStore(userId, product.storeId())) {
             throw new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND);
         }
 
-        if (product.getStatus() != ProductStatus.ACTIVE) {
+        if (product.status() != ProductStatus.ACTIVE) {
             throw new BusinessException(ProductErrorCode.INVALID_PRODUCT_STATUS);
         }
         if (quantity <= 0) {
@@ -78,12 +80,13 @@ public class OrderService {
         stockRedisService.reserveStock(productId, quantity);
 
         try {
-            long totalPrice = (long) product.getPrice() * quantity;
+            long totalPrice = product.price() * quantity;
 
             Order order = Order.create(user, totalPrice);
             orderRepository.save(order);
 
-            OrderItem item = OrderItem.create(order, product, Long.valueOf(quantity));
+            Product productReference = productRepository.getReferenceById(productId);
+            OrderItem item = OrderItem.create(order, productReference, Long.valueOf(quantity));
             orderItemRepository.save(item);
 
             orderCreatedCounter.increment();

--- a/src/main/java/com/gongu/server/domain/product/dto/ProductCacheDto.java
+++ b/src/main/java/com/gongu/server/domain/product/dto/ProductCacheDto.java
@@ -1,0 +1,20 @@
+package com.gongu.server.domain.product.dto;
+
+import com.gongu.server.domain.product.entity.Product;
+import com.gongu.server.domain.product.entity.ProductStatus;
+
+public record ProductCacheDto(
+        Long id,
+        Long storeId,
+        Long price,
+        ProductStatus status
+) {
+    public static ProductCacheDto from(Product product) {
+        return new ProductCacheDto(
+                product.getId(),
+                product.getStore().getId(),
+                product.getPrice(),
+                product.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusTransactionHelper.java
+++ b/src/main/java/com/gongu/server/domain/product/scheduler/ProductStatusTransactionHelper.java
@@ -2,6 +2,7 @@ package com.gongu.server.domain.product.scheduler;
 
 import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.product.service.ProductCacheService;
 import com.gongu.server.global.exception.BusinessException;
 import com.gongu.server.global.exception.errorcode.ProductErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -14,11 +15,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProductStatusTransactionHelper {
 
     private final ProductRepository productRepository;
+    private final ProductCacheService productCacheService;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void activateOne(Long productId) {
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
         product.activate();
+        productCacheService.evict(productId);
     }
 }

--- a/src/main/java/com/gongu/server/domain/product/service/ProductCacheService.java
+++ b/src/main/java/com/gongu/server/domain/product/service/ProductCacheService.java
@@ -1,0 +1,30 @@
+package com.gongu.server.domain.product.service;
+
+import com.gongu.server.domain.product.dto.ProductCacheDto;
+import com.gongu.server.domain.product.entity.Product;
+import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.ProductErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductCacheService {
+
+    private final ProductRepository productRepository;
+
+    @Cacheable(value = "product", key = "#productId")
+    public ProductCacheDto getProduct(Long productId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        return ProductCacheDto.from(product);
+    }
+
+    @CacheEvict(value = "product", key = "#productId")
+    public void evict(Long productId) {
+    }
+}

--- a/src/main/java/com/gongu/server/domain/product/service/ProductService.java
+++ b/src/main/java/com/gongu/server/domain/product/service/ProductService.java
@@ -40,6 +40,7 @@ public class ProductService {
     private final StoreRepository storeRepository;
     private final StoreAdminRepository storeAdminRepository;
     private final StockRedisService stockRedisService;
+    private final ProductCacheService productCacheService;
     private final MeterRegistry meterRegistry;
 
     // 회원: 상품 목록 조회
@@ -145,6 +146,7 @@ public class ProductService {
 
         product.update(request.name(), request.description(), request.price(),
                 request.totalStock(), request.startAt(), request.endAt());
+        productCacheService.evict(productId);
 
         return ProductDetailResponse.from(product);
     }
@@ -172,5 +174,6 @@ public class ProductService {
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         product.close();
+        productCacheService.evict(productId);
     }
 }

--- a/src/main/java/com/gongu/server/domain/store/service/StoreService.java
+++ b/src/main/java/com/gongu/server/domain/store/service/StoreService.java
@@ -26,6 +26,7 @@ public class StoreService {
     private final StoreRepository storeRepository;
     private final UserRepository userRepository;
     private final UserStoreRepository userStoreRepository;
+    private final UserStoreCacheService userStoreCacheService;
 
     public Page<StoreResponse> getStores(Pageable pageable) {
         return storeRepository.findAllByIsActiveTrueAndDeletedAtIsNull(pageable)
@@ -57,6 +58,7 @@ public class StoreService {
 
         UserStore userStore = UserStore.create(user, store, request.isPreferred());
         userStoreRepository.save(userStore);
+        userStoreCacheService.evict(userId, store.getId());
 
         return RegisterUserStoreResponse.from(userStore);
     }

--- a/src/main/java/com/gongu/server/domain/store/service/UserStoreCacheService.java
+++ b/src/main/java/com/gongu/server/domain/store/service/UserStoreCacheService.java
@@ -1,0 +1,37 @@
+package com.gongu.server.domain.store.service;
+
+import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.domain.store.repository.StoreRepository;
+import com.gongu.server.domain.store.repository.UserStoreRepository;
+import com.gongu.server.domain.user.entity.User;
+import com.gongu.server.domain.user.repository.UserRepository;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.StoreErrorCode;
+import com.gongu.server.global.exception.errorcode.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserStoreCacheService {
+
+    private final UserRepository userRepository;
+    private final StoreRepository storeRepository;
+    private final UserStoreRepository userStoreRepository;
+
+    @Cacheable(value = "user-store", key = "#userId + ':' + #storeId")
+    public boolean existsByUserAndStore(Long userId, Long storeId) {
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        Store store = storeRepository.findByIdAndDeletedAtIsNull(storeId)
+                .orElseThrow(() -> new BusinessException(StoreErrorCode.STORE_NOT_FOUND));
+
+        return userStoreRepository.existsByUserAndStore(user, store);
+    }
+
+    @CacheEvict(value = "user-store", key = "#userId + ':' + #storeId")
+    public void evict(Long userId, Long storeId) {
+    }
+}

--- a/src/main/java/com/gongu/server/global/config/CacheConfig.java
+++ b/src/main/java/com/gongu/server/global/config/CacheConfig.java
@@ -32,6 +32,7 @@ public class CacheConfig {
                         "product", defaultCacheConfiguration.entryTtl(Duration.ofMinutes(5)),
                         "user-store", defaultCacheConfiguration.entryTtl(Duration.ofMinutes(10))
                 ))
+                .enableStatistics()
                 .build();
     }
 }

--- a/src/main/java/com/gongu/server/global/config/CacheConfig.java
+++ b/src/main/java/com/gongu/server/global/config/CacheConfig.java
@@ -1,0 +1,37 @@
+package com.gongu.server.global.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.Map;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration defaultCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        new GenericJackson2JsonRedisSerializer()
+                ))
+                .disableCachingNullValues();
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(defaultCacheConfiguration)
+                .withInitialCacheConfigurations(Map.of(
+                        "product", defaultCacheConfiguration.entryTtl(Duration.ofMinutes(5)),
+                        "user-store", defaultCacheConfiguration.entryTtl(Duration.ofMinutes(10))
+                ))
+                .build();
+    }
+}

--- a/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/order/service/OrderServiceTest.java
@@ -9,14 +9,17 @@ import com.gongu.server.domain.order.entity.OrderItem;
 import com.gongu.server.domain.order.entity.OrderStatus;
 import com.gongu.server.domain.order.repository.OrderItemRepository;
 import com.gongu.server.domain.order.repository.OrderRepository;
+import com.gongu.server.domain.product.dto.ProductCacheDto;
 import com.gongu.server.domain.product.entity.Product;
 import com.gongu.server.domain.product.entity.ProductStatus;
 import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.product.service.ProductCacheService;
 import com.gongu.server.domain.product.service.StockRedisService;
 import com.gongu.server.domain.store.entity.Store;
 import com.gongu.server.domain.store.entity.StoreAdmin;
 import com.gongu.server.domain.store.repository.StoreAdminRepository;
 import com.gongu.server.domain.store.repository.UserStoreRepository;
+import com.gongu.server.domain.store.service.UserStoreCacheService;
 import com.gongu.server.domain.user.entity.User;
 import com.gongu.server.domain.user.repository.UserRepository;
 import com.gongu.server.global.exception.BusinessException;
@@ -79,6 +82,12 @@ class OrderServiceTest {
     @Mock
     private StockRedisService stockRedisService;
 
+    @Mock
+    private ProductCacheService productCacheService;
+
+    @Mock
+    private UserStoreCacheService userStoreCacheService;
+
     private Counter orderCreatedCounter;
     private Timer lockWaitOrderTimer;
     private OrderService orderService;
@@ -98,6 +107,8 @@ class OrderServiceTest {
                 storeAdminRepository,
                 userStoreRepository,
                 stockRedisService,
+                productCacheService,
+                userStoreCacheService,
                 orderCreatedCounter,
                 lockWaitOrderTimer
         );
@@ -109,11 +120,13 @@ class OrderServiceTest {
         // given
         User user = user(1L);
         Product product = product(1L, store(1L), 10);
+        ProductCacheDto productCacheDto = productCacheDto(product);
 
         given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
-        given(productRepository.findById(1L)).willReturn(Optional.of(product));
-        given(userStoreRepository.existsByUserAndStore(any(User.class), any(Store.class))).willReturn(true);
+        given(productCacheService.getProduct(1L)).willReturn(productCacheDto);
+        given(userStoreCacheService.existsByUserAndStore(1L, 1L)).willReturn(true);
         given(orderRepository.save(any(Order.class))).willAnswer(inv -> inv.getArgument(0));
+        given(productRepository.getReferenceById(1L)).willReturn(product);
         given(orderItemRepository.save(any(OrderItem.class))).willAnswer(inv -> inv.getArgument(0));
 
         // when
@@ -124,9 +137,9 @@ class OrderServiceTest {
         assertThat(result.getTotalPrice()).isEqualTo(20_000L);
         assertThat(product.getRemainingStock()).isEqualTo(10);
         verify(orderRepository).save(any(Order.class));
-        InOrder inOrder = inOrder(productRepository, userStoreRepository);
-        inOrder.verify(productRepository).findById(1L);
-        inOrder.verify(userStoreRepository).existsByUserAndStore(any(User.class), any(Store.class));
+        InOrder inOrder = inOrder(productCacheService, userStoreCacheService);
+        inOrder.verify(productCacheService).getProduct(1L);
+        inOrder.verify(userStoreCacheService).existsByUserAndStore(1L, 1L);
         verify(stockRedisService).reserveStock(1L, 2);
         verify(orderItemRepository).save(any(OrderItem.class));
     }
@@ -151,7 +164,8 @@ class OrderServiceTest {
         User user = user(1L);
 
         given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
-        given(productRepository.findById(999L)).willReturn(Optional.empty());
+        given(productCacheService.getProduct(999L))
+                .willThrow(new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         // when & then
         assertThatThrownBy(() -> orderService.createOrder(1L, 999L, 1))
@@ -166,10 +180,11 @@ class OrderServiceTest {
         // given
         User user = user(1L);
         Product product = product(1L, store(1L), 10);
+        ProductCacheDto productCacheDto = productCacheDto(product);
 
         given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
-        given(productRepository.findById(1L)).willReturn(Optional.of(product));
-        given(userStoreRepository.existsByUserAndStore(any(User.class), any(Store.class))).willReturn(false);
+        given(productCacheService.getProduct(1L)).willReturn(productCacheDto);
+        given(userStoreCacheService.existsByUserAndStore(1L, 1L)).willReturn(false);
 
         // when & then
         assertThatThrownBy(() -> orderService.createOrder(1L, 1L, 1))
@@ -185,10 +200,11 @@ class OrderServiceTest {
         // given
         User user = user(1L);
         Product product = product(1L, store(1L), 10);
+        ProductCacheDto productCacheDto = productCacheDto(product);
 
         given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
-        given(productRepository.findById(1L)).willReturn(Optional.of(product));
-        given(userStoreRepository.existsByUserAndStore(any(User.class), any(Store.class))).willReturn(false);
+        given(productCacheService.getProduct(1L)).willReturn(productCacheDto);
+        given(userStoreCacheService.existsByUserAndStore(1L, 1L)).willReturn(false);
 
         // when & then
         assertThatThrownBy(() -> orderService.createOrder(1L, 1L, 1))
@@ -206,10 +222,11 @@ class OrderServiceTest {
         // given
         User user = user(1L);
         Product product = product(1L, store(1L), 10);
+        ProductCacheDto productCacheDto = productCacheDto(product);
 
         given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
-        given(productRepository.findById(1L)).willReturn(Optional.of(product));
-        given(userStoreRepository.existsByUserAndStore(any(User.class), any(Store.class))).willReturn(true);
+        given(productCacheService.getProduct(1L)).willReturn(productCacheDto);
+        given(userStoreCacheService.existsByUserAndStore(1L, 1L)).willReturn(true);
         willThrow(new BusinessException(ProductErrorCode.INSUFFICIENT_STOCK))
                 .given(stockRedisService).reserveStock(1L, 11);
 
@@ -226,11 +243,12 @@ class OrderServiceTest {
         // given
         User user = user(1L);
         Product product = product(1L, store(1L), 10);
+        ProductCacheDto productCacheDto = productCacheDto(product);
         RuntimeException dbException = new RuntimeException("DB 저장 실패");
 
         given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
-        given(productRepository.findById(1L)).willReturn(Optional.of(product));
-        given(userStoreRepository.existsByUserAndStore(any(User.class), any(Store.class))).willReturn(true);
+        given(productCacheService.getProduct(1L)).willReturn(productCacheDto);
+        given(userStoreCacheService.existsByUserAndStore(1L, 1L)).willReturn(true);
         willThrow(dbException).given(orderRepository).save(any(Order.class));
 
         // when & then
@@ -246,11 +264,12 @@ class OrderServiceTest {
         // given
         User user = user(1L);
         Product product = product(1L, store(1L), 10);
+        ProductCacheDto productCacheDto = productCacheDto(product);
         RuntimeException dbException = new RuntimeException("DB 저장 실패");
 
         given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
-        given(productRepository.findById(1L)).willReturn(Optional.of(product));
-        given(userStoreRepository.existsByUserAndStore(any(User.class), any(Store.class))).willReturn(true);
+        given(productCacheService.getProduct(1L)).willReturn(productCacheDto);
+        given(userStoreCacheService.existsByUserAndStore(1L, 1L)).willReturn(true);
         willThrow(dbException).given(orderRepository).save(any(Order.class));
 
         // when & then
@@ -265,10 +284,11 @@ class OrderServiceTest {
         // given
         User user = user(1L);
         Product product = product(1L, store(1L), 10, ProductStatus.UPCOMING);
+        ProductCacheDto productCacheDto = productCacheDto(product);
 
         given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
-        given(productRepository.findById(1L)).willReturn(Optional.of(product));
-        given(userStoreRepository.existsByUserAndStore(any(User.class), any(Store.class))).willReturn(true);
+        given(productCacheService.getProduct(1L)).willReturn(productCacheDto);
+        given(userStoreCacheService.existsByUserAndStore(1L, 1L)).willReturn(true);
 
         // when & then
         assertThatThrownBy(() -> orderService.createOrder(1L, 1L, 1))
@@ -863,6 +883,15 @@ class OrderServiceTest {
         OrderItem item = OrderItem.create(order, product, quantity);
         setId(item, 1L);
         return item;
+    }
+
+    private ProductCacheDto productCacheDto(Product product) {
+        return new ProductCacheDto(
+                product.getId(),
+                product.getStore().getId(),
+                product.getPrice(),
+                product.getStatus()
+        );
     }
 
     private void setId(Object target, Long id) {

--- a/src/test/java/com/gongu/server/domain/product/service/ProductCacheServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/product/service/ProductCacheServiceTest.java
@@ -1,0 +1,88 @@
+package com.gongu.server.domain.product.service;
+
+import com.gongu.server.domain.product.dto.ProductCacheDto;
+import com.gongu.server.domain.product.entity.Product;
+import com.gongu.server.domain.product.entity.ProductStatus;
+import com.gongu.server.domain.product.repository.ProductRepository;
+import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.ProductErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ProductCacheServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private ProductCacheService productCacheService;
+
+    @Test
+    @DisplayName("getProduct_캐시미스시_DB조회후DTO반환")
+    void getProduct_캐시미스시_DB조회후DTO반환() {
+        // given
+        Product product = product(1L, store(10L), 20_000L, ProductStatus.ACTIVE);
+        given(productRepository.findById(1L)).willReturn(Optional.of(product));
+
+        // when
+        ProductCacheDto result = productCacheService.getProduct(1L);
+
+        // then
+        assertThat(result.id()).isEqualTo(1L);
+        assertThat(result.storeId()).isEqualTo(10L);
+        assertThat(result.price()).isEqualTo(20_000L);
+        assertThat(result.status()).isEqualTo(ProductStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("getProduct_존재하지않는상품_예외")
+    void getProduct_존재하지않는상품_예외() {
+        // given
+        given(productRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> productCacheService.getProduct(999L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    private Product product(Long id, Store store, Long price, ProductStatus status) {
+        Product product = Product.create(
+                store,
+                "상품" + id,
+                "상품 설명",
+                price,
+                10,
+                status,
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(1)
+        );
+        setId(product, id);
+        return product;
+    }
+
+    private Store store(Long id) {
+        Store store = Store.create("매장" + id, "서울시 강남구", "02-1234-5678");
+        setId(store, id);
+        return store;
+    }
+
+    private void setId(Object target, Long id) {
+        ReflectionTestUtils.setField(target, "id", id);
+    }
+}

--- a/src/test/java/com/gongu/server/domain/store/service/UserStoreCacheServiceTest.java
+++ b/src/test/java/com/gongu/server/domain/store/service/UserStoreCacheServiceTest.java
@@ -1,0 +1,101 @@
+package com.gongu.server.domain.store.service;
+
+import com.gongu.server.domain.store.entity.Store;
+import com.gongu.server.domain.store.repository.StoreRepository;
+import com.gongu.server.domain.store.repository.UserStoreRepository;
+import com.gongu.server.domain.user.entity.User;
+import com.gongu.server.domain.user.repository.UserRepository;
+import com.gongu.server.global.exception.BusinessException;
+import com.gongu.server.global.exception.errorcode.UserErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class UserStoreCacheServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private UserStoreRepository userStoreRepository;
+
+    @InjectMocks
+    private UserStoreCacheService userStoreCacheService;
+
+    @Test
+    @DisplayName("existsByUserAndStore_구독중_true반환")
+    void existsByUserAndStore_구독중_true반환() {
+        // given
+        User user = user(1L);
+        Store store = store(10L);
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(storeRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(store));
+        given(userStoreRepository.existsByUserAndStore(user, store)).willReturn(true);
+
+        // when
+        boolean result = userStoreCacheService.existsByUserAndStore(1L, 10L);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("existsByUserAndStore_미구독_false반환")
+    void existsByUserAndStore_미구독_false반환() {
+        // given
+        User user = user(1L);
+        Store store = store(10L);
+        given(userRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+        given(storeRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(store));
+        given(userStoreRepository.existsByUserAndStore(user, store)).willReturn(false);
+
+        // when
+        boolean result = userStoreCacheService.existsByUserAndStore(1L, 10L);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("existsByUserAndStore_존재하지않는유저_예외")
+    void existsByUserAndStore_존재하지않는유저_예외() {
+        // given
+        given(userRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userStoreCacheService.existsByUserAndStore(999L, 10L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    private User user(Long id) {
+        User user = User.of("홍길동" + id, "010-1234-567" + id);
+        setId(user, id);
+        return user;
+    }
+
+    private Store store(Long id) {
+        Store store = Store.create("매장" + id, "서울시 강남구", "02-1234-5678");
+        setId(store, id);
+        return store;
+    }
+
+    private void setId(Object target, Long id) {
+        ReflectionTestUtils.setField(target, "id", id);
+    }
+}


### PR DESCRIPTION
## 🔷 Github Issue ID
- close #163

## 📌 작업 내용 및 특이사항
- `CacheConfig`: Spring Cache + RedisCacheManager 설정 추가 (`product` 5분, `user-store` 10분 TTL)
- `ProductCacheDto` + `ProductCacheService`: Product 정적 정보(id, storeId, price, status)를 Redis에 캐싱 (`@Cacheable`/`@CacheEvict`)
- `UserStoreCacheService`: 사용자 구독 여부를 `"userId:storeId"` 키로 캐싱
- `OrderService.createOrder`: DB read 4건 → 캐시 서비스 조회로 교체. `OrderItem` FK 연결은 `getReferenceById()`로 프록시만 참조 (DB 조회 0건)
- Evict 연동: `ProductService.updateProduct/closeProduct`, `ProductStatusTransactionHelper.activateOne`, `StoreService.registerUserStore`

**특이사항**
- `remainingStock`은 이미 Redis가 소스 오브 트루스이므로 캐시 DTO에서 제외
- JPA 엔티티를 직접 캐싱하지 않고 record DTO 사용 (Hibernate 프록시 직렬화 문제 방지)

## 📚 참고사항
- 구현 계획: `docs/superpowers/plans/2026-06-28-product-store-cache.md`